### PR TITLE
Pluggable request library

### DIFF
--- a/examples/basic-jquery.html
+++ b/examples/basic-jquery.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <title>Dropbox API JavaScript Client</title>
+  <script src="../dist/dropbox-sdk.js"></script>
+</head>
+<body>
+  <script>
+    var ACCESS_TOKEN = 'hjIsF2ns3_AAAAAAAAhd2Z2E1FXHksrwqnTYbssExyc1yAN6UBZ1mhXeCIY2JrzP';
+    var dbx = new DropboxApi({ accessToken: ACCESS_TOKEN });
+    dbx.useJqueryRpc();
+    dbx.listFolder('/Screenshots')
+      .then(function(response) {
+        console.log(response);
+      })
+      .catch(function(error) {
+        console.log(error);
+      });
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "es6-promise": "^3.1.2",
+    "jquery": "^2.2.3",
     "superagent": "^1.8.3"
   }
 }

--- a/src/dropbox-api.js
+++ b/src/dropbox-api.js
@@ -1,4 +1,5 @@
 var rpcRequest = require('./rpc-request');
+var jqueryRpcRequest = require('./rpc-request-jquery');
 
 var DropboxApi = function (options) {
   this.accessToken = options && options.accessToken || '';
@@ -15,6 +16,13 @@ DropboxApi.prototype.getAccessToken = function () {
 
 DropboxApi.prototype.setRpcRequest = function (rpcRequest) {
   this.rpcRequest = rpcRequest;
+};
+
+// Realistically this will be a lib that the client produces and adds, but im
+// putting it in here like this to avoid having to build it on my own for this
+// example.
+DropboxApi.prototype.useJqueryRpc = function () {
+  this.setRpcRequest(jqueryRpcRequest);
 };
 
 DropboxApi.prototype.listFolder = function (path) {

--- a/src/rpc-request-jquery.js
+++ b/src/rpc-request-jquery.js
@@ -1,0 +1,51 @@
+var $ = require('jquery');
+var Promise = require('es6-promise').Promise;
+
+var BASE_URL = 'https://api.dropboxapi.com/2/';
+
+// This doesn't match what was spec'd in paper doc yet
+var buildCustomError = function (error, response) {
+  return {
+    status: error.status,
+    error: response.text,
+    response: response
+  };
+};
+
+var rpcRequest = function (path, body, accessToken) {
+  var promiseFunction = function (resolve, reject) {
+    function success(data) {
+      if (resolve) {
+        resolve(data);
+      }
+    }
+
+    function failure(error) {
+      if (reject) {
+        reject(error);
+      }
+    }
+
+    console.log('using jquery.ajax');
+
+    $.ajax(BASE_URL + path, {
+      contentType: 'application/json',
+      data: JSON.stringify(body),
+      headers: {
+        'Authorization': 'Bearer ' + accessToken
+      },
+      method: 'POST',
+      success: function(data) {
+        success(data);
+      },
+      error: function(jqXHR, textStatus) {
+        // TODO: this is not the same custom error object the other function uses
+        failure(jqXHR);
+      }
+    });
+  };
+
+  return new Promise(promiseFunction);
+};
+
+module.exports = rpcRequest;


### PR DESCRIPTION
This demonstrates how different request libraries could be plugged into the sdk.

The user would create their own `rpcRequest()` function that had the desired function signature and return value and then pass that into the sdk using `dbx.setRpcRequest(myPrcRequest)`. The sdk would then operate the same as usual, but call the new rpcRequest function instead of the libraries default.

> This example is slightly contrived, because I have included the `rpc-request-jquery.js` in the library so I didn't have to build it separately, but the user would actually write their own function and pass it in via `dbx.setRpcRequest()` and `dbx.useJqueryRpc()` would not exist.
