### PR TITLE
Lazy load rpc-request to avoid unnecessary dependencies

### DIFF
--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -1,5 +1,4 @@
 var REQUEST_CONSTANTS = require('./request-constants');
-var rpcRequest = require('./rpc-request');
 var DropboxBase;
 
 // Polyfill Object.assign() for older browsers
@@ -91,7 +90,7 @@ DropboxBase.prototype.getAuthenticationUrl = function (redirectUri, state) {
 
 DropboxBase.prototype.request = function (path, body, host, style) {
   if (style === REQUEST_CONSTANTS.RPC) {
-    return this.rpcRequest(path, body, this.getAccessToken(), this.selectUser);
+    return this.getRpcRequest()(path, body, this.getAccessToken(), this.selectUser);
   } else if (style === REQUEST_CONSTANTS.DOWNLOAD) {
     throw new Error('Download endpoints are not yet implemented');
   } else if (style === REQUEST_CONSTANTS.UPLOAD) {
@@ -101,13 +100,15 @@ DropboxBase.prototype.request = function (path, body, host, style) {
   }
 };
 
-DropboxBase.prototype.rpcRequest = rpcRequest;
-
 DropboxBase.prototype.setRpcRequest = function (newRpcRequest) {
   DropboxBase.prototype.rpcRequest = newRpcRequest;
 };
 
 DropboxBase.prototype.getRpcRequest = function () {
+  if (DropboxBase.prototype.rpcRequest === undefined) {
+    DropboxBase.prototype.rpcRequest = require('./rpc-request');
+  }
+
   return DropboxBase.prototype.rpcRequest;
 };
 

--- a/test/dropbox-base.js
+++ b/test/dropbox-base.js
@@ -111,7 +111,8 @@ describe('DropboxBase', function () {
     it('calls the correct request method', function () {
       var rpcSpy;
       dbx = new DropboxBase();
-      rpcSpy = sinon.spy(dbx, 'rpcRequest');
+      rpcSpy = sinon.spy(dbx.getRpcRequest());
+      dbx.setRpcRequest(rpcSpy);
       dbx.request('path', {}, 'api', REQUEST_CONSTANTS.RPC);
       assert(rpcSpy.calledOnce);
       assert.equal('path', dbx.rpcRequest.getCall(0).args[0]);


### PR DESCRIPTION
Previously, if you set a custom RPC request handler, the `es6-promise` and `superagent` dependencies were still required and an exception would be thrown if they are missing during runtime. This change lazy-loads the default RPC request handler so errors won't be thrown about missing dependencies if the handler implementation is changed.