### PR TITLE
Handle errors where no response is received

### DIFF
--- a/src/download-request.js
+++ b/src/download-request.js
@@ -15,7 +15,7 @@ request.parse['application/octect-stream'] = function (obj) {
 buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response && response.text,
+    error: (response ? response.text : null) || error.toString(),
     response: response
   };
 };

--- a/src/download-request.js
+++ b/src/download-request.js
@@ -15,7 +15,7 @@ request.parse['application/octect-stream'] = function (obj) {
 buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response.text,
+    error: response && response.text,
     response: response
   };
 };

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -7,7 +7,7 @@ var BASE_URL = 'https://api.dropboxapi.com/2/';
 var buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response.text,
+    error: response && response.text,
     response: response
   };
 };

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -7,7 +7,7 @@ var BASE_URL = 'https://api.dropboxapi.com/2/';
 var buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response && response.text,
+    error: (response ? response.text : null) || error.toString(),
     response: response
   };
 };

--- a/src/upload-request.js
+++ b/src/upload-request.js
@@ -7,7 +7,7 @@ var BASE_URL = 'https://content.dropboxapi.com/2/';
 var buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response.text,
+    error: response && response.text,
     response: response
   };
 };

--- a/src/upload-request.js
+++ b/src/upload-request.js
@@ -7,7 +7,7 @@ var BASE_URL = 'https://content.dropboxapi.com/2/';
 var buildCustomError = function (error, response) {
   return {
     status: error.status,
-    error: response && response.text,
+    error: (response ? response.text : null) || error.toString(),
     response: response
   };
 };


### PR DESCRIPTION
This fixes the error cause when no response object was passed into the custom error building function. It will now have `text: undefined` when no response object is passed.

Fixes: #68