### PR TITLE
Error handling in case of timeout

### DIFF
--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -5,11 +5,22 @@ var BASE_URL = 'https://api.dropboxapi.com/2/';
 
 // This doesn't match what was spec'd in paper doc yet
 var buildCustomError = function (error, response) {
-  return {
-    status: error.status,
-    error: response.text,
-    response: response
-  };
+  
+  if (typeof response != 'undefined') {
+    return {
+      status: error.status,
+      error: response.text,
+      response: response
+    };
+  } else {
+    return {
+      status: error.status,
+      error: 'No response',
+      response: {}
+    }
+  }
+  
+  
 };
 
 var rpcRequest = function (path, body, accessToken, selectUser) {


### PR DESCRIPTION
If the error code is ETIMEDOUT will response be undefined. When response.text is called in buildCustomError will the server crash and output:

error: response.text,
TypeError: Cannot read property 'text' of undefined

By checking if response is undefined is it possible to give proper error handling and not crash the server.