### PR TITLE
Transforming filenames to lowercase/camelCase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 dist/
 generated-docs/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run build-cjs && npm run build-umd && npm run compressed-size",
     "build-cjs": "webpack",
     "build-umd": "webpack -p --config webpack-umd.config.js",
-    "compressed-size": "echo 'Dropbox-sdk.min.js gzipped will weigh' $(cat dist/Dropbox-sdk.min.js | gzip -9 | wc -c | pretty-bytes)",
+    "compressed-size": "echo 'dropbox-sdk.min.js gzipped will weigh' $(cat dist/dropbox-sdk.min.js | gzip -9 | wc -c | pretty-bytes)",
     "publish-docs": "rm -rf generated-docs && npm run generate-docs && gh-pages -d generated-docs",
     "generate-docs": "jsdoc -c ./conf.json -d generated-docs -t ./node_modules/ink-docstrap/template -R docs/README.md -r ./src",
     "lint": "eslint src --ignore-path src/types.js",

--- a/webpack-umd.config.js
+++ b/webpack-umd.config.js
@@ -3,12 +3,10 @@ var webpack = require('webpack');
 module.exports = {
 
   entry: {
-    Dropbox: __dirname + '/src/index.js',
-    DropboxTeam: __dirname + '/src/team/index.js'
+    dropbox: __dirname + '/src/index.js',
+    dropboxTeam: __dirname + '/src/team/index.js'
   },
 
-  // Note that this makes filenames with capitals: Dropbox-sdk.min.js
-  // Not sure how to get around this. even webpack examples do this...
   output: {
     filename: '[name]-sdk.min.js',
     library: '[name]',


### PR DESCRIPTION
To have filenames to lowercase or camelCase or any other case you want, just change the **left** parameter in the **entry** section.

```
entry: {
    lowercase: __dirname + '/src/index.js',
    camelCase: __dirname + '/src/otherFile.js',
    snake_case: __dirname + '/src/anyFile.js'
},
```

**Note**: Tests are failing on Windows 10 using latest NodeJS, NPM and GitBash for Windows, cannot find test directory, but passes on my homestead vm (Ubuntu 16.04).

Test  fail on Windows: http://prntscr.com/cxj2u7

Test Passing on Homestead: http://prntscr.com/cxj3e7