### PR TITLE
encode special characters in Dropbox-API-Arg

### DIFF
--- a/src/download-request.js
+++ b/src/download-request.js
@@ -1,6 +1,7 @@
 var request = require('superagent');
 var Promise = require('es6-promise').Promise;
 var getBaseURL = require('./get-base-url');
+var httpHeaderSafeJson = require('./http-header-safe-json');
 
 var buildCustomError;
 var downloadRequest;
@@ -68,7 +69,7 @@ downloadRequest = function (path, args, auth, host, accessToken, selectUser) {
 
     apiRequest = request.post(getBaseURL(host) + path)
       .set('Authorization', 'Bearer ' + accessToken)
-      .set('Dropbox-API-Arg', JSON.stringify(args))
+      .set('Dropbox-API-Arg', httpHeaderSafeJson(args))
       .on('request', function () {
         if (this.xhr) {
           this.xhr.responseType = 'blob';

--- a/src/http-header-safe-json.js
+++ b/src/http-header-safe-json.js
@@ -1,0 +1,10 @@
+// source https://www.dropboxforum.com/t5/API-support/HTTP-header-quot-Dropbox-API-Arg-quot-could-not-decode-input-as/m-p/173823/highlight/true#M6786
+var charsToEncode = /[\u007f-\uffff]/g;
+
+function httpHeaderSafeJson(args) {
+  return JSON.stringify(args).replace(charsToEncode, function (c) {
+    return '\\u' + ('000' + c.charCodeAt(0).toString(16)).slice(-4);
+  });
+}
+
+module.exports = httpHeaderSafeJson;

--- a/src/upload-request.js
+++ b/src/upload-request.js
@@ -1,6 +1,7 @@
 var request = require('superagent');
 var Promise = require('es6-promise').Promise;
 var getBaseURL = require('./get-base-url');
+var httpHeaderSafeJson = require('./http-header-safe-json');
 
 // This doesn't match what was spec'd in paper doc yet
 var buildCustomError = function (error, response) {
@@ -47,7 +48,7 @@ var uploadRequest = function (path, args, auth, host, accessToken, selectUser) {
     apiRequest = request.post(getBaseURL(host) + path)
       .type('application/octet-stream')
       .set('Authorization', 'Bearer ' + accessToken)
-      .set('Dropbox-API-Arg', JSON.stringify(args));
+      .set('Dropbox-API-Arg', httpHeaderSafeJson(args));
 
     if (selectUser) {
       apiRequest = apiRequest.set('Dropbox-API-Select-User', selectUser);

--- a/test/download-request.js
+++ b/test/download-request.js
@@ -81,6 +81,13 @@ describe('downloadRequest', function () {
     assert.equal(JSON.stringify({ foo: 'bar' }), setStub.secondCall.args[1]);
   });
 
+  it('escapes special characters in the Dropbox-API-Arg header', function () {
+    downloadRequest('sharing/create_shared_link', { foo: 'bar单bazá' }, 'user', 'content', 'atoken');
+    assert(setStub.calledTwice);
+    assert.equal('Dropbox-API-Arg', setStub.secondCall.args[0]);
+    assert.equal('{"foo":"bar\\u5355baz\\u00e1"}', setStub.secondCall.args[1]);
+  });
+
   it('sets the response handler function', function () {
     downloadRequest('sharing/create_shared_link', { foo: 'bar' }, 'user', 'content', 'atoken');
     assert(endStub.calledOnce);

--- a/test/upload-request.js
+++ b/test/upload-request.js
@@ -76,6 +76,13 @@ describe('uploadRequest', function () {
     assert.equal(JSON.stringify({ foo: 'bar' }), setStub.secondCall.args[1]);
   });
 
+  it('escapes special characters in the Dropbox-API-Arg header', function () {
+    uploadRequest('files/upload', { foo: 'bar单bazá' }, 'user', 'content', 'atoken');
+    assert(setStub.calledTwice);
+    assert.equal('Dropbox-API-Arg', setStub.secondCall.args[0]);
+    assert.equal('{"foo":"bar\\u5355baz\\u00e1"}', setStub.secondCall.args[1]);
+  });
+
   it('doesn\'t include args.contents in the Dropbox-API-Arg header', function () {
     uploadRequest('files/upload', { foo: 'bar', contents: 'fakecontents' }, 'user', 'content', 'atoken');
     assert(setStub.calledTwice);


### PR DESCRIPTION
This PR fix issue #86 and it is based on response on dropbox forum https://www.dropboxforum.com/t5/API-support/HTTP-header-quot-Dropbox-API-Arg-quot-could-not-decode-input-as/m-p/195155#M8876 (posted by @MaxwellK in #86)
