### PR TITLE
Fix package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sdk",
     "client"
   ],
-  "repository": "dropbox/dropbox-sdk-js/issues",
+  "repository": "https://github.com/dropbox/dropbox-sdk-js",
   "bugs": "https://github.com/dropbox/dropbox-sdk-js/issues",
   "author": "Riley Tomasek",
   "devDependencies": {


### PR DESCRIPTION
@braincore just realized this was broken because npm isn't linking back to GitHub.