### PR TITLE
try/catch when parsing json in error responses, fixes #126

### DIFF
--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -4,9 +4,17 @@ var getBaseURL = require('./get-base-url');
 
 // This doesn't match what was spec'd in paper doc yet
 var buildCustomError = function (error, response) {
+  var err;
+  if (response) {
+    try {
+      err = JSON.parse(response.text);
+    } catch (e) {
+      err = response.text;
+    }
+  }
   return {
     status: error.status,
-    error: (response ? JSON.parse(response.text): null) || error,
+    error: err || error,
     response: response
   };
 };

--- a/test/rpc-request-error.js
+++ b/test/rpc-request-error.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+var chai = require('chai');
+var request = require('superagent');
+var rpcRequest = require('../src/rpc-request');
+var sinon = require('sinon');
+
+var assert = chai.assert;
+
+var exampleErr = {
+  error_summary: 'other/...',
+  error: {
+    '.tag': 'other'
+  }
+};
+
+describe('rpcRequest error', function () {
+  var postStub;
+
+  afterEach(function () {
+    postStub.restore();
+  });
+
+  it('handles errors in expected format', function (done) {
+    var stubRequest;
+
+    stubRequest = {
+      end: function (cb) {
+        var err = new Error('Internal server error');
+        err.status = 500;
+        return cb(err, { text: JSON.stringify(exampleErr) });
+      },
+      send: function () {},
+      set: function () {},
+      type: function () {}
+    };
+    postStub = sinon.stub(request, 'post').returns(stubRequest);
+    sinon.stub(stubRequest, 'send').returns(stubRequest);
+    sinon.stub(stubRequest, 'set').returns(stubRequest);
+    sinon.stub(stubRequest, 'type').returns(stubRequest);
+
+    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+      .then(function () {
+        done(new Error('shouldn’t reach this callback'));
+      })
+      .catch(function (err) {
+        assert(err);
+        assert.equal(err.status, 500);
+        assert.deepEqual(err.error, exampleErr);
+        done();
+      });
+  });
+
+  it('handles errors when json cannot be parsed', function (done) {
+    var stubRequest;
+
+    stubRequest = {
+      end: function (cb) {
+        var err = new Error('Internal server error');
+        err.status = 500;
+        return cb(err, { text: 'not json' });
+      },
+      send: function () {},
+      set: function () {},
+      type: function () {}
+    };
+    postStub = sinon.stub(request, 'post').returns(stubRequest);
+    sinon.stub(stubRequest, 'send').returns(stubRequest);
+    sinon.stub(stubRequest, 'set').returns(stubRequest);
+    sinon.stub(stubRequest, 'type').returns(stubRequest);
+
+    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+      .then(function () {
+        done(new Error('shouldn’t reach this callback'));
+      })
+      .catch(function (err) {
+        assert(err);
+        assert.equal(err.status, 500);
+        assert.equal(err.error, 'not json');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
This PR prevents the uncaught exceptions seen in #126 by attempting to `try`/`catch` the json parse.

I've added tests for the RPC error handling – one happy case where the errors are as expected (where the sdk was working fine) and one case where the thing being parsed was not valid json (the suspected cause of the crash).

I noticed that the fix to #108 was probably the where this bug was introduced, so while waiting for this to merge we're going to rollback to `v2.5.2`.

Cheers.