### PR TITLE
Add Support for Outbound Proxy

### DIFF
--- a/generator/typescript/dropbox_types.d.ts
+++ b/generator/typescript/dropbox_types.d.ts
@@ -6,6 +6,8 @@ declare module DropboxTypes {
     clientId?: string;
     // Select user is only used by team endpoints. It specifies which user the team access token should be acting as.
     selectUser?: string;
+    // A URL to proxy all HTTP requests through a proxy server
+    proxy?: string;
   }
 
   class DropboxBase {
@@ -29,6 +31,11 @@ declare module DropboxTypes {
     getClientId(): string;
 
     /**
+     * Get the proxy
+     */
+    getProxy(): string;
+
+    /**
      * Set the access token used to authenticate requests to the API.
      * @param accessToken An access token.
      */
@@ -39,6 +46,12 @@ declare module DropboxTypes {
      * @param clientId Your app's client ID.
      */
     setClientId(clientId: string): void;
+
+    /**
+     * Set the proxy URL
+     * @param proxy The proxy URL
+     */
+    setProxy(proxy: string): void;
   }
 
 

--- a/generator/typescript/dropbox_types.d.tstemplate
+++ b/generator/typescript/dropbox_types.d.tstemplate
@@ -6,6 +6,8 @@ declare module DropboxTypes {
     clientId?: string;
     // Select user is only used by team endpoints. It specifies which user the team access token should be acting as.
     selectUser?: string;
+    // A URL to proxy all HTTP requests through a proxy server
+    proxy?: string;
   }
 
   class DropboxBase {
@@ -29,6 +31,11 @@ declare module DropboxTypes {
     getClientId(): string;
 
     /**
+     * Get the proxy
+     */
+    getProxy(): string;
+
+    /**
      * Set the access token used to authenticate requests to the API.
      * @param accessToken An access token.
      */
@@ -39,6 +46,12 @@ declare module DropboxTypes {
      * @param clientId Your app's client ID.
      */
     setClientId(clientId: string): void;
+
+    /**
+     * Set the proxy URL
+     * @param proxy The proxy URL
+     */
+    setProxy(proxy: string): void;
   }
 
 /*TYPES*/

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "es6-promise": "^3.1.2",
-    "superagent": "^3.5.2"
+    "superagent": "^3.5.2",
+    "superagent-proxy": "^1.0.2"
   }
 }

--- a/src/download-request.js
+++ b/src/download-request.js
@@ -3,6 +3,8 @@ var Promise = require('es6-promise').Promise;
 var getBaseURL = require('./get-base-url');
 var httpHeaderSafeJson = require('./http-header-safe-json');
 
+require('superagent-proxy')(request);
+
 var buildCustomError;
 var downloadRequest;
 var nodeBinaryParser;
@@ -30,7 +32,7 @@ nodeBinaryParser = function (res, done) {
   });
 };
 
-downloadRequest = function (path, args, auth, host, accessToken, selectUser) {
+downloadRequest = function (path, args, auth, host, accessToken, selectUser, proxy) {
   if (auth !== 'user') {
     throw new Error('Unexpected auth type: ' + auth);
   }
@@ -78,6 +80,10 @@ downloadRequest = function (path, args, auth, host, accessToken, selectUser) {
 
     if (selectUser) {
       apiRequest = apiRequest.set('Dropbox-API-Select-User', selectUser);
+    }
+
+    if (proxy) {
+      apiRequest.proxy(proxy);
     }
 
     // Apply the node binary parser to the response if executing in node

--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -17,12 +17,14 @@ require('./object-assign-polyfill');
  * authentication URL.
  * @arg {Number} [options.selectUser] - User is the team access token would like
  * to act as.
+ * @arg {String} [options.proxy] - URL to proxy all requests to.
  */
 DropboxBase = function (options) {
   options = options || {};
   this.accessToken = options.accessToken;
   this.clientId = options.clientId;
   this.selectUser = options.selectUser;
+  this.proxy = options.proxy;
 };
 
 /**
@@ -58,6 +60,24 @@ DropboxBase.prototype.setClientId = function (clientId) {
 DropboxBase.prototype.getClientId = function () {
   return this.clientId;
 };
+
+/**
+ * Set the proxy
+ * @arg {String} proxy - The proxy URL
+ * @returns {undefined}
+ */
+DropboxBase.prototype.setProxy = function (proxy) {
+  this.proxy = proxy;
+};
+
+/**
+ * Get the proxy
+ * @returns {String} The proxy URL
+ */
+DropboxBase.prototype.getProxy = function () {
+  return this.proxy;
+};
+
 
 /**
  * Get a URL that can be used to authenticate users for the Dropbox API.
@@ -171,7 +191,7 @@ DropboxBase.prototype.request = function (path, args, auth, host, style) {
       throw new Error('Invalid request style: ' + style);
   }
 
-  return request(path, args, auth, host, this.getAccessToken(), this.selectUser);
+  return request(path, args, auth, host, this.getAccessToken(), this.selectUser, this.proxy);
 };
 
 DropboxBase.prototype.setRpcRequest = function (newRpcRequest) {

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -2,6 +2,8 @@ var request = require('superagent');
 var Promise = require('es6-promise').Promise;
 var getBaseURL = require('./get-base-url');
 
+require('superagent-proxy')(request);
+
 // This doesn't match what was spec'd in paper doc yet
 var buildCustomError = function (error, response) {
   var err;
@@ -19,7 +21,7 @@ var buildCustomError = function (error, response) {
   };
 };
 
-var rpcRequest = function (path, body, auth, host, accessToken, selectUser) {
+var rpcRequest = function (path, body, auth, host, accessToken, selectUser, proxy) {
   var promiseFunction = function (resolve, reject) {
     var apiRequest;
 
@@ -65,6 +67,10 @@ var rpcRequest = function (path, body, auth, host, accessToken, selectUser) {
 
     if (selectUser) {
       apiRequest = apiRequest.set('Dropbox-API-Select-User', selectUser);
+    }
+
+    if (proxy) {
+      apiRequest.proxy(proxy);
     }
 
     apiRequest.send(body)

--- a/src/team/dropbox-team.js
+++ b/src/team/dropbox-team.js
@@ -32,7 +32,8 @@ DropboxTeam.prototype.actAsUser = function (userId) {
   return new Dropbox({
     accessToken: this.accessToken,
     clientId: this.clientId,
-    selectUser: userId
+    selectUser: userId,
+    proxy: this.proxy
   });
 };
 

--- a/src/upload-request.js
+++ b/src/upload-request.js
@@ -3,6 +3,8 @@ var Promise = require('es6-promise').Promise;
 var getBaseURL = require('./get-base-url');
 var httpHeaderSafeJson = require('./http-header-safe-json');
 
+require('superagent-proxy')(request);
+
 // This doesn't match what was spec'd in paper doc yet
 var buildCustomError = function (error, response) {
   return {
@@ -12,7 +14,7 @@ var buildCustomError = function (error, response) {
   };
 };
 
-var uploadRequest = function (path, args, auth, host, accessToken, selectUser) {
+var uploadRequest = function (path, args, auth, host, accessToken, selectUser, proxy) {
   if (auth !== 'user') {
     throw new Error('Unexpected auth type: ' + auth);
   }
@@ -52,6 +54,10 @@ var uploadRequest = function (path, args, auth, host, accessToken, selectUser) {
 
     if (selectUser) {
       apiRequest = apiRequest.set('Dropbox-API-Select-User', selectUser);
+    }
+
+    if (proxy) {
+      apiRequest.proxy(proxy);
     }
 
     apiRequest

--- a/test/download-request.js
+++ b/test/download-request.js
@@ -16,6 +16,7 @@ describe('downloadRequest', function () {
   var typeStub;
   var bufferStub;
   var parseStub;
+  var proxyStub;
 
   beforeEach(function () {
     stubRequest = {
@@ -24,7 +25,8 @@ describe('downloadRequest', function () {
       set: function () {},
       type: function () {},
       buffer: function () {},
-      parse: function () {}
+      parse: function () {},
+      proxy: function () {}
     };
     postStub = sinon.stub(request, 'post').returns(stubRequest);
     endStub = sinon.stub(stubRequest, 'end').returns(stubRequest);
@@ -33,6 +35,7 @@ describe('downloadRequest', function () {
     typeStub = sinon.stub(stubRequest, 'type').returns(stubRequest);
     bufferStub = sinon.stub(stubRequest, 'buffer').returns(stubRequest);
     parseStub = sinon.stub(stubRequest, 'parse').returns(stubRequest);
+    proxyStub = sinon.stub(stubRequest, 'proxy').returns(stubRequest);
   });
 
   afterEach(function () {
@@ -92,5 +95,10 @@ describe('downloadRequest', function () {
     downloadRequest('sharing/create_shared_link', { foo: 'bar' }, 'user', 'content', 'atoken');
     assert(endStub.calledOnce);
     assert.isFunction(endStub.firstCall.args[0]);
+  });
+
+  it('sets a proxy', function () {
+    downloadRequest('sharing/get_shared_link_file', { foo: 'bar' }, 'user', 'content', 'atoken', 'selectedUserId', 'proxy');
+    assert(proxyStub.calledOnce);
   });
 });

--- a/test/dropbox-base.js
+++ b/test/dropbox-base.js
@@ -57,6 +57,25 @@ describe('DropboxBase', function () {
     });
   });
 
+  describe('.proxy', function () {
+    it('can be set in the constructor', function () {
+      dbx = new DropboxBase({ proxy: 'http://localhost:3128' });
+      assert.equal(dbx.getProxy(), 'http://localhost:3128');
+    });
+
+    it('is undefined if not set in constructor', function () {
+      dbx = new DropboxBase();
+      assert.equal(dbx.getProxy(), undefined);
+    });
+
+    it('can be set after being instantiated', function () {
+      dbx = new DropboxBase();
+      dbx.setClientId('http://localhost:3128');
+      assert.equal(dbx.getClientId(), 'http://localhost:3128');
+    });
+  });
+
+
   describe('#rpcRequest()', function () {
     it('defaults to the libraries implementation', function () {
       dbx = new DropboxBase();

--- a/test/rpc-request.js
+++ b/test/rpc-request.js
@@ -15,19 +15,22 @@ describe('rpcRequest', function () {
   var sendStub;
   var setStub;
   var typeStub;
+  var proxyStub;
 
   beforeEach(function () {
     stubRequest = {
       end: function () {},
       send: function () {},
       set: function () {},
-      type: function () {}
+      type: function () {},
+      proxy: function () {}
     };
     postStub = sinon.stub(request, 'post').returns(stubRequest);
     endStub = sinon.stub(stubRequest, 'end').returns(stubRequest);
     sendStub = sinon.stub(stubRequest, 'send').returns(stubRequest);
     setStub = sinon.stub(stubRequest, 'set').returns(stubRequest);
     typeStub = sinon.stub(stubRequest, 'type').returns(stubRequest);
+    proxyStub = sinon.stub(stubRequest, 'proxy').returns(stubRequest);
   });
 
   afterEach(function () {
@@ -85,5 +88,10 @@ describe('rpcRequest', function () {
     rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken');
     assert(endStub.calledOnce);
     assert.isFunction(endStub.firstCall.args[0]);
+  });
+
+  it('sets a proxy', function () {
+    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken', 'selectedUserId', 'proxy');
+    assert(proxyStub.calledOnce);
   });
 });

--- a/test/upload-request.js
+++ b/test/upload-request.js
@@ -14,19 +14,22 @@ describe('uploadRequest', function () {
   var setStub;
   var typeStub;
   var sendStub;
+  var proxyStub;
 
   beforeEach(function () {
     stubRequest = {
       end: function () {},
       send: function () {},
       set: function () {},
-      type: function () {}
+      type: function () {},
+      proxy: function () {}
     };
     postStub = sinon.stub(request, 'post').returns(stubRequest);
     endStub = sinon.stub(stubRequest, 'end').returns(stubRequest);
     setStub = sinon.stub(stubRequest, 'set').returns(stubRequest);
     typeStub = sinon.stub(stubRequest, 'type').returns(stubRequest);
     sendStub = sinon.stub(stubRequest, 'send').returns(stubRequest);
+    proxyStub = sinon.stub(stubRequest, 'proxy').returns(stubRequest);
   });
 
   afterEach(function () {
@@ -101,5 +104,10 @@ describe('uploadRequest', function () {
     uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken');
     assert(endStub.calledOnce);
     assert.isFunction(endStub.firstCall.args[0]);
+  });
+
+  it('sets a proxy', function () {
+    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken', 'selectedUserId', 'proxy');
+    assert(proxyStub.calledOnce);
   });
 });

--- a/webpack-umd.config.js
+++ b/webpack-umd.config.js
@@ -16,6 +16,8 @@ module.exports = {
     path: __dirname + '/dist'
   },
 
+  externals: Object.keys(require(__dirname + '/package.json').dependencies),
+
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin()
   ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,8 @@ module.exports = {
     path: __dirname + '/dist'
   },
 
+  externals: Object.keys(require(__dirname + '/package.json').dependencies),
+
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin()
   ]


### PR DESCRIPTION
This addresses issue #150.

Basically, it allows us to write code like this:

```js
const Dropbox = require('dropbox');

var dbx = new Dropbox({
  // other options
  proxy: 'http://proxy.acme.com:3128'
});

dbx.fileUploads({
}).then(results => {
  // deal with results
}).catch(err => report);
```
In this example, the file upload will happen through an outbound proxy.

In this PR, I also added new unit tests to check the proxy settings and usage.