### PR TITLE
Updating es6-promise dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "webpack-dev-middleware": "^1.6.1"
   },
   "dependencies": {
-    "es6-promise": "^3.1.2",
+    "es6-promise": "^4.1.1",
     "superagent": "^3.5.2"
   }
 }


### PR DESCRIPTION
from https://github.com/dropbox/dropbox-sdk-js/issues/152 : 
es6-promise package was updated in version 4 to avoid overwriting global.Promise.

Simply updating the package.json to use the newer version of the package fixes the issue.