### PR TITLE
Add jsDelivr links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,9 +19,11 @@ $ npm install dropbox --save
 
 #### Script tag
 
-The UMD build is available on [unpkg](https://unpkg.com/):
+The UMD build is available on [jsDelivr](https://www.jsdelivr.com/package/npm/dropbox) or [unpkg](https://unpkg.com/):
 
 ```html
+<script src="https://cdn.jsdelivr.net/npm/dropbox/dist/Dropbox-sdk.min.js"></script>
+<!-- or -->
 <script src="https://unpkg.com/dropbox/dist/Dropbox-sdk.min.js"></script>
 ```
 
@@ -32,7 +34,7 @@ You can find the library on `window.Dropbox`.
 #### Browser with `<script>`
 
 ```html
-<script src="https://unpkg.com/dropbox/dist/Dropbox-sdk.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dropbox/dist/Dropbox-sdk.min.js"></script>
 <script>
   var dbx = new Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN_HERE' });
   dbx.filesListFolder({path: ''})


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/dropbox) to your site as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can instantly serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.