### PR TITLE
Add ability to not place url in getAuthenticationUrl

### DIFF
--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -106,7 +106,7 @@ export class DropboxBase {
     if (!clientId) {
       throw new Error('A client id is required. You can set the client id using .setClientId().');
     }
-    if (!redirectUri) {
+    if (authType !== 'code' && !redirectUri) {
       throw new Error('A redirect uri is required.');
     }
     if (!['code', 'token'].includes(authType)) {

--- a/test/dropbox-base.js
+++ b/test/dropbox-base.js
@@ -86,6 +86,14 @@ describe('DropboxBase', function () {
         'A redirect uri is required.'
       );
     });
+    
+    it('throws an error if the redirect url isn\'t set and type is code', function () {
+      dbx = new DropboxBase({ clientId: 'CLIENT_ID' });
+      assert.equal(
+        dbx.getAuthenticationUrl('', null, 'code'),
+        'https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID'
+      );
+    });
 
     it('returns auth url with redirect uri', function () {
       dbx = new DropboxBase({ clientId: 'CLIENT_ID' });


### PR DESCRIPTION
`redirect_uri` can be empty for `node.js` applications, as I understood from [docs](https://www.dropbox.com/developers/reference/oauth-guide):

> Note that for certain apps, such as command line and desktop apps, it's not possible for a web browser to redirect back to your app. In these cases, your app does not need to include a redirect_uri parameter. Dropbox will present the user with an authorization code that they will need to copy and paste into your app, at which point your app can exchange it for a reusable access toke

And such `url` will work as expected:

```
https://www.dropbox.com/oauth2/authorize?response_type=code&client_id={client_id}
```

So I added ability to not put `url` if there is no need for it.