### PR TITLE
Bugfix/typescript outdated definitions

### DIFF
--- a/generator/typescript/dropbox_types.d.tstemplate
+++ b/generator/typescript/dropbox_types.d.tstemplate
@@ -21,7 +21,7 @@ declare module DropboxTypes {
      * @param state State that will be returned in the redirect URL to help
      *   prevent cross site scripting attacks.
      */
-    getAuthenticationUrl(redirectUri: string, state?: string): string;
+    getAuthenticationUrl(redirectUri: string, state?: string, authType = 'token'): string;
 
     /**
      * Get the client id

--- a/generator/typescript/dropbox_types.d.tstemplate
+++ b/generator/typescript/dropbox_types.d.tstemplate
@@ -39,6 +39,12 @@ declare module DropboxTypes {
      * @param clientId Your app's client ID.
      */
     setClientId(clientId: string): void;
+
+    /**
+     * Set the client secret
+     * @param clientSecret Your app's client secret.
+     */
+    setClientSecret(clientSecret: string): void;
   }
 
 /*TYPES*/

--- a/generator/typescript/dropbox_types.d.tstemplate
+++ b/generator/typescript/dropbox_types.d.tstemplate
@@ -15,6 +15,14 @@ declare module DropboxTypes {
     getAccessToken(): string;
 
     /**
+     * Get an OAuth2 access token from an OAuth2 Code.
+     * @param redirectUri A URL to redirect the user to after authenticating.
+     *   This must be added to your app through the admin interface.
+     * @param code An OAuth2 code.
+     */
+    getAccessTokenFromCode(redirectUri: string, code: string): Promise<string>;
+
+    /**
      * Get a URL that can be used to authenticate users for the Dropbox API.
      * @param redirectUri A URL to redirect the user to after authenticating.
      *   This must be added to your app through the admin interface.

--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -162,7 +162,7 @@ export class DropboxBase {
 
   /**
    * Set the client secret
-   * @arg {String} clientId - Your apps client secret
+   * @arg {String} clientSecret - Your app's client secret
    * @returns {undefined}
    */
   setClientSecret(clientSecret) {


### PR DESCRIPTION
Fixes #191 

This PR does the following:
- Typescript definitions
  - Adds function signature for `setClientSecret`
  - Adds function signature for `getAccessTokenFromCode`
  - Updates function signature `getAuthenticationUrl`
- Fixes typo in doc for `setClientSecret`

This is extremely useful for users relying on `dropbox-sdk-js` in a Typescript environment, because many of these functions are leveraged in OAuth2 authorization code grant flows.

Other token fetching methods use special types (e.g. `auth.TokenFromOAuth1Result`), so I was unsure if `getAccessTokenFromCode` needed a special return type in the Promise.