### PR TITLE
Distribute .d.ts files as part of build step and fix .d.ts file

### DIFF
--- a/generator/typescript/dropbox_types.d.ts
+++ b/generator/typescript/dropbox_types.d.ts
@@ -28,8 +28,9 @@ declare module DropboxTypes {
      *   This must be added to your app through the admin interface.
      * @param state State that will be returned in the redirect URL to help
      *   prevent cross site scripting attacks.
+     * @param authType Auth type, defaults to 'token', other option is 'code'
      */
-    getAuthenticationUrl(redirectUri: string, state?: string, authType = 'token'): string;
+    getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code'): string;
 
     /**
      * Get the client id

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint src/",
     "test:unit": "cross-env BABEL_ENV=testing mocha --require babel-polyfill --require isomorphic-fetch --compilers js:babel-register 'test/*.js'",
-    "build": "npm run build:cjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:team:umd && npm run build:team:umd:min",
+    "build": "npm run build:cjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:team:umd && npm run build:team:umd:min && npm run generate-tsds",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development rollup -c -i src/index.js -o dist/Dropbox-sdk.js -n Dropbox",


### PR DESCRIPTION
This PR adds the generation of typescript definition files to ensure they show up in distributed package.

When TypeScript definition files were introduced in https://github.com/dropbox/dropbox-sdk-js/pull/96, there was command added to the build step to ensure the `.d.ts` files are built.  See `&& npm run generate-tsds ` in [package.json line 15](https://github.com/jvilk/dropbox-sdk-js/blob/5eab745a91094f7dcaa04f796faa78b80bd47739/package.json#L15)

When RollUp was introduced in https://github.com/dropbox/dropbox-sdk-js/pull/137, `npm run generate-tsds` was now excluded from the build step.  This stops the `.d.ts` files from being generated and included in the package published to npm.

Without this PR, running `npm run build` creates the following files in the `dist/` directory:

```
Dropbox-sdk.js
Dropbox-sdk.js.map
Dropbox-sdk.min.js
DropboxTeam-sdk.js
DropboxTeam-sdk.js.map
DropboxTeam-sdk.min.js
```

With this PR, the same command produces the following:

```
Dropbox-sdk.js
Dropbox-sdk.js.map
Dropbox-sdk.min.d.ts
Dropbox-sdk.min.js
DropboxTeam-sdk.js
DropboxTeam-sdk.js.map
DropboxTeam-sdk.min.d.ts
DropboxTeam-sdk.min.js
dropbox-sdk.d.ts
dropbox.d.ts
dropbox_team.d.ts
dropbox_types.d.ts
```

I found this out because the typescript definition files in the latest package (4.0.3) exclude the changes made by this PR: https://github.com/dropbox/dropbox-sdk-js/pull/194.   You can see this by looking at https://unpkg.com/dropbox@4.0.3/dist/dropbox_types.d.ts : `getAuthenticationUrl` still only includes two parameters instead of three.   This PR should fix this.

This also includes a fix to https://github.com/dropbox/dropbox-sdk-js/pull/194 -- TS wasn't liking the default parameter in the `.d.ts` file (See [screenshot](https://monosnap.com/image/OvDpcR84P2tYVDSID7T9jtBSL53if7.png)).  Instead changed this to be an optional type and enum as a value per doc.