### PR TITLE
Fix issue where large response never resolves

### DIFF
--- a/generator/typescript/dropbox_types.d.ts
+++ b/generator/typescript/dropbox_types.d.ts
@@ -29,7 +29,7 @@ declare module DropboxTypes {
      * @param state State that will be returned in the redirect URL to help
      *   prevent cross site scripting attacks.
      */
-    getAuthenticationUrl(redirectUri: string, state?: string, authType = 'token'): string;
+    getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code'): string;
 
     /**
      * Get the client id

--- a/generator/typescript/dropbox_types.d.tstemplate
+++ b/generator/typescript/dropbox_types.d.tstemplate
@@ -29,7 +29,7 @@ declare module DropboxTypes {
      * @param state State that will be returned in the redirect URL to help
      *   prevent cross site scripting attacks.
      */
-    getAuthenticationUrl(redirectUri: string, state?: string, authType = 'token'): string;
+    getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code'): string;
 
     /**
      * Get the client id

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -3,11 +3,9 @@ import { getBaseURL } from './utils';
 
 function parseBodyToType(res) {
   const clone = res.clone();
-  return new Promise((resolve) => {
-    res.json()
-      .then(data => resolve(data))
-      .catch(() => clone.text().then(data => resolve(data)));
-  }).then(data => [res, data]);
+  return res.json()
+            .then(data => [res, data])
+            .catch(() => clone.text().then(data => [res, data]));
 }
 
 export function rpcRequest(path, body, auth, host, accessToken, options) {

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -2,10 +2,10 @@ import { Buffer } from 'buffer/';
 import { getBaseURL } from './utils';
 
 function parseBodyToType(res) {
-  const clone = res.clone();
-  return res.json()
-            .then(data => [res, data])
-            .catch(() => clone.text().then(data => [res, data]));
+  if (res.headers.get('Content-Type') === 'application/json') {
+    return res.json().then(data => [res, data]);
+  }
+  return res.text().then(data => [res, data]);
 }
 
 export function rpcRequest(path, body, auth, host, accessToken, options) {

--- a/test/rpc-request-error.js
+++ b/test/rpc-request-error.js
@@ -21,7 +21,10 @@ describe('rpcRequest error', function () {
     fetchMock.mock('*', function () {
       return {
         status: 500,
-        body: JSON.stringify(exampleErr)
+        body: JSON.stringify(exampleErr),
+        headers: {
+          'Content-Type': 'application/json',
+        },
       };
     }).catch(500);
 


### PR DESCRIPTION
We were seeing that when we had a folder that  exceeded ~70 files and called `filesListFolder` with the folder's path, the promise would never respond.

This is on a project that uses `isomorphic-fetch` to support dropbox sdk's fetch methods.

Digging into the problem, I found that it was the use of cloning the response from fetch by `parseBodyToType`.  When the response is sufficiently large, there is a known issue in `node_fetch` ( which is a dependency of `isomorphic-fetch` ) in which `clone` never responds, see https://github.com/bitinn/node-fetch/issues/396

The `.clone` was used to be able to re-read the stream as text in the case of `.json()` rejecting.  This happens when`.json()` rejects because the server responds with text instead of a JSON object.

We fix this by: instead of catching the rejection of `.json()` to recognize when text is returned by the server, we instead check the headers of the return response to evaluate whether or not the response contains json.

This allows us to get rid of `.clone`, and always just read the response stream once.

We are using this fork in our code base and it fixes the problem.  Large responses now resolve correctly.

Also, fixes https://github.com/dropbox/dropbox-sdk-js/issues/199