### PR TITLE
instantiate w fetch; warn deprecated global fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Dropbox JavaScript SDK is a lightweight, promise based interface to the Drop
 Please view our full JavaScript SDK documentation at <http://dropbox.github.io/dropbox-sdk-js>.
 
 ## Prerequisites
-This library depends on the Promise and Fetch globals which require a polyfill ([whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch), [es6-promise](https://www.npmjs.com/package/es6-promise)) for unsupported browsers and a wrapper around request within Node.js applications. We advise using the [isormophic-fetch](https://www.npmjs.com/package/isomorphic-fetch) library which supports fetch within both environments.
+This library depends on the Promise global which requires a polyfill ([es6-promise](https://www.npmjs.com/package/es6-promise)) for unsupported browsers. It also requires that `fetch` be passed into the constructor; we advise using the [isormophic-fetch](https://www.npmjs.com/package/isomorphic-fetch) library which supports fetch within both environments.
 
 ## Quickstart
 For a quick overview the below example will install the package and use it as a CommonJS module. For more alternative loading options please view our [Getting started](http://dropbox.github.io/dropbox-sdk-js/tutorial-Getting%20started.html) tutorial.
@@ -19,9 +19,9 @@ $ npm install --save dropbox
 Include the Dropbox or DropboxTeam class to start making your API calls.
 
 ```javascript
-require('isomorphic-fetch'); // or another library of choice.
+var fetch = require('isomorphic-fetch'); // or another library of choice.
 var Dropbox = require('dropbox').Dropbox;
-var dbx = new Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN_HERE' });
+var dbx = new Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN_HERE', fetch: fetch });
 dbx.filesListFolder({path: ''})
   .then(function(response) {
     console.log(response);

--- a/docs/tutorials/Authentication.md
+++ b/docs/tutorials/Authentication.md
@@ -16,9 +16,9 @@ used.
 `Dropbox.authenticateWithCordova()` is a method that simplifies authentication from a Cordova / PhoneGap application.
 
 ```javascript
-require('isomorphic-fetch')
+var fetch = require('isomorphic-fetch');
 var Dropbox = require('dropbox').Dropbox;
-var dbx = new Dropbox({ clientId: 'YOUR_CLIENT_KEY_HERE' });
+var dbx = new Dropbox({ clientId: 'YOUR_CLIENT_KEY_HERE', fetch: fetch });
 dbx.authenticateWithCordova(
   function(accessToken) {
       console.log(accessToken);

--- a/docs/tutorials/Installation.md
+++ b/docs/tutorials/Installation.md
@@ -1,7 +1,7 @@
 This package supports ES6 Modules, CommonJS and UMD distributable files we will guide you through the installation steps of installing the JavaScript SDK for your application. If you're having problems installing the package please [submit an issue](https://github.com/dropbox/dropbox-sdk-js/issues).
 
 ## Prerequisites
-This library depends on the Promise and Fetch globals which require a polyfill ([whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch), [es6-promise](https://www.npmjs.com/package/es6-promise)) for unsupported browsers and a wrapper around request within Node.js applications. We advise using the [isormophic-fetch](https://www.npmjs.com/package/isomorphic-fetch) library which supports fetch within both environments.
+This library depends on the Promise global which requires a polyfill ([es6-promise](https://www.npmjs.com/package/es6-promise)) for unsupported browsers. It also requires that `fetch` be passed into the constructor; we advise using the [isormophic-fetch](https://www.npmjs.com/package/isomorphic-fetch) library which supports fetch within both environments.
 
 ## Methods of installation
 **With npm or yarn**

--- a/docs/tutorials/JavaScript SDK.md
+++ b/docs/tutorials/JavaScript SDK.md
@@ -4,9 +4,10 @@ The JavaScript SDK provides a promise interface to relaying calls to the Dropbox
 Using an access token generated from your developer account you'll be able to access your Dropbox information using the Dropbox class to demonstrate the SDK is working correctly.
 
 ```javascript
-require('isomorphic-fetch')
+var fetch = require('isomorphic-fetch');
 var Dropbox = require('dropbox').Dropbox;
 new Dropbox({
+  fetch: fetch,
   accessToken: 'YOUR_ACCESS_TOKEN_HERE'
 })
   .filesListFolder({path: ''})

--- a/examples/javascript/code_flow_example.js
+++ b/examples/javascript/code_flow_example.js
@@ -5,7 +5,7 @@
 // On the server logs, you should have the auth code, as well as the token
 // from exchanging it. This exchange is invisible to the app user
 
-require('isomorphic-fetch');
+var fetch = require('isomorphic-fetch');
 
 const app = require('express')();
 const hostname = 'localhost';
@@ -14,22 +14,23 @@ const port = 3000;
 
 
 const config = {
+  fetch: fetch,
   clientId: [clientId],
   clientSecret: [clientSecret]
 };
- 
+
 const Dropbox = require('dropbox').Dropbox;
 var dbx = new Dropbox(config);
 
 const redirectUri = `http://${hostname}:${port}/auth`;
 const authUrl = dbx.getAuthenticationUrl(redirectUri, null, 'code');
- 
+
 app.get('/', (req, res) => {
   res.writeHead(302, { 'Location': authUrl });
   res.end();
 });
 
- 
+
 app.get('/auth', (req, res) => {
   let code = req.query.code;
   console.log(code);
@@ -37,8 +38,8 @@ app.get('/auth', (req, res) => {
     code,
     redirectUri
   }, config);
- 
- 
+
+
   dbx.getAccessTokenFromCode(redirectUri, code)
     .then(function(token) {
         console.log(token);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "rimraf dist/ es/ lib/",
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint src/",
-    "test:unit": "cross-env BABEL_ENV=testing mocha --require babel-polyfill --require isomorphic-fetch --compilers js:babel-register 'test/*.js'",
+    "test:unit": "cross-env BABEL_ENV=testing mocha --require babel-polyfill --compilers js:babel-register 'test/*.js'",
     "build": "npm run build:cjs && npm run build:es && npm run build:umd && npm run build:umd:min && npm run build:team:umd && npm run build:team:umd:min && npm run generate-tsds",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:cjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ const env = process.env.NODE_ENV;
 const config = {
   format: 'umd',
   sourceMap: (env !== 'production'),
-  external: ['es6-promise/auto', 'isomorphic-fetch'],
+  external: ['es6-promise/auto'],
 
   plugins: [
     resolve({

--- a/src/download-request.js
+++ b/src/download-request.js
@@ -29,30 +29,32 @@ function responseHandler(res, data) {
   return result;
 }
 
-export function downloadRequest(path, args, auth, host, accessToken, options) {
-  if (auth !== 'user') {
-    throw new Error(`Unexpected auth type: ${auth}`);
-  }
+export function downloadRequest(fetch) {
+  return function downloadRequestWithFetch(path, args, auth, host, accessToken, options) {
+    if (auth !== 'user') {
+      throw new Error(`Unexpected auth type: ${auth}`);
+    }
 
-  const fetchOptions = {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Dropbox-API-Arg': httpHeaderSafeJson(args),
-    },
+    const fetchOptions = {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Dropbox-API-Arg': httpHeaderSafeJson(args),
+      },
+    };
+
+    if (options) {
+      if (options.selectUser) {
+        fetchOptions.headers['Dropbox-API-Select-User'] = options.selectUser;
+      }
+      if (options.selectAdmin) {
+        fetchOptions.headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
+      }
+    }
+
+
+    return fetch(getBaseURL(host) + path, fetchOptions)
+      .then(res => getDataFromConsumer(res).then(data => [res, data]))
+      .then(([res, data]) => responseHandler(res, data));
   };
-
-  if (options) {
-    if (options.selectUser) {
-      fetchOptions.headers['Dropbox-API-Select-User'] = options.selectUser;
-    }
-    if (options.selectAdmin) {
-      fetchOptions.headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
-    }
-  }
-
-
-  return fetch(getBaseURL(host) + path, fetchOptions)
-    .then(res => getDataFromConsumer(res).then(data => [res, data]))
-    .then(([res, data]) => responseHandler(res, data));
 }

--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -126,7 +126,7 @@ export class DropboxBase {
     this.selectUser = options.selectUser;
     this.selectAdmin = options.selectAdmin;
     this.fetch = options.fetch || fetch;
-    if (!this.fetch) { console.warn('Global fetch is deprecated and will be unsupported in a future version. Please pass fetch function as option when instantiating dropbox instance: new Dropbox({fetch})'); } // eslint-disable-line no-console
+    if (!options.fetch) { console.warn('Global fetch is deprecated and will be unsupported in a future version. Please pass fetch function as option when instantiating dropbox instance: new Dropbox({fetch})'); } // eslint-disable-line no-console
   }
 
   /**

--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -96,6 +96,7 @@ if (!Array.prototype.includes) {
  * shared between Dropbox and DropboxTeam classes. It is marked as private so
  * that it doesn't show up in the docs because it is never used directly.
  * @arg {Object} options
+ * @arg {Function} [options.fetch] - fetch library for making requests.
  * @arg {String} [options.accessToken] - An access token for making authenticated
  * requests.
  * @arg {String} [options.clientId] - The client id for your app. Used to create
@@ -124,6 +125,8 @@ export class DropboxBase {
     this.clientSecret = options.clientSecret;
     this.selectUser = options.selectUser;
     this.selectAdmin = options.selectAdmin;
+    this.fetch = options.fetch || fetch;
+    if (!this.fetch) { console.warn('Global fetch is deprecated and will be unsupported in a future version. Please pass fetch function as option when instantiating dropbox instance: new Dropbox({fetch})'); } // eslint-disable-line no-console
   }
 
   /**
@@ -243,7 +246,7 @@ client_id=${clientId}&client_secret=${clientSecret}`;
       },
     };
 
-    return fetch(path, fetchOptions)
+    return this.fetch(path, fetchOptions)
       .then(res => parseBodyToType(res))
       .then(([res, data]) => {
         // maintaining existing API for error codes not equal to 200 range
@@ -357,7 +360,7 @@ client_id=${clientId}&client_secret=${clientSecret}`;
 
   getRpcRequest() {
     if (this.rpcRequest === undefined) {
-      this.rpcRequest = rpcRequest;
+      this.rpcRequest = rpcRequest(this.fetch);
     }
     return this.rpcRequest;
   }
@@ -368,7 +371,7 @@ client_id=${clientId}&client_secret=${clientSecret}`;
 
   getDownloadRequest() {
     if (this.downloadRequest === undefined) {
-      this.downloadRequest = downloadRequest;
+      this.downloadRequest = downloadRequest(this.fetch);
     }
     return this.downloadRequest;
   }
@@ -379,7 +382,7 @@ client_id=${clientId}&client_secret=${clientSecret}`;
 
   getUploadRequest() {
     if (this.uploadRequest === undefined) {
-      this.uploadRequest = uploadRequest;
+      this.uploadRequest = uploadRequest(this.fetch);
     }
     return this.uploadRequest;
   }

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -7,6 +7,7 @@ import { DropboxBase } from './dropbox-base';
  * @classdesc The Dropbox SDK class that provides methods to read, write and
  * create files or folders in a user's Dropbox.
  * @arg {Object} options
+ * @arg {Function} [options.fetch] - fetch library for making requests.
  * @arg {String} [options.accessToken] - An access token for making authenticated
  * requests.
  * @arg {String} [options.clientId] - The client id for your app. Used to create

--- a/src/rpc-request.js
+++ b/src/rpc-request.js
@@ -8,58 +8,60 @@ function parseBodyToType(res) {
   return res.text().then(data => [res, data]);
 }
 
-export function rpcRequest(path, body, auth, host, accessToken, options) {
-  const fetchOptions = {
-    method: 'POST',
-    body: (body) ? JSON.stringify(body) : null,
+export function rpcRequest(fetch) {
+  return function rpcRequestWithFetch(path, body, auth, host, accessToken, options) {
+    const fetchOptions = {
+      method: 'POST',
+      body: (body) ? JSON.stringify(body) : null,
+    };
+    const headers = {};
+    if (body) {
+      headers['Content-Type'] = 'application/json';
+    }
+    let authHeader = '';
+
+    switch (auth) {
+      case 'app':
+        if (!options.clientId || !options.clientSecret) {
+          throw new Error('A client id and secret is required for this function');
+        }
+        authHeader = new Buffer(`${options.clientId}:${options.clientSecret}`).toString('base64');
+        headers.Authorization = `Basic ${authHeader}`;
+        break;
+      case 'team':
+      case 'user':
+        headers.Authorization = `Bearer ${accessToken}`;
+        break;
+      case 'noauth':
+        break;
+      default:
+        throw new Error(`Unhandled auth type: ${auth}`);
+    }
+
+    if (options) {
+      if (options.selectUser) {
+        headers['Dropbox-API-Select-User'] = options.selectUser;
+      }
+      if (options.selectAdmin) {
+        headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
+      }
+    }
+
+    fetchOptions.headers = headers;
+    return fetch(getBaseURL(host) + path, fetchOptions)
+      .then(res => parseBodyToType(res))
+      .then(([res, data]) => {
+        // maintaining existing API for error codes not equal to 200 range
+        if (!res.ok) {
+          // eslint-disable-next-line no-throw-literal
+          throw {
+            error: data,
+            response: res,
+            status: res.status,
+          };
+        }
+
+        return data;
+      });
   };
-  const headers = {};
-  if (body) {
-    headers['Content-Type'] = 'application/json';
-  }
-  let authHeader = '';
-
-  switch (auth) {
-    case 'app':
-      if (!options.clientId || !options.clientSecret) {
-        throw new Error('A client id and secret is required for this function');
-      }
-      authHeader = new Buffer(`${options.clientId}:${options.clientSecret}`).toString('base64');
-      headers.Authorization = `Basic ${authHeader}`;
-      break;
-    case 'team':
-    case 'user':
-      headers.Authorization = `Bearer ${accessToken}`;
-      break;
-    case 'noauth':
-      break;
-    default:
-      throw new Error(`Unhandled auth type: ${auth}`);
-  }
-
-  if (options) {
-    if (options.selectUser) {
-      headers['Dropbox-API-Select-User'] = options.selectUser;
-    }
-    if (options.selectAdmin) {
-      headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
-    }
-  }
-
-  fetchOptions.headers = headers;
-  return fetch(getBaseURL(host) + path, fetchOptions)
-    .then(res => parseBodyToType(res))
-    .then(([res, data]) => {
-      // maintaining existing API for error codes not equal to 200 range
-      if (!res.ok) {
-        // eslint-disable-next-line no-throw-literal
-        throw {
-          error: data,
-          response: res,
-          status: res.status,
-        };
-      }
-
-      return data;
-    });
 }

--- a/src/upload-request.js
+++ b/src/upload-request.js
@@ -9,46 +9,48 @@ function parseBodyToType(res) {
   }).then(data => [res, data]);
 }
 
-export function uploadRequest(path, args, auth, host, accessToken, options) {
-  if (auth !== 'user') {
-    throw new Error(`Unexpected auth type: ${auth}`);
-  }
-
-  const { contents } = args;
-  delete args.contents;
-
-  const fetchOptions = {
-    body: contents,
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/octet-stream',
-      'Dropbox-API-Arg': httpHeaderSafeJson(args),
-    },
-  };
-
-  if (options) {
-    if (options.selectUser) {
-      fetchOptions.headers['Dropbox-API-Select-User'] = options.selectUser;
+export function uploadRequest(fetch) {
+  return function uploadRequestWithFetch(path, args, auth, host, accessToken, options) {
+    if (auth !== 'user') {
+      throw new Error(`Unexpected auth type: ${auth}`);
     }
-    if (options.selectAdmin) {
-      fetchOptions.headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
-    }
-  }
 
-  return fetch(getBaseURL(host) + path, fetchOptions)
-    .then(res => parseBodyToType(res))
-    .then(([res, data]) => {
-      // maintaining existing API for error codes not equal to 200 range
-      if (!res.ok) {
-        // eslint-disable-next-line no-throw-literal
-        throw {
-          error: data,
-          response: res,
-          status: res.status,
-        };
+    const { contents } = args;
+    delete args.contents;
+
+    const fetchOptions = {
+      body: contents,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/octet-stream',
+        'Dropbox-API-Arg': httpHeaderSafeJson(args),
+      },
+    };
+
+    if (options) {
+      if (options.selectUser) {
+        fetchOptions.headers['Dropbox-API-Select-User'] = options.selectUser;
       }
+      if (options.selectAdmin) {
+        fetchOptions.headers['Dropbox-API-Select-Admin'] = options.selectAdmin;
+      }
+    }
 
-      return data;
-    });
+    return fetch(getBaseURL(host) + path, fetchOptions)
+      .then(res => parseBodyToType(res))
+      .then(([res, data]) => {
+        // maintaining existing API for error codes not equal to 200 range
+        if (!res.ok) {
+          // eslint-disable-next-line no-throw-literal
+          throw {
+            error: data,
+            response: res,
+            status: res.status,
+          };
+        }
+
+        return data;
+      });
+  };
 }

--- a/test/dropbox-base.js
+++ b/test/dropbox-base.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
+import fetch from 'isomorphic-fetch';
 import { RPC } from '../src/constants';
 import { DropboxBase } from '../src/dropbox-base';
 import { rpcRequest } from '../src/rpc-request';
@@ -57,7 +58,7 @@ describe('DropboxBase', function () {
   describe('#rpcRequest()', function () {
     it('defaults to the libraries implementation', function () {
       dbx = new DropboxBase();
-      assert.equal(dbx.getRpcRequest(), rpcRequest);
+      assert.equal(dbx.getRpcRequest().toString(), rpcRequest('fetch goes here').toString());
     });
 
     it('can be set to something else by the user', function () {
@@ -86,7 +87,7 @@ describe('DropboxBase', function () {
         'A redirect uri is required.'
       );
     });
-    
+
     it('throws an error if the redirect url isn\'t set and type is code', function () {
       dbx = new DropboxBase({ clientId: 'CLIENT_ID' });
       assert.equal(
@@ -283,7 +284,7 @@ describe('DropboxBase', function () {
   describe('.request()', function () {
     it('calls the correct request method', function () {
       var rpcSpy;
-      dbx = new DropboxBase();
+      dbx = new DropboxBase({fetch});
       rpcSpy = sinon.spy(dbx.getRpcRequest());
       dbx.setRpcRequest(rpcSpy);
       dbx.request('path', {}, 'user', 'api', RPC);

--- a/test/dropbox-team.js
+++ b/test/dropbox-team.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
+import fetch from 'isomorphic-fetch';
 
 import { RPC } from '../src/constants';
 import { Dropbox } from '../src/dropbox';
@@ -19,7 +20,7 @@ describe('DropboxTeam', function () {
   describe('api method', function () {
     it('teamGroupsList calls DropboxTeam.request', function () {
       var requestSpy;
-      dbx = new DropboxTeam();
+      dbx = new DropboxTeam({fetch});
       requestSpy = sinon.spy(dbx, 'request');
       dbx.teamGroupsList({ limit: 10 });
       assert(requestSpy.calledOnce);

--- a/test/dropbox.js
+++ b/test/dropbox.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
+import fetch from 'isomorphic-fetch';
 
 import { RPC } from '../src/constants';
 import { Dropbox } from '../src/dropbox';
@@ -9,7 +10,7 @@ describe('Dropbox', function () {
   describe('api method', function () {
     it('filesListFolder calls Dropbox.request', function () {
       var requestSpy;
-      dbx = new Dropbox();
+      dbx = new Dropbox({fetch});
       requestSpy = sinon.spy(dbx, 'request');
       dbx.filesListFolder({});
       assert(requestSpy.calledOnce);

--- a/test/rpc-request-error.js
+++ b/test/rpc-request-error.js
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
-import fetchMock from 'fetch-mock';
+import FetchMock from 'fetch-mock';
+import isomorphicFetch from 'isomorphic-fetch'; // fetchMock needs this in scope to mock correctly.
 import { rpcRequest } from '../src/rpc-request';
 
 var exampleErr = {
@@ -13,12 +14,12 @@ var exampleErr = {
 describe('rpcRequest error', function () {
 
   afterEach(function () {
-    fetchMock.restore();
+    FetchMock.restore();
   });
 
   it('handles errors in expected format', function (done) {
 
-    fetchMock.mock('*', function () {
+    const fetchMock = FetchMock.sandbox().mock('*', function () {
       return {
         status: 500,
         body: JSON.stringify(exampleErr),
@@ -28,7 +29,7 @@ describe('rpcRequest error', function () {
       };
     }).catch(500);
 
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then(function (data) {
         done(new Error('shouldn’t reach this callback'));
       })
@@ -42,14 +43,14 @@ describe('rpcRequest error', function () {
 
   it('handles errors when json cannot be parsed', function (done) {
 
-    fetchMock.mock('*', function () {
+    const fetchMock = FetchMock.sandbox().mock('*', function () {
       return {
         status: 500,
         body: 'not json'
       };
     }).catch(500);
 
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then(function (data) {
         done(new Error('shouldn’t reach this callback'));
       })

--- a/test/rpc-request.js
+++ b/test/rpc-request.js
@@ -1,13 +1,15 @@
 import 'babel-polyfill';
 import sinon from 'sinon';
 import { assert } from 'chai';
-import fetchMock from 'fetch-mock';
+import FetchMock from 'fetch-mock';
+import isomorphicFetch from 'isomorphic-fetch'; // fetchMock needs this in scope to mock correctly.
 import { rpcRequest } from '../src/rpc-request';
 
 describe('rpcRequest', function () {
 
+  let fetchMock;
   beforeEach(function () {
-    fetchMock.mock('*', new Response(
+    fetchMock = FetchMock.sandbox().mock('*', new Response(
       '{"test": "test"}',
       {
         status : 200 ,
@@ -21,25 +23,25 @@ describe('rpcRequest', function () {
   });
 
   afterEach(function () {
-    fetchMock.restore();
+    FetchMock.restore();
   });
 
   it('returns an error when no auth given', function () {
     assert.throws(
-      rpcRequest,
+      rpcRequest(fetchMock),
       Error
     );
   });
 
   it('returns a promise when given valid arguments', function () {
     assert.instanceOf(
-      rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken'),
+      rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken'),
       Promise
     );
   });
 
   it('posts to the correct url once', function (done) {
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then(res => {
         assert.equal(fetchMock.calls().matched.length, 1);
         assert.equal(fetchMock.lastUrl(), 'https://api.dropboxapi.com/2/files/list');
@@ -48,7 +50,7 @@ describe('rpcRequest', function () {
   });
 
   it('sets the request type to application/json', function (done) {
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then((res) => {
         assert.equal(fetchMock.lastOptions().headers['Content-Type'], 'application/json');
         done();
@@ -56,7 +58,7 @@ describe('rpcRequest', function () {
   });
 
   it('sets the authorization header', function (done) {
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then((res) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         done();
@@ -64,7 +66,7 @@ describe('rpcRequest', function () {
   });
 
   it('sets the authorization and select user headers if selectUser set', function (done) {
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken', {selectUser: 'selectedUserId'})
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken', {selectUser: 'selectedUserId'})
       .then((res) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         assert.equal(fetchMock.lastOptions().headers['Dropbox-API-Select-User'], 'selectedUserId');
@@ -73,7 +75,7 @@ describe('rpcRequest', function () {
   });
 
   it('sets the request body', function (done) {
-    rpcRequest('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', { foo: 'bar' }, 'user', 'api', 'atoken')
       .then((res) => {
         assert.equal(fetchMock.lastOptions().body, JSON.stringify({ foo: 'bar' }));
         done();
@@ -81,7 +83,7 @@ describe('rpcRequest', function () {
   });
 
   it('sets the request body to null if body isn\'t passed', function (done) {
-    rpcRequest('files/list', undefined, 'user', 'api', 'atoken')
+    rpcRequest(fetchMock)('files/list', undefined, 'user', 'api', 'atoken')
       .then((res) => {
         assert.deepEqual(fetchMock.lastOptions().body, null);
         done();

--- a/test/upload-request.js
+++ b/test/upload-request.js
@@ -1,11 +1,13 @@
 import { assert } from 'chai';
-import fetchMock from 'fetch-mock';
+import FetchMock from 'fetch-mock';
+import isomorphicFetch from 'isomorphic-fetch'; // fetchMock needs this in scope to mock correctly.
 import { uploadRequest } from '../src/upload-request';
 
 describe('uploadRequest', function () {
 
+  let fetchMock;
   beforeEach(function () {
-    fetchMock.post('*', new Response(
+    fetchMock = FetchMock.sandbox().post('*', new Response(
       '{"foo": "bar"}',
       {
         status : 200 ,
@@ -19,18 +21,18 @@ describe('uploadRequest', function () {
   });
 
   afterEach(function () {
-    fetchMock.restore();
+    FetchMock.restore();
   });
 
   it('returns a promise', function () {
     assert.instanceOf(
-      uploadRequest('path', {}, 'user', 'content', 'atoken'),
+      uploadRequest(fetchMock)('path', {}, 'user', 'content', 'atoken'),
       Promise
     );
   });
 
   it('posts to the correct url', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
       .then(() => {
         assert.equal(fetchMock.calls().matched.length, 1);
         assert.equal(fetchMock.lastUrl(), 'https://content.dropboxapi.com/2/files/upload');
@@ -39,7 +41,7 @@ describe('uploadRequest', function () {
   });
 
   it('sets the request type to application/octet-stream', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
       .then(() => {
         assert.equal(fetchMock.lastOptions().headers['Content-Type'], 'application/octet-stream');
         done();
@@ -47,7 +49,7 @@ describe('uploadRequest', function () {
   });
 
   it('sets the authorization header', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
       .then((data) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         done();
@@ -55,7 +57,7 @@ describe('uploadRequest', function () {
   });
 
   it('sets the authorization and select user headers if selectUser set', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken', {selectUser: 'selectedUserId'})
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken', {selectUser: 'selectedUserId'})
       .then((data) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         assert.equal(fetchMock.lastOptions().headers['Dropbox-API-Select-User'], 'selectedUserId');
@@ -64,7 +66,7 @@ describe('uploadRequest', function () {
   });
 
   it('sets the Dropbox-API-Arg header', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
       .then((data) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         assert.equal(fetchMock.lastOptions().headers['Dropbox-API-Arg'], JSON.stringify({ foo: 'bar' }));
@@ -73,7 +75,7 @@ describe('uploadRequest', function () {
   });
 
   it('escapes special characters in the Dropbox-API-Arg header', function (done) {
-    uploadRequest('files/upload', { foo: 'bar单bazá' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar单bazá' }, 'user', 'content', 'atoken')
       .then((data) => {
         assert.equal(fetchMock.lastOptions().headers['Authorization'], 'Bearer atoken');
         assert.equal(fetchMock.lastOptions().headers['Dropbox-API-Arg'], '{"foo":"bar\\u5355baz\\u00e1"}');
@@ -84,7 +86,7 @@ describe('uploadRequest', function () {
 
 
   it('doesn\'t include args.contents in the Dropbox-API-Arg header', function (done) {
-    uploadRequest('files/upload', { foo: 'bar', contents: 'fakecontents' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar', contents: 'fakecontents' }, 'user', 'content', 'atoken')
       .then((data) => {
         assert.equal(fetchMock.lastOptions().headers['Dropbox-API-Arg'], JSON.stringify({ foo: 'bar' }));
         done();
@@ -92,7 +94,7 @@ describe('uploadRequest', function () {
   });
 
   it('returns a valid response', function (done) {
-    uploadRequest('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
+    uploadRequest(fetchMock)('files/upload', { foo: 'bar' }, 'user', 'content', 'atoken')
       .then((data) => {
         assert.deepEqual(data, { foo: 'bar' })
         done();


### PR DESCRIPTION
- [x] fixes #200 
- [x] still allow use of global fetch.
- [x] warn when using global fetch that it should be passed in constructor and will be deprecated later.
- [x] fix tests.
- [x] update docs and examples.

I assume we'll have some go-arounds on this PR so feedback and edits welcome! 😊