### PR TITLE
Fix iOS auth on cordova-plugin-inappbrowser

### DIFF
--- a/src/dropbox-base.js
+++ b/src/dropbox-base.js
@@ -286,10 +286,12 @@ client_id=${clientId}&client_secret=${clientSecret}`;
     let removed = false;
     const browser = window.open(url, '_blank');
 
-    function onLoadError() {
-      // Try to avoid a browser crash on browser.close().
-      window.setTimeout(() => { browser.close(); }, 10);
-      errorCallback();
+    function onLoadError(event) {
+      if (event.code != -999) { // Workaround to fix wrong behavior on cordova-plugin-inappbrowser
+        // Try to avoid a browser crash on browser.close().
+        window.setTimeout(() => { browser.close(); }, 10);
+        errorCallback();
+      }
     }
 
     function onLoadStop(event) {


### PR DESCRIPTION
We're using dropbox-sdk-js in a Cordova application but can't authorize because the InAppBrowser windows closes as an `-999` error is raised in iOS.