### PR TITLE
Fix "Tutorials" links in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,10 @@ The Dropbox JavaScript SDK is a lightweight, promise based interface to the Drop
 
 ## Tutorials
 
-- [Installation](tutorial-Installation.html)
-- [Getting started](tutorial-Getting%20started.html)
-- [JavaScript SDK](tutorial-JavaScript%20SDK.html)
-- [Authentication](tutorial-Authentication.html)
+- [Installation](tutorials/Installation.md)
+- [Getting started](tutorials/Getting%20started.md)
+- [JavaScript SDK](tutorials/JavaScript%20SDK.md)
+- [Authentication](tutorials/Authentication.md)
 
 ## Examples
 


### PR DESCRIPTION
Links were broken and returned a 404 since they pointed to non-existent HTML files.
This change updates the links to point to the actual Markdown files.