### PR TITLE
Fix node JS example upload

### DIFF
--- a/examples/javascript/node/upload.js
+++ b/examples/javascript/node/upload.js
@@ -14,7 +14,7 @@ prompt.get({
 }, function (error, result) {
   var dbx = new Dropbox({ accessToken: result.accessToken });
 
-  fs.readFile(path.join(__dirname, '/basic.js'), 'utf8', function (err, contents) {
+  fs.readFile(path.join(__dirname, '/basic.js'), function (err, contents) {
     if (err) {
       console.log('Error: ', err);
     }


### PR DESCRIPTION
Fixed issue where utf8 encoding corrupts files being uploaded