### PR TITLE
Fix refreshAccessToken data accessing

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -322,8 +322,8 @@ export default class DropboxAuth {
     return this.fetch(refreshUrl, fetchOptions)
       .then((res) => parseResponse(res))
       .then((res) => {
-        this.setAccessToken(res.access_token);
-        this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.expires_in));
+        this.setAccessToken(res.result.access_token);
+        this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.result.expires_in));
       });
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
The fetch result is wrapped by `DropboxResponse` but `refreshAccessToken` didn't  access the returned data correctly 

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `npm test` pass?
- [x] Does `npm run build` pass?
- [x] Does `npm run lint` pass?