### PR TITLE
Fix noauth constant, Update error types, Add release scripts

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,0 +1,9 @@
+Release Notes: 
+
+* Bump sinon from 9.0.3 to 9.1.0 (#310) 
+
+* Fix refreshAccessToken response (#311) 
+
+* Fix type in question_help template (#302) 
+
+* Misc Bug Fixes (#307) 

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,9 +1,0 @@
-Release Notes: 
-
-* Bump sinon from 9.0.3 to 9.1.0 (#310) 
-
-* Fix refreshAccessToken response (#311) 
-
-* Fix type in question_help template (#302) 
-
-* Misc Bug Fixes (#307) 

--- a/scripts/release_note_generator.sh
+++ b/scripts/release_note_generator.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-last_version=$(git tag -l | tail -n 2 | head -n 1)
+last_version=$(git tag --sort v:refname | tail -n 2 | head -n 1)
 echo "Getting commit history since $last_version"
 num_commits=$(git rev-list --count $last_version..HEAD)
 echo "Found $num_commits commits since last revision"
 git_log=$(git log -n $num_commits --pretty="format:* %s %n")
-linked_log=$(echo "Release Notes: \n\n$git_log" | sed -e 's/#\([0-9]*\)/[#\1](github.com\/dropbox\/dropbox-sdk-js\/pulls\/\1)/g')
+linked_log=$(echo "Release Notes: \n\n$git_log" | sed -e 's/#\([0-9]*\)/[#\1](github.com\/dropbox\/dropbox-sdk-js\/pull\/\1)/g')
 echo "\n\n$linked_log"

--- a/scripts/release_note_generator.sh
+++ b/scripts/release_note_generator.sh
@@ -4,8 +4,6 @@ last_version=$(git tag -l | tail -n 2 | head -n 1)
 echo "Getting commit history since $last_version"
 num_commits=$(git rev-list --count $last_version..HEAD)
 echo "Found $num_commits commits since last revision"
-log=$(git log -n $num_commits --pretty="format:* %s %n")
-echo $log
-#linked_log=$(echo "Release Notes: \n\n$log" | sed 's/#\([0-9]\+\)/[#\1](link\/\1)/g')
-#echo $linked_log
-echo "Release notes written to release_notes.txt"
+git_log=$(git log -n $num_commits --pretty="format:* %s %n")
+linked_log=$(echo "Release Notes: \n\n$git_log" | sed -e 's/#\([0-9]*\)/[#\1](github.com\/dropbox\/dropbox-sdk-js\/pulls\/\1)/g')
+echo "\n\n$linked_log"

--- a/scripts/release_note_generator.sh
+++ b/scripts/release_note_generator.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+last_version=$(git tag -l | tail -n 2 | head -n 1)
+echo "Getting commit history since $last_version"
+num_commits=$(git rev-list --count $last_version..HEAD)
+echo "Found $num_commits commits since last revision"
+log=$(git log -n $num_commits --pretty="format:* %s %n")
+echo $log
+#linked_log=$(echo "Release Notes: \n\n$log" | sed 's/#\([0-9]\+\)/[#\1](link\/\1)/g')
+#echo $linked_log
+echo "Release notes written to release_notes.txt"

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -z $1 ]; then
+    echo "error: $0 needs a version number as argument.";
+    exit 1
+else
+    set -ex
+    NEW_VERSION=$1
+
+    git checkout master
+    git reset --hard HEAD
+
+    git tag "v${NEW_VERSION}" -m "${NEW_VERSION} release"
+
+    git push origin
+    git push origin --tags
+fi

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,4 +5,4 @@ export const DOWNLOAD = 'download';
 export const APP_AUTH = 'app';
 export const USER_AUTH = 'user';
 export const TEAM_AUTH = 'team';
-export const NO_AUTH = 'no_auth';
+export const NO_AUTH = 'noauth';

--- a/src/response.js
+++ b/src/response.js
@@ -11,7 +11,7 @@ export class DropboxResponse {
 export function parseResponse(res) {
   const clone = res.clone();
 
-  if(!res.ok) {
+  if (!res.ok) {
     res.text()
       .then((data) => {
         // eslint-disable-next-line no-throw-literal

--- a/src/response.js
+++ b/src/response.js
@@ -11,6 +11,18 @@ export class DropboxResponse {
 export function parseResponse(res) {
   const clone = res.clone();
 
+  if(!res.ok) {
+    res.text()
+      .then((data) => {
+        // eslint-disable-next-line no-throw-literal
+        throw {
+          error: data,
+          response: res,
+          status: res.status,
+        };
+      });
+  }
+
   return res.json()
     .catch(() => {
       clone.text();
@@ -35,7 +47,12 @@ export function parseDownloadResponse(res) {
       let result;
 
       if (!res.ok) {
-        result = data;
+        // eslint-disable-next-line no-throw-literal
+        throw {
+          error: data,
+          response: res,
+          status: res.status,
+        };
       } else {
         result = JSON.parse(res.headers.get('dropbox-api-result'));
 


### PR DESCRIPTION
- Change NO_AUTH constant from no_auth to noauth
- Throw errors instead of returning DropboxResponse with invalid status in response
- Add release_note_generator and update_version scripts

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [X] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [X] Non-code related change (markdown/git settings etc)
- [X] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [X] Does `npm test` pass?
- [X] Does `npm run build` pass?
- [X] Does `npm run lint` pass?