### PR TITLE
Fix: keep error in same async loop

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -12,7 +12,7 @@ export function parseResponse(res) {
   const clone = res.clone();
 
   if (!res.ok) {
-    res.text()
+    return res.text()
       .then((data) => {
         // eslint-disable-next-line no-throw-literal
         throw {


### PR DESCRIPTION

This PR fixes the error which is actually thrown after the promise resolution

## **Checklist**

**General Contributing**
- [X] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [X] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [X] Does `npm test` pass?
- [X] Does `npm run build` pass?
- [X] Does `npm run lint` pass?