### PR TITLE
use fetch function defined in the class property, instead of the global one

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -148,7 +148,7 @@ export default class Dropbox {
 
         return fetchOptions;
       })
-      .then((fetchOptions) => fetch(getBaseURL(host) + path, fetchOptions))
+      .then((fetchOptions) => this.fetch(getBaseURL(host) + path, fetchOptions))
       .then((res) => parseDownloadResponse(res));
   }
 


### PR DESCRIPTION
Small change to use the `fetch` function that was set in the contstructor:
```
this.fetch = options.fetch || fetch;
```
instead of the global fetch defined at the top of the file.

This fixes an issue where a custom fetch function was passed into the dropbox constructor, but here it was still using the wrong fetch.

Note: `npm run lint` does not pass, but it was not passing before either, this PR does not introduce any new lint warnings/errors.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `npm test` pass?
- [x] Does `npm run build` pass?
- [ ] Does `npm run lint` pass?