### PR TITLE
Fix PKCE for browsers and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ We provide [Examples][examples] to help get you started with a lot of the basic 
     - Auth - [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/auth) ] - A simple auth example to get an access token and list the files in the root of your Dropbox account.
     - Simple Backend [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/simple-backend) ] - A simple example of a node backend doing a multi-step auth flow for Short Lived Tokens.
     - PKCE Backend [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/PKCE-backend) ] - A simple example of a node backend doing a multi-step auth flow using PKCE and Short Lived Tokens.
+    - PKCE Browser [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/PKCE-browser) ] - A simple example of a frontend doing a multi-step auth flow using PKCE and Short Lived Tokens.
 
 - **Other Examples**
     - Basic - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/node), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/basic) ] - A simple example that takes in a token and fetches files from your Dropbox account.

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -32,7 +32,7 @@
             <li><a href="team-as-user">Team as user example</a></li>
             <li><a href="upload">File upload</a></li>
             <li><a href="download">File download</a></li>
-            <li><a href="pkce-browser">PKCE Browser Example</a></li>
+            <li><a href="pkce-browser">PKCE browser example</a></li>
         </ul>
     </section>
 </body>

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -1,37 +1,40 @@
 <!doctype html>
 <html>
-<head>
-  <title>Dropbox JavaScript SDK Examples</title>
-  <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-  <!-- Example layout boilerplate -->
-  <header class="page-header">
-    <div class="container">
-      <nav>
-        <a href="/">
-          <h1>
-            <img src="https://cfl.dropboxstatic.com/static/images/brand/logotype_white-vflRG5Zd8.svg" class="logo" />
-            JavaScript SDK Examples
-          </h1>
-        </a>
-        <a href="https://github.com/dropbox/dropbox-sdk-js/tree/master/examples/javascript" class="view-source">View Source</a>
-      </nav>
-      <h2 class="code">
-        <a href="/">examples</a>
-      </h2>
-    </div>
-  </header>
 
-  <section class="container main">
-    <ul>
-      <li><a href="basic">Basic example</a></li>
-      <li><a href="auth">Authentication example</a></li>
-      <li><a href="team">Team example</a></li>
-      <li><a href="team-as-user">Team as user example</a></li>
-      <li><a href="upload">File upload</a></li>
-      <li><a href="download">File download</a></li>
-    </ul>
-  </section>
+<head>
+    <title>Dropbox JavaScript SDK Examples</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+
+<body>
+    <!-- Example layout boilerplate -->
+    <header class="page-header">
+        <div class="container">
+            <nav>
+                <a href="/">
+                    <h1>
+                        <img src="https://cfl.dropboxstatic.com/static/images/brand/logotype_white-vflRG5Zd8.svg" class="logo" /> JavaScript SDK Examples
+                    </h1>
+                </a>
+                <a href="https://github.com/dropbox/dropbox-sdk-js/tree/master/examples/javascript" class="view-source">View Source</a>
+            </nav>
+            <h2 class="code">
+                <a href="/">examples</a>
+            </h2>
+        </div>
+    </header>
+
+    <section class="container main">
+        <ul>
+            <li><a href="basic">Basic example</a></li>
+            <li><a href="auth">Authentication example</a></li>
+            <li><a href="team">Team example</a></li>
+            <li><a href="team-as-user">Team as user example</a></li>
+            <li><a href="upload">File upload</a></li>
+            <li><a href="download">File download</a></li>
+            <li><a href="pkce-browser">PKCE Browser Example</a></li>
+        </ul>
+    </section>
 </body>
+
 </html>

--- a/examples/javascript/pkce-browser/index.html
+++ b/examples/javascript/pkce-browser/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html>
+
+<head>
+    <title>Dropbox JavaScript SDK</title>
+    <link rel="stylesheet" href="/styles.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@7/dist/polyfill.min.js"></script>
+    <script src="/__build__/Dropbox-sdk.min.js"></script>
+    <script src="/utils.js"></script>
+</head>
+
+<body>
+    <!-- Example layout boilerplate -->
+    <header class="page-header">
+        <div class="container">
+            <nav>
+                <a href="/">
+                    <h1>
+                        <img src="https://cfl.dropboxstatic.com/static/images/brand/logotype_white-vflRG5Zd8.svg" class="logo" /> JavaScript SDK Examples
+                    </h1>
+                </a>
+                <a href="https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript" class="view-source">View Source</a>
+            </nav>
+            <h2 class="code">
+                <a href="/">examples</a> / PKCE Browser
+            </h2>
+        </div>
+    </header>
+
+    <!-- Example description and UI -->
+    <section class="container main">
+        <p>This example shows how to use PKCE in the browser</p>
+        <div id="pre-auth-section" style="display:none;">
+            <button onClick="doAuth()">Start PKCE Auth Flow</button>
+
+            <p class="info">Once authenticated, it will use the access token to list the files in your root directory.</p>
+        </div>
+
+        <div id="authed-section" style="display:none;">
+            <p>You have successfully authenticated. Below are the contents of your root directory. They were fetched using the SDK and access token.</p>
+            <ul id="files"></ul>
+        </div>
+    </section>
+
+    <!-- Scripts to run example -->
+    <script>
+        var REDIRECT_URI = 'http://localhost:8080/pkce-browser';
+        var CLIENT_ID = '42zjexze6mfpf7x';
+        var dbxAuth = new Dropbox.DropboxAuth({
+            clientId: CLIENT_ID,
+        });
+
+        // Parses the url and gets the access token if it is in the urls hash
+        function getCodeFromUrl() {
+            return utils.parseQueryString(window.location.search).code;
+        }
+
+        // If the user was just redirected from authenticating, the urls hash will
+        // contain the access token.
+        function hasRedirectedFromAuth() {
+            return !!getCodeFromUrl();
+        }
+
+        // Render a list of items to #files
+        function renderItems(items) {
+            var filesContainer = document.getElementById('files');
+            items.forEach(function(item) {
+                var li = document.createElement('li');
+                li.innerHTML = item.name;
+                filesContainer.appendChild(li);
+            });
+        }
+
+        // This example keeps both the authenticate and non-authenticated setions
+        // in the DOM and uses this function to show/hide the correct section.
+        function showPageSection(elementId) {
+            document.getElementById(elementId).style.display = 'block';
+        }
+
+        function doAuth() {
+            dbxAuth.getAuthenticationUrl(REDIRECT_URI, undefined, 'code', 'offline', undefined, undefined, true)
+                .then(authUrl => {
+                    window.sessionStorage.clear();
+                    window.sessionStorage.setItem("codeVerifier", dbxAuth.codeVerifier);
+                    window.location.href = authUrl;
+                })
+                .catch((error) => console.error(error));
+        };
+
+        if (hasRedirectedFromAuth()) {
+            showPageSection('authed-section');
+            dbxAuth.setPkceCodeVerifierAndGenerateChallenge(window.sessionStorage.getItem('codeVerifier'));
+            dbxAuth.getAccessTokenFromCode(REDIRECT_URI, getCodeFromUrl())
+                .then((response) => {
+                    dbxAuth.setAccessToken(response.result.access_token);
+                    var dbx = new Dropbox.Dropbox({
+                        auth: dbxAuth
+                    });
+                    return dbx.filesListFolder({
+                        path: ''
+                    });
+                })
+                .then((response) => {
+                    renderItems(response.result.entries);
+                })
+                .catch((error) => {
+                    console.error(error)
+                });
+        } else {
+            showPageSection('pre-auth-section');
+        }
+    </script>
+</body>
+
+</html>

--- a/examples/javascript/pkce-browser/index.html
+++ b/examples/javascript/pkce-browser/index.html
@@ -17,13 +17,14 @@
             <nav>
                 <a href="/">
                     <h1>
-                        <img src="https://cfl.dropboxstatic.com/static/images/brand/logotype_white-vflRG5Zd8.svg" class="logo" /> JavaScript SDK Examples
+                        <img src="https://cfl.dropboxstatic.com/static/images/brand/logotype_white-vflRG5Zd8.svg" class="logo" /> 
+                        JavaScript SDK Examples
                     </h1>
                 </a>
                 <a href="https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript" class="view-source">View Source</a>
             </nav>
             <h2 class="code">
-                <a href="/">examples</a> / PKCE Browser
+                <a href="/">examples</a> / PKCE browser
             </h2>
         </div>
     </header>
@@ -72,7 +73,7 @@
             });
         }
 
-        // This example keeps both the authenticate and non-authenticated setions
+        // This example keeps both the authenticated and non-authenticated setions
         // in the DOM and uses this function to show/hide the correct section.
         function showPageSection(elementId) {
             document.getElementById(elementId).style.display = 'block';

--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -120,6 +120,18 @@ export class DropboxAuth {
   getAccessTokenExpiresAt(): Date;
 
   /**
+    * Sets the code verifier for PKCE flow
+    * @param {String} codeVerifier - new code verifier 
+    */
+  setCodeVerifier(codeVerifier: string): void;
+
+  /**
+    * Gets the code verifier for PKCE flow
+    * @returns {String} - code verifier for PKCE
+    */
+  getCodeVerifier(): string;
+
+  /**
    * Checks if a token is needed, can be refreshed and if the token is expired.
    * If so, attempts to refresh access token
    * @returns {Promise<*>}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dropbox",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dropbox",
-  "version": "9.1.0",
+  "version": "9.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,110 +1,110 @@
 {
-  "name": "dropbox",
-  "version": "9.2.0",
-  "registry": "npm",
-  "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
-  "main": "cjs/index.js",
-  "browser": "dist/Dropbox-sdk.min.js",
-  "typings": "types/index",
-  "types": "types/index",
-  "module": "es/index.js",
-  "jsnext:main": "es/index.js",
-  "scripts": {
-    "build:es": "cross-env BABEL_ENV=es babel src -d es/src; cross-env BABEL_ENV=es babel lib -d es/lib; cross-env BABEL_ENV=es babel index.js -d es",
-    "build:cjs": "cross-env BABEL_ENV=commonjs babel src -d cjs/src; cross-env BABEL_ENV=commonjs babel lib -d cjs/lib; cross-env BABEL_ENV=commonjs babel index.js -d cjs",
-    "build:umd": "cross-env BABEL_ENV=es BUNDLE_TYPE=normal rollup -c -i index.js -o dist/Dropbox-sdk.js -n Dropbox",
-    "build:umd:min": "cross-env BABEL_ENV=es BUNDLE_TYPE=minified rollup -c -i index.js -o dist/Dropbox-sdk.min.js -n Dropbox",
-    "build": "npm run build:es && npm run build:cjs && npm run build:umd && npm run build:umd:min",
-    "lint": "eslint --ext .js,.jsx,.ts .",
-    "lint-fix": "eslint --fix --ext .js,.jsx,.ts .",
-    "test": "npm run test:typescript && npm run test:unit",
-    "test:typescript": "tsc --build test/types",
-    "test:integration": "mocha --timeout 10000 --require @babel/register test/integration/**/*.js",
-    "test:unit": "mocha --require @babel/register test/unit/**/*.js",
-    "test:build": "mocha --timeout 100000 --require @babel/register test/build/*.js",
-    "report": "nyc report --reporter=lcov --reporter=text",
-    "clean": "rm -rf dist es cjs",
-    "generate-docs": "jsdoc -c ./.jsdoc.json",
-    "coverage:unit": "cross-env BABEL_ENV=coverage nyc --reporter=lcov npm run test:unit",
-    "coverage:integration": "cross-env BABEL_ENV=coverage nyc --reporter=lcov npm run test:integration"
-  },
-  "files": [
-    "*.md",
-    "LICENSE",
-    "index.js",
-    "src",
-    "lib",
-    "types",
-    "dist",
-    "es",
-    "cjs"
-  ],
-  "keywords": [
-    "dropbox",
-    "files",
-    "sync",
-    "sdk",
-    "client"
-  ],
-  "homepage": "https://github.com/dropbox/dropbox-sdk-js#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dropbox/dropbox-sdk-js.git"
-  },
-  "bugs": {
-    "url": "https://github.com/dropbox/dropbox-sdk-js/issues"
-  },
-  "license": "MIT",
-  "directories": {
-    "example": "examples",
-    "test": "test"
-  },
-  "engines": {
-    "node": ">=0.10.3"
-  },
-  "contributors": [
-    "Brad Rogers <brad12rogers@gmail.com>",
-    "Andrew Lawson <alawson@dropbox.com>",
-    "James Sidhu <james.thomas.sidhu@gmail.com>",
-    "John Vilk <jvilk@cs.umass.edu>",
-    "Steve Klebanoff <steve.klebanoff@gmail.com>",
-    "Bohdan Tereta <Bohdan.Tereta@gmail.com>"
-  ],
-  "devDependencies": {
-    "@babel/cli": "^7.11.6",
-    "@babel/core": "^7.11.6",
-    "@babel/preset-env": "^7.11.5",
-    "@babel/register": "^7.11.5",
-    "@testing-library/dom": "^7.24.5",
-    "@types/node": "^14.11.2",
-    "@types/node-fetch": "^2.5.7",
-    "@typescript-eslint/eslint-plugin": "^4.0.0",
-    "@typescript-eslint/parser": "^3.10.1",
-    "babel-plugin-istanbul": "^6.0.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
-    "chai": "^4.2.0",
-    "chai-as-promised": "^7.1.1",
-    "cross-env": "^7.0.2",
-    "eslint": "^7.9.0",
-    "eslint-config-airbnb-base": "^14.2.0",
-    "eslint-plugin-import": "^2.22.0",
-    "express": "^4.17.1",
-    "express-urlrewrite": "^1.3.0",
-    "gh-pages": "^3.1.0",
-    "ink-docstrap": "^1.3.2",
-    "jsdoc": "^3.6.6",
-    "jsdom": "^16.4.0",
-    "mocha": "^8.1.3",
-    "nyc": "^15.1.0",
-    "prompt": "^1.0.0",
-    "rollup": "^2.28.2",
-    "rollup-endpoint": "^0.2.2",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-terser": "^7.0.2",
-    "sinon": "^9.0.3",
-    "typescript": "^4.0.3"
-  },
-  "dependencies": {
-    "node-fetch": "^2.6.1"
-  }
+    "name": "dropbox",
+    "version": "9.3.0",
+    "registry": "npm",
+    "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
+    "main": "cjs/index.js",
+    "browser": "dist/Dropbox-sdk.min.js",
+    "typings": "types/index",
+    "types": "types/index",
+    "module": "es/index.js",
+    "jsnext:main": "es/index.js",
+    "scripts": {
+        "build:es": "cross-env BABEL_ENV=es babel src -d es/src; cross-env BABEL_ENV=es babel lib -d es/lib; cross-env BABEL_ENV=es babel index.js -d es",
+        "build:cjs": "cross-env BABEL_ENV=commonjs babel src -d cjs/src; cross-env BABEL_ENV=commonjs babel lib -d cjs/lib; cross-env BABEL_ENV=commonjs babel index.js -d cjs",
+        "build:umd": "cross-env BABEL_ENV=es BUNDLE_TYPE=normal rollup -c -i index.js -o dist/Dropbox-sdk.js -n Dropbox",
+        "build:umd:min": "cross-env BABEL_ENV=es BUNDLE_TYPE=minified rollup -c -i index.js -o dist/Dropbox-sdk.min.js -n Dropbox",
+        "build": "npm run build:es && npm run build:cjs && npm run build:umd && npm run build:umd:min",
+        "lint": "eslint --ext .js,.jsx,.ts .",
+        "lint-fix": "eslint --fix --ext .js,.jsx,.ts .",
+        "test": "npm run test:typescript && npm run test:unit",
+        "test:typescript": "tsc --build test/types",
+        "test:integration": "mocha --timeout 10000 --require @babel/register test/integration/**/*.js",
+        "test:unit": "mocha --require @babel/register test/unit/**/*.js",
+        "test:build": "mocha --timeout 100000 --require @babel/register test/build/*.js",
+        "report": "nyc report --reporter=lcov --reporter=text",
+        "clean": "rm -rf dist es cjs",
+        "generate-docs": "jsdoc -c ./.jsdoc.json",
+        "coverage:unit": "cross-env BABEL_ENV=coverage nyc --reporter=lcov npm run test:unit",
+        "coverage:integration": "cross-env BABEL_ENV=coverage nyc --reporter=lcov npm run test:integration"
+    },
+    "files": [
+        "*.md",
+        "LICENSE",
+        "index.js",
+        "src",
+        "lib",
+        "types",
+        "dist",
+        "es",
+        "cjs"
+    ],
+    "keywords": [
+        "dropbox",
+        "files",
+        "sync",
+        "sdk",
+        "client"
+    ],
+    "homepage": "https://github.com/dropbox/dropbox-sdk-js#readme",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dropbox/dropbox-sdk-js.git"
+    },
+    "bugs": {
+        "url": "https://github.com/dropbox/dropbox-sdk-js/issues"
+    },
+    "license": "MIT",
+    "directories": {
+        "example": "examples",
+        "test": "test"
+    },
+    "engines": {
+        "node": ">=0.10.3"
+    },
+    "contributors": [
+        "Brad Rogers <brad12rogers@gmail.com>",
+        "Andrew Lawson <alawson@dropbox.com>",
+        "James Sidhu <james.thomas.sidhu@gmail.com>",
+        "John Vilk <jvilk@cs.umass.edu>",
+        "Steve Klebanoff <steve.klebanoff@gmail.com>",
+        "Bohdan Tereta <Bohdan.Tereta@gmail.com>"
+    ],
+    "devDependencies": {
+        "@babel/cli": "^7.11.6",
+        "@babel/core": "^7.11.6",
+        "@babel/preset-env": "^7.11.5",
+        "@babel/register": "^7.11.5",
+        "@testing-library/dom": "^7.24.5",
+        "@types/node": "^14.11.2",
+        "@types/node-fetch": "^2.5.7",
+        "@typescript-eslint/eslint-plugin": "^4.0.0",
+        "@typescript-eslint/parser": "^3.10.1",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+        "chai": "^4.2.0",
+        "chai-as-promised": "^7.1.1",
+        "cross-env": "^7.0.2",
+        "eslint": "^7.9.0",
+        "eslint-config-airbnb-base": "^14.2.0",
+        "eslint-plugin-import": "^2.22.0",
+        "express": "^4.17.1",
+        "express-urlrewrite": "^1.3.0",
+        "gh-pages": "^3.1.0",
+        "ink-docstrap": "^1.3.2",
+        "jsdoc": "^3.6.6",
+        "jsdom": "^16.4.0",
+        "mocha": "^8.1.3",
+        "nyc": "^15.1.0",
+        "prompt": "^1.0.0",
+        "rollup": "^2.28.2",
+        "rollup-endpoint": "^0.2.2",
+        "rollup-plugin-babel": "^4.4.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "sinon": "^9.0.3",
+        "typescript": "^4.0.3"
+    },
+    "dependencies": {
+        "node-fetch": "^2.6.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "9.3.0",
+    "version": "9.4.0",
     "registry": "npm",
     "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
     "main": "cjs/index.js",

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,29 +1,29 @@
 import {
-    getTokenExpiresAtDate,
-    isBrowserEnv,
-    createBrowserSafeString,
+  getTokenExpiresAtDate,
+  isBrowserEnv,
+  createBrowserSafeString,
 } from './utils.js';
 import { parseResponse } from './response.js';
 
 let fetch;
 if (isBrowserEnv()) {
-    fetch = window.fetch.bind(window);
+  fetch = window.fetch.bind(window);
 } else {
-    fetch = require('node-fetch'); // eslint-disable-line global-require
+  fetch = require('node-fetch'); // eslint-disable-line global-require
 }
 
 let crypto;
 if (isBrowserEnv()) {
-    crypto = window.crypto || window.msCrypto; // for IE11
+  crypto = window.crypto || window.msCrypto; // for IE11
 } else {
-    crypto = require('crypto'); // eslint-disable-line global-require
+  crypto = require('crypto'); // eslint-disable-line global-require
 }
 
 let Encoder;
 if (typeof TextEncoder === 'undefined') {
-    Encoder = require('util').TextEncoder; // eslint-disable-line global-require
+  Encoder = require('util').TextEncoder; // eslint-disable-line global-require
 } else {
-    Encoder = TextEncoder;
+  Encoder = TextEncoder;
 }
 
 // Expiration is 300 seconds but needs to be in milliseconds for Date object
@@ -34,7 +34,6 @@ const GrantTypes = ['code', 'token'];
 const IncludeGrantedScopes = ['none', 'user', 'team'];
 const BaseAuthorizeUrl = 'https://www.dropbox.com/oauth2/authorize';
 const BaseTokenUrl = 'https://api.dropboxapi.com/oauth2/token';
-const OAuthRedirectRecieverUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
 
 /**
  * @class DropboxAuth
@@ -52,151 +51,151 @@ const OAuthRedirectRecieverUrl = 'https://www.dropbox.com/1/oauth2/redirect_rece
  * authentication URL and refresh access tokens.
  */
 export default class DropboxAuth {
-    constructor(options) {
-        options = options || {};
+  constructor(options) {
+    options = options || {};
 
-        this.fetch = options.fetch || fetch;
-        this.accessToken = options.accessToken;
-        this.accessTokenExpiresAt = options.accessTokenExpiresAt;
-        this.refreshToken = options.refreshToken;
-        this.clientId = options.clientId;
-        this.clientSecret = options.clientSecret;
-    }
+    this.fetch = options.fetch || fetch;
+    this.accessToken = options.accessToken;
+    this.accessTokenExpiresAt = options.accessTokenExpiresAt;
+    this.refreshToken = options.refreshToken;
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+  }
 
-    /**
+  /**
      * Set the access token used to authenticate requests to the API.
      * @arg {String} accessToken - An access token
      * @returns {undefined}
      */
-    setAccessToken(accessToken) {
-        this.accessToken = accessToken;
-    }
+  setAccessToken(accessToken) {
+    this.accessToken = accessToken;
+  }
 
-    /**
+  /**
      * Get the access token
      * @returns {String} Access token
      */
-    getAccessToken() {
-        return this.accessToken;
-    }
+  getAccessToken() {
+    return this.accessToken;
+  }
 
-    /**
+  /**
      * Set the client id, which is used to help gain an access token.
      * @arg {String} clientId - Your apps client id
      * @returns {undefined}
      */
-    setClientId(clientId) {
-        this.clientId = clientId;
-    }
+  setClientId(clientId) {
+    this.clientId = clientId;
+  }
 
-    /**
+  /**
      * Get the client id
      * @returns {String} Client id
      */
-    getClientId() {
-        return this.clientId;
-    }
+  getClientId() {
+    return this.clientId;
+  }
 
-    /**
+  /**
      * Set the client secret
      * @arg {String} clientSecret - Your app's client secret
      * @returns {undefined}
      */
-    setClientSecret(clientSecret) {
-        this.clientSecret = clientSecret;
-    }
+  setClientSecret(clientSecret) {
+    this.clientSecret = clientSecret;
+  }
 
-    /**
+  /**
      * Get the client secret
      * @returns {String} Client secret
      */
-    getClientSecret() {
-        return this.clientSecret;
-    }
+  getClientSecret() {
+    return this.clientSecret;
+  }
 
-    /**
+  /**
      * Gets the refresh token
      * @returns {String} Refresh token
      */
-    getRefreshToken() {
-        return this.refreshToken;
-    }
+  getRefreshToken() {
+    return this.refreshToken;
+  }
 
-    /**
+  /**
      * Sets the refresh token
      * @param refreshToken - A refresh token
      */
-    setRefreshToken(refreshToken) {
-        this.refreshToken = refreshToken;
-    }
+  setRefreshToken(refreshToken) {
+    this.refreshToken = refreshToken;
+  }
 
-    /**
+  /**
      * Gets the access token's expiration date
      * @returns {Date} date of token expiration
      */
-    getAccessTokenExpiresAt() {
-        return this.accessTokenExpiresAt;
-    }
+  getAccessTokenExpiresAt() {
+    return this.accessTokenExpiresAt;
+  }
 
-    /**
+  /**
      * Sets the access token's expiration date
      * @param accessTokenExpiresAt - new expiration date
      */
-    setAccessTokenExpiresAt(accessTokenExpiresAt) {
-        this.accessTokenExpiresAt = accessTokenExpiresAt;
-    }
+  setAccessTokenExpiresAt(accessTokenExpiresAt) {
+    this.accessTokenExpiresAt = accessTokenExpiresAt;
+  }
 
-    /**
+  /**
      * Sets the code verifier for PKCE flow
-     * @param {String} codeVerifier - new code verifier 
+     * @param {String} codeVerifier - new code verifier
      */
-    setCodeVerifier(codeVerifier) {
-        this.codeVerifier = codeVerifier;
-    }
+  setCodeVerifier(codeVerifier) {
+    this.codeVerifier = codeVerifier;
+  }
 
-    /**
+  /**
      * Gets the code verifier for PKCE flow
      * @returns {String} - code verifier for PKCE
      */
-    getCodeVerifier() {
-        return this.codeVerifier;
+  getCodeVerifier() {
+    return this.codeVerifier;
+  }
+
+  generateCodeChallenge() {
+    const encoder = new Encoder();
+    const codeData = encoder.encode(this.codeVerifier);
+    let codeChallenge;
+    if (isBrowserEnv()) {
+      return crypto.subtle.digest('SHA-256', codeData)
+        .then((digestedHash) => {
+          const b64ed = btoa(String.fromCharCode.apply(null, new Uint8Array(digestedHash)));
+          codeChallenge = createBrowserSafeString(b64ed).substr(0, 128);
+          this.codeChallenge = codeChallenge;
+        });
     }
+    const digestedHash = crypto.createHash('sha256').update(codeData).digest();
+    codeChallenge = createBrowserSafeString(digestedHash);
+    this.codeChallenge = codeChallenge;
+    return Promise.resolve();
+  }
 
-    generateCodeChallenge() {
-        const encoder = new Encoder();
-        const codeData = encoder.encode(this.codeVerifier);
-        let codeChallenge;
-        if (isBrowserEnv()) {
-            return crypto.subtle.digest('SHA-256', codeData)
-                .then((digestedHash) => {
-                    const b64ed = btoa(String.fromCharCode.apply(null, new Uint8Array(digestedHash)))
-                    codeChallenge = createBrowserSafeString(b64ed).substr(0, 128);
-                    this.codeChallenge = codeChallenge;
-                });
-        }
-        const digestedHash = crypto.createHash('sha256').update(codeData).digest();
-        codeChallenge = createBrowserSafeString(digestedHash);
-        this.codeChallenge = codeChallenge;
-        return Promise.resolve();
+  generatePKCECodes() {
+    let codeVerifier;
+    if (isBrowserEnv()) {
+      const array = new Uint8Array(PKCELength);
+      const randomValueArray = crypto.getRandomValues(array);
+      const base64String = btoa(randomValueArray);
+      codeVerifier = createBrowserSafeString(base64String).substr(0, 128);
+    } else {
+      const randomBytes = crypto.randomBytes(PKCELength);
+      codeVerifier = createBrowserSafeString(randomBytes).substr(0, 128);
     }
+    this.codeVerifier = codeVerifier;
 
-    generatePKCECodes() {
-        let codeVerifier;
-        if (isBrowserEnv()) {
-            const array = new Uint8Array(PKCELength);
-            const randomValueArray = crypto.getRandomValues(array);
-            const base64String = btoa(randomValueArray);
-            codeVerifier = createBrowserSafeString(base64String).substr(0, 128);
-        } else {
-            const randomBytes = crypto.randomBytes(PKCELength);
-            codeVerifier = createBrowserSafeString(randomBytes).substr(0, 128);
-        }
-        this.codeVerifier = codeVerifier;
+    return this.generateCodeChallenge();
+  }
 
-        return this.generateCodeChallenge();
-    }
-
-    /**
+  /**
      * Get a URL that can be used to authenticate users for the Dropbox API.
      * @arg {String} redirectUri - A URL to redirect the user to after
      * authenticating. This must be added to your app through the admin interface.
@@ -214,224 +213,224 @@ export default class DropboxAuth {
      * user - include user scopes in the grant
      * team - include team scopes in the grant
      * Note: if this user has never linked the app, include_granted_scopes must be None
-     * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use on
-     * client apps which doesn't call your server. It is less secure than non-PKCE flow but
+     * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use
+     * on client apps which doesn't call your server. It is less secure than non-PKCE flow but
      * can be used if you are unable to safely retrieve your app secret
      * @returns {Promise<String>} - Url to send user to for Dropbox API authentication
      * returned in a promise
      */
-    getAuthenticationUrl(redirectUri, state, authType = 'token', tokenAccessType = null, scope = null, includeGrantedScopes = 'none', usePKCE = false) {
-        const clientId = this.getClientId();
-        const baseUrl = BaseAuthorizeUrl;
+  getAuthenticationUrl(redirectUri, state, authType = 'token', tokenAccessType = null, scope = null, includeGrantedScopes = 'none', usePKCE = false) {
+    const clientId = this.getClientId();
+    const baseUrl = BaseAuthorizeUrl;
 
-        if (!clientId) {
-            throw new Error('A client id is required. You can set the client id using .setClientId().');
-        }
-        if (authType !== 'code' && !redirectUri) {
-            throw new Error('A redirect uri is required.');
-        }
-        if (!GrantTypes.includes(authType)) {
-            throw new Error('Authorization type must be code or token');
-        }
-        if (tokenAccessType && !TokenAccessTypes.includes(tokenAccessType)) {
-            throw new Error('Token Access Type must be legacy, offline, or online');
-        }
-        if (scope && !(scope instanceof Array)) {
-            throw new Error('Scope must be an array of strings');
-        }
-        if (!IncludeGrantedScopes.includes(includeGrantedScopes)) {
-            throw new Error('includeGrantedScopes must be none, user, or team');
-        }
-
-        let authUrl;
-        if (authType === 'code') {
-            authUrl = `${baseUrl}?response_type=code&client_id=${clientId}`;
-        } else {
-            authUrl = `${baseUrl}?response_type=token&client_id=${clientId}`;
-        }
-
-        if (redirectUri) {
-            authUrl += `&redirect_uri=${redirectUri}`;
-        }
-        if (state) {
-            authUrl += `&state=${state}`;
-        }
-        if (tokenAccessType) {
-            authUrl += `&token_access_type=${tokenAccessType}`;
-        }
-        if (scope) {
-            authUrl += `&scope=${scope.join(' ')}`;
-        }
-        if (includeGrantedScopes !== 'none') {
-            authUrl += `&include_granted_scopes=${includeGrantedScopes}`;
-        }
-        if (usePKCE) {
-            return this.generatePKCECodes()
-                .then(() => {
-                    authUrl += '&code_challenge_method=S256';
-                    authUrl += `&code_challenge=${this.codeChallenge}`;
-                    return authUrl;
-                });
-        }
-        return Promise.resolve(authUrl);
+    if (!clientId) {
+      throw new Error('A client id is required. You can set the client id using .setClientId().');
+    }
+    if (authType !== 'code' && !redirectUri) {
+      throw new Error('A redirect uri is required.');
+    }
+    if (!GrantTypes.includes(authType)) {
+      throw new Error('Authorization type must be code or token');
+    }
+    if (tokenAccessType && !TokenAccessTypes.includes(tokenAccessType)) {
+      throw new Error('Token Access Type must be legacy, offline, or online');
+    }
+    if (scope && !(scope instanceof Array)) {
+      throw new Error('Scope must be an array of strings');
+    }
+    if (!IncludeGrantedScopes.includes(includeGrantedScopes)) {
+      throw new Error('includeGrantedScopes must be none, user, or team');
     }
 
-    /**
+    let authUrl;
+    if (authType === 'code') {
+      authUrl = `${baseUrl}?response_type=code&client_id=${clientId}`;
+    } else {
+      authUrl = `${baseUrl}?response_type=token&client_id=${clientId}`;
+    }
+
+    if (redirectUri) {
+      authUrl += `&redirect_uri=${redirectUri}`;
+    }
+    if (state) {
+      authUrl += `&state=${state}`;
+    }
+    if (tokenAccessType) {
+      authUrl += `&token_access_type=${tokenAccessType}`;
+    }
+    if (scope) {
+      authUrl += `&scope=${scope.join(' ')}`;
+    }
+    if (includeGrantedScopes !== 'none') {
+      authUrl += `&include_granted_scopes=${includeGrantedScopes}`;
+    }
+    if (usePKCE) {
+      return this.generatePKCECodes()
+        .then(() => {
+          authUrl += '&code_challenge_method=S256';
+          authUrl += `&code_challenge=${this.codeChallenge}`;
+          return authUrl;
+        });
+    }
+    return Promise.resolve(authUrl);
+  }
+
+  /**
      * Get an OAuth2 access token from an OAuth2 Code.
      * @arg {String} redirectUri - A URL to redirect the user to after
      * authenticating. This must be added to your app through the admin interface.
      * @arg {String} code - An OAuth2 code.
      * @returns {Object} An object containing the token and related info (if applicable)
      */
-    getAccessTokenFromCode(redirectUri, code) {
-        const clientId = this.getClientId();
-        const clientSecret = this.getClientSecret();
+  getAccessTokenFromCode(redirectUri, code) {
+    const clientId = this.getClientId();
+    const clientSecret = this.getClientSecret();
 
-        if (!clientId) {
-            throw new Error('A client id is required. You can set the client id using .setClientId().');
-        }
-        let path = BaseTokenUrl;
-        path += '?grant_type=authorization_code';
-        path += `&code=${code}`;
-        path += `&client_id=${clientId}`;
+    if (!clientId) {
+      throw new Error('A client id is required. You can set the client id using .setClientId().');
+    }
+    let path = BaseTokenUrl;
+    path += '?grant_type=authorization_code';
+    path += `&code=${code}`;
+    path += `&client_id=${clientId}`;
 
-        if (clientSecret) {
-            path += `&client_secret=${clientSecret}`;
-        } else {
-            if (!this.codeVerifier) {
-                throw new Error('You must use PKCE when generating the authorization URL to not include a client secret');
-            }
-            path += `&code_verifier=${this.codeVerifier}`;
-        }
-        if (redirectUri) {
-            path += `&redirect_uri=${redirectUri}`;
-        }
-
-        const fetchOptions = {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-        };
-        return this.fetch(path, fetchOptions)
-            .then((res) => parseResponse(res));
+    if (clientSecret) {
+      path += `&client_secret=${clientSecret}`;
+    } else {
+      if (!this.codeVerifier) {
+        throw new Error('You must use PKCE when generating the authorization URL to not include a client secret');
+      }
+      path += `&code_verifier=${this.codeVerifier}`;
+    }
+    if (redirectUri) {
+      path += `&redirect_uri=${redirectUri}`;
     }
 
-    /**
+    const fetchOptions = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    };
+    return this.fetch(path, fetchOptions)
+      .then((res) => parseResponse(res));
+  }
+
+  /**
      * Checks if a token is needed, can be refreshed and if the token is expired.
      * If so, attempts to refresh access token
      * @returns {Promise<*>}
      */
-    checkAndRefreshAccessToken() {
-        const canRefresh = this.getRefreshToken() && this.getClientId();
-        const needsRefresh = !this.getAccessTokenExpiresAt() ||
-            (new Date(Date.now() + TokenExpirationBuffer)) >= this.getAccessTokenExpiresAt();
-        const needsToken = !this.getAccessToken();
-        if ((needsRefresh || needsToken) && canRefresh) {
-            return this.refreshAccessToken();
-        }
-        return Promise.resolve();
+  checkAndRefreshAccessToken() {
+    const canRefresh = this.getRefreshToken() && this.getClientId();
+    const needsRefresh = !this.getAccessTokenExpiresAt()
+            || (new Date(Date.now() + TokenExpirationBuffer)) >= this.getAccessTokenExpiresAt();
+    const needsToken = !this.getAccessToken();
+    if ((needsRefresh || needsToken) && canRefresh) {
+      return this.refreshAccessToken();
     }
+    return Promise.resolve();
+  }
 
-    /**
+  /**
      * Refreshes the access token using the refresh token, if available
      * @arg {Array<String>} scope - a subset of scopes from the original
      * refresh to acquire with an access token
      * @returns {Promise<*>}
      */
-    refreshAccessToken(scope = null) {
-        let refreshUrl = BaseTokenUrl;
-        const clientId = this.getClientId();
-        const clientSecret = this.getClientSecret();
+  refreshAccessToken(scope = null) {
+    let refreshUrl = BaseTokenUrl;
+    const clientId = this.getClientId();
+    const clientSecret = this.getClientSecret();
 
-        if (!clientId) {
-            throw new Error('A client id is required. You can set the client id using .setClientId().');
-        }
-        if (scope && !(scope instanceof Array)) {
-            throw new Error('Scope must be an array of strings');
-        }
-
-        const headers = {};
-        headers['Content-Type'] = 'application/json';
-        refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
-        refreshUrl += `&client_id=${clientId}`;
-        if (clientSecret) {
-            refreshUrl += `&client_secret=${clientSecret}`;
-        }
-        if (scope) {
-            refreshUrl += `&scope=${scope.join(' ')}`;
-        }
-        const fetchOptions = {
-            method: 'POST',
-        };
-
-        fetchOptions.headers = headers;
-
-        return this.fetch(refreshUrl, fetchOptions)
-            .then((res) => parseResponse(res))
-            .then((res) => {
-                this.setAccessToken(res.result.access_token);
-                this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.result.expires_in));
-            });
+    if (!clientId) {
+      throw new Error('A client id is required. You can set the client id using .setClientId().');
+    }
+    if (scope && !(scope instanceof Array)) {
+      throw new Error('Scope must be an array of strings');
     }
 
-    /**
+    const headers = {};
+    headers['Content-Type'] = 'application/json';
+    refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
+    refreshUrl += `&client_id=${clientId}`;
+    if (clientSecret) {
+      refreshUrl += `&client_secret=${clientSecret}`;
+    }
+    if (scope) {
+      refreshUrl += `&scope=${scope.join(' ')}`;
+    }
+    const fetchOptions = {
+      method: 'POST',
+    };
+
+    fetchOptions.headers = headers;
+
+    return this.fetch(refreshUrl, fetchOptions)
+      .then((res) => parseResponse(res))
+      .then((res) => {
+        this.setAccessToken(res.result.access_token);
+        this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.result.expires_in));
+      });
+  }
+
+  /**
      * An authentication process that works with cordova applications.
      * @param {successCallback} successCallback
      * @param {errorCallback} errorCallback
      */
-    authenticateWithCordova(successCallback, errorCallback) {
-        const redirectUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
-        this.getAuthenticationUrl(redirectUrl)
-            .then((url) => {
-                let removed = false;
-                const browser = window.open(url, '_blank');
+  authenticateWithCordova(successCallback, errorCallback) {
+    const redirectUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
+    this.getAuthenticationUrl(redirectUrl)
+      .then((url) => {
+        let removed = false;
+        const browser = window.open(url, '_blank');
 
-                function onLoadError(event) {
-                    // Workaround to fix wrong behavior on cordova-plugin-inappbrowser
-                    if (event.code !== -999) {
-                        // Try to avoid a browser crash on browser.close().
-                        window.setTimeout(() => { browser.close(); }, 10);
-                        errorCallback();
-                    }
-                }
+        function onLoadError(event) {
+          // Workaround to fix wrong behavior on cordova-plugin-inappbrowser
+          if (event.code !== -999) {
+            // Try to avoid a browser crash on browser.close().
+            window.setTimeout(() => { browser.close(); }, 10);
+            errorCallback();
+          }
+        }
 
-                function onLoadStop(event) {
-                    const errorLabel = '&error=';
-                    const errorIndex = event.url.indexOf(errorLabel);
+        function onLoadStop(event) {
+          const errorLabel = '&error=';
+          const errorIndex = event.url.indexOf(errorLabel);
 
-                    if (errorIndex > -1) {
-                        // Try to avoid a browser crash on browser.close().
-                        window.setTimeout(() => { browser.close(); }, 10);
-                        errorCallback();
-                    } else {
-                        const tokenLabel = '#access_token=';
-                        let tokenIndex = event.url.indexOf(tokenLabel);
-                        const tokenTypeIndex = event.url.indexOf('&token_type=');
-                        if (tokenIndex > -1) {
-                            tokenIndex += tokenLabel.length;
-                            // Try to avoid a browser crash on browser.close().
-                            window.setTimeout(() => { browser.close(); }, 10);
+          if (errorIndex > -1) {
+            // Try to avoid a browser crash on browser.close().
+            window.setTimeout(() => { browser.close(); }, 10);
+            errorCallback();
+          } else {
+            const tokenLabel = '#access_token=';
+            let tokenIndex = event.url.indexOf(tokenLabel);
+            const tokenTypeIndex = event.url.indexOf('&token_type=');
+            if (tokenIndex > -1) {
+              tokenIndex += tokenLabel.length;
+              // Try to avoid a browser crash on browser.close().
+              window.setTimeout(() => { browser.close(); }, 10);
 
-                            const accessToken = event.url.substring(tokenIndex, tokenTypeIndex);
-                            successCallback(accessToken);
-                        }
-                    }
-                }
+              const accessToken = event.url.substring(tokenIndex, tokenTypeIndex);
+              successCallback(accessToken);
+            }
+          }
+        }
 
-                function onExit() {
-                    if (removed) {
-                        return;
-                    }
-                    browser.removeEventListener('loaderror', onLoadError);
-                    browser.removeEventListener('loadstop', onLoadStop);
-                    browser.removeEventListener('exit', onExit);
-                    removed = true;
-                }
+        function onExit() {
+          if (removed) {
+            return;
+          }
+          browser.removeEventListener('loaderror', onLoadError);
+          browser.removeEventListener('loadstop', onLoadStop);
+          browser.removeEventListener('exit', onExit);
+          removed = true;
+        }
 
-                browser.addEventListener('loaderror', onLoadError);
-                browser.addEventListener('loadstop', onLoadStop);
-                browser.addEventListener('exit', onExit);
-            });
-    }
+        browser.addEventListener('loaderror', onLoadError);
+        browser.addEventListener('loadstop', onLoadStop);
+        browser.addEventListener('exit', onExit);
+      });
+  }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -168,8 +168,8 @@ export default class DropboxAuth {
     if (isBrowserEnv()) {
       return crypto.subtle.digest('SHA-256', codeData)
         .then((digestedHash) => {
-          const b64ed = btoa(String.fromCharCode.apply(null, new Uint8Array(digestedHash)));
-          codeChallenge = createBrowserSafeString(b64ed).substr(0, 128);
+          const base64String = btoa(String.fromCharCode.apply(null, new Uint8Array(digestedHash)));
+          codeChallenge = createBrowserSafeString(base64String).substr(0, 128);
           this.codeChallenge = codeChallenge;
         });
     }

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,29 +1,29 @@
 import {
-  getTokenExpiresAtDate,
-  isBrowserEnv,
-  createBrowserSafeString,
+    getTokenExpiresAtDate,
+    isBrowserEnv,
+    createBrowserSafeString,
 } from './utils.js';
 import { parseResponse } from './response.js';
 
 let fetch;
 if (isBrowserEnv()) {
-  fetch = window.fetch.bind(window);
+    fetch = window.fetch.bind(window);
 } else {
-  fetch = require('node-fetch'); // eslint-disable-line global-require
+    fetch = require('node-fetch'); // eslint-disable-line global-require
 }
 
 let crypto;
 if (isBrowserEnv()) {
-  crypto = window.crypto || window.msCrypto; // for IE11
+    crypto = window.crypto || window.msCrypto; // for IE11
 } else {
-  crypto = require('crypto'); // eslint-disable-line global-require
+    crypto = require('crypto'); // eslint-disable-line global-require
 }
 
 let Encoder;
 if (typeof TextEncoder === 'undefined') {
-  Encoder = require('util').TextEncoder; // eslint-disable-line global-require
+    Encoder = require('util').TextEncoder; // eslint-disable-line global-require
 } else {
-  Encoder = TextEncoder;
+    Encoder = TextEncoder;
 }
 
 // Expiration is 300 seconds but needs to be in milliseconds for Date object
@@ -34,6 +34,7 @@ const GrantTypes = ['code', 'token'];
 const IncludeGrantedScopes = ['none', 'user', 'team'];
 const BaseAuthorizeUrl = 'https://www.dropbox.com/oauth2/authorize';
 const BaseTokenUrl = 'https://api.dropboxapi.com/oauth2/token';
+const OAuthRedirectRecieverUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
 
 /**
  * @class DropboxAuth
@@ -51,367 +52,386 @@ const BaseTokenUrl = 'https://api.dropboxapi.com/oauth2/token';
  * authentication URL and refresh access tokens.
  */
 export default class DropboxAuth {
-  constructor(options) {
-    options = options || {};
+    constructor(options) {
+        options = options || {};
 
-    this.fetch = options.fetch || fetch;
-    this.accessToken = options.accessToken;
-    this.accessTokenExpiresAt = options.accessTokenExpiresAt;
-    this.refreshToken = options.refreshToken;
-    this.clientId = options.clientId;
-    this.clientSecret = options.clientSecret;
-  }
-
-  /**
-   * Set the access token used to authenticate requests to the API.
-   * @arg {String} accessToken - An access token
-   * @returns {undefined}
-   */
-  setAccessToken(accessToken) {
-    this.accessToken = accessToken;
-  }
-
-  /**
-   * Get the access token
-   * @returns {String} Access token
-   */
-  getAccessToken() {
-    return this.accessToken;
-  }
-
-  /**
-   * Set the client id, which is used to help gain an access token.
-   * @arg {String} clientId - Your apps client id
-   * @returns {undefined}
-   */
-  setClientId(clientId) {
-    this.clientId = clientId;
-  }
-
-  /**
-   * Get the client id
-   * @returns {String} Client id
-   */
-  getClientId() {
-    return this.clientId;
-  }
-
-  /**
-   * Set the client secret
-   * @arg {String} clientSecret - Your app's client secret
-   * @returns {undefined}
-   */
-  setClientSecret(clientSecret) {
-    this.clientSecret = clientSecret;
-  }
-
-  /**
-   * Get the client secret
-   * @returns {String} Client secret
-   */
-  getClientSecret() {
-    return this.clientSecret;
-  }
-
-  /**
-   * Gets the refresh token
-   * @returns {String} Refresh token
-   */
-  getRefreshToken() {
-    return this.refreshToken;
-  }
-
-  /**
-   * Sets the refresh token
-   * @param refreshToken - A refresh token
-   */
-  setRefreshToken(refreshToken) {
-    this.refreshToken = refreshToken;
-  }
-
-  /**
-   * Gets the access token's expiration date
-   * @returns {Date} date of token expiration
-   */
-  getAccessTokenExpiresAt() {
-    return this.accessTokenExpiresAt;
-  }
-
-  /**
-   * Sets the access token's expiration date
-   * @param accessTokenExpiresAt - new expiration date
-   */
-  setAccessTokenExpiresAt(accessTokenExpiresAt) {
-    this.accessTokenExpiresAt = accessTokenExpiresAt;
-  }
-
-  generatePKCECodes() {
-    let codeVerifier;
-    if (isBrowserEnv()) {
-      const array = new Uint8Array(PKCELength);
-      const randomValueArray = crypto.getRandomValues(array);
-      const base64String = btoa(randomValueArray);
-      codeVerifier = createBrowserSafeString(base64String).substr(0, 128);
-    } else {
-      const randomBytes = crypto.randomBytes(PKCELength);
-      codeVerifier = createBrowserSafeString(randomBytes).substr(0, 128);
-    }
-    this.codeVerifier = codeVerifier;
-
-    const encoder = new Encoder();
-    const codeData = encoder.encode(codeVerifier);
-    let codeChallenge;
-    if (isBrowserEnv()) {
-      return crypto.subtle.digest('SHA-256', codeData)
-        .then((digestedHash) => {
-          const typedArray = new Uint8Array(digestedHash);
-          const base64String = btoa(typedArray);
-          codeChallenge = createBrowserSafeString(base64String).substr(0, 128);
-          this.codeChallenge = codeChallenge;
-        });
-    }
-    const digestedHash = crypto.createHash('sha256').update(codeData).digest();
-    codeChallenge = createBrowserSafeString(digestedHash);
-    this.codeChallenge = codeChallenge;
-    return Promise.resolve();
-  }
-
-  /**
-   * Get a URL that can be used to authenticate users for the Dropbox API.
-   * @arg {String} redirectUri - A URL to redirect the user to after
-   * authenticating. This must be added to your app through the admin interface.
-   * @arg {String} [state] - State that will be returned in the redirect URL to help
-   * prevent cross site scripting attacks.
-   * @arg {String} [authType] - auth type, defaults to 'token', other option is 'code'
-   * @arg {String} [tokenAccessType] - type of token to request.  From the following:
-   * null - creates a token with the app default (either legacy or online)
-   * legacy - creates one long-lived token with no expiration
-   * online - create one short-lived token with an expiration
-   * offline - create one short-lived token with an expiration with a refresh token
-   * @arg {Array<String>} [scope] - scopes to request for the grant
-   * @arg {String} [includeGrantedScopes] - whether or not to include previously granted scopes.
-   * From the following:
-   * user - include user scopes in the grant
-   * team - include team scopes in the grant
-   * Note: if this user has never linked the app, include_granted_scopes must be None
-   * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use on
-   * client apps which doesn't call your server. It is less secure than non-PKCE flow but
-   * can be used if you are unable to safely retrieve your app secret
-   * @returns {Promise<String>} - Url to send user to for Dropbox API authentication
-   * returned in a promise
-   */
-  getAuthenticationUrl(redirectUri, state, authType = 'token', tokenAccessType = null, scope = null, includeGrantedScopes = 'none', usePKCE = false) {
-    const clientId = this.getClientId();
-    const baseUrl = BaseAuthorizeUrl;
-
-    if (!clientId) {
-      throw new Error('A client id is required. You can set the client id using .setClientId().');
-    }
-    if (authType !== 'code' && !redirectUri) {
-      throw new Error('A redirect uri is required.');
-    }
-    if (!GrantTypes.includes(authType)) {
-      throw new Error('Authorization type must be code or token');
-    }
-    if (tokenAccessType && !TokenAccessTypes.includes(tokenAccessType)) {
-      throw new Error('Token Access Type must be legacy, offline, or online');
-    }
-    if (scope && !(scope instanceof Array)) {
-      throw new Error('Scope must be an array of strings');
-    }
-    if (!IncludeGrantedScopes.includes(includeGrantedScopes)) {
-      throw new Error('includeGrantedScopes must be none, user, or team');
+        this.fetch = options.fetch || fetch;
+        this.accessToken = options.accessToken;
+        this.accessTokenExpiresAt = options.accessTokenExpiresAt;
+        this.refreshToken = options.refreshToken;
+        this.clientId = options.clientId;
+        this.clientSecret = options.clientSecret;
     }
 
-    let authUrl;
-    if (authType === 'code') {
-      authUrl = `${baseUrl}?response_type=code&client_id=${clientId}`;
-    } else {
-      authUrl = `${baseUrl}?response_type=token&client_id=${clientId}`;
+    /**
+     * Set the access token used to authenticate requests to the API.
+     * @arg {String} accessToken - An access token
+     * @returns {undefined}
+     */
+    setAccessToken(accessToken) {
+        this.accessToken = accessToken;
     }
 
-    if (redirectUri) {
-      authUrl += `&redirect_uri=${redirectUri}`;
-    }
-    if (state) {
-      authUrl += `&state=${state}`;
-    }
-    if (tokenAccessType) {
-      authUrl += `&token_access_type=${tokenAccessType}`;
-    }
-    if (scope) {
-      authUrl += `&scope=${scope.join(' ')}`;
-    }
-    if (includeGrantedScopes !== 'none') {
-      authUrl += `&include_granted_scopes=${includeGrantedScopes}`;
-    }
-    if (usePKCE) {
-      return this.generatePKCECodes()
-        .then(() => {
-          authUrl += '&code_challenge_method=S256';
-          authUrl += `&code_challenge=${this.codeChallenge}`;
-          return authUrl;
-        });
-    }
-    return Promise.resolve(authUrl);
-  }
-
-  /**
-   * Get an OAuth2 access token from an OAuth2 Code.
-   * @arg {String} redirectUri - A URL to redirect the user to after
-   * authenticating. This must be added to your app through the admin interface.
-   * @arg {String} code - An OAuth2 code.
-   * @returns {Object} An object containing the token and related info (if applicable)
-  */
-  getAccessTokenFromCode(redirectUri, code) {
-    const clientId = this.getClientId();
-    const clientSecret = this.getClientSecret();
-
-    if (!clientId) {
-      throw new Error('A client id is required. You can set the client id using .setClientId().');
-    }
-    let path = BaseTokenUrl;
-    path += '?grant_type=authorization_code';
-    path += `&code=${code}`;
-    path += `&client_id=${clientId}`;
-
-    if (clientSecret) {
-      path += `&client_secret=${clientSecret}`;
-    } else {
-      if (!this.codeChallenge) {
-        throw new Error('You must use PKCE when generating the authorization URL to not include a client secret');
-      }
-      path += `&code_verifier=${this.codeVerifier}`;
-    }
-    if (redirectUri) {
-      path += `&redirect_uri=${redirectUri}`;
+    /**
+     * Get the access token
+     * @returns {String} Access token
+     */
+    getAccessToken() {
+        return this.accessToken;
     }
 
-    const fetchOptions = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-    };
-    return this.fetch(path, fetchOptions)
-      .then((res) => parseResponse(res));
-  }
-
-  /**
-   * Checks if a token is needed, can be refreshed and if the token is expired.
-   * If so, attempts to refresh access token
-   * @returns {Promise<*>}
-   */
-  checkAndRefreshAccessToken() {
-    const canRefresh = this.getRefreshToken() && this.getClientId();
-    const needsRefresh = !this.getAccessTokenExpiresAt()
-      || (new Date(Date.now() + TokenExpirationBuffer)) >= this.getAccessTokenExpiresAt();
-    const needsToken = !this.getAccessToken();
-    if ((needsRefresh || needsToken) && canRefresh) {
-      return this.refreshAccessToken();
-    }
-    return Promise.resolve();
-  }
-
-  /**
-   * Refreshes the access token using the refresh token, if available
-   * @arg {Array<String>} scope - a subset of scopes from the original
-   * refresh to acquire with an access token
-   * @returns {Promise<*>}
-   */
-  refreshAccessToken(scope = null) {
-    let refreshUrl = BaseTokenUrl;
-    const clientId = this.getClientId();
-    const clientSecret = this.getClientSecret();
-
-    if (!clientId) {
-      throw new Error('A client id is required. You can set the client id using .setClientId().');
-    }
-    if (scope && !(scope instanceof Array)) {
-      throw new Error('Scope must be an array of strings');
+    /**
+     * Set the client id, which is used to help gain an access token.
+     * @arg {String} clientId - Your apps client id
+     * @returns {undefined}
+     */
+    setClientId(clientId) {
+        this.clientId = clientId;
     }
 
-    const headers = {};
-    headers['Content-Type'] = 'application/json';
-    refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
-    refreshUrl += `&client_id=${clientId}`;
-    if (clientSecret) {
-      refreshUrl += `&client_secret=${clientSecret}`;
+    /**
+     * Get the client id
+     * @returns {String} Client id
+     */
+    getClientId() {
+        return this.clientId;
     }
-    if (scope) {
-      refreshUrl += `&scope=${scope.join(' ')}`;
+
+    /**
+     * Set the client secret
+     * @arg {String} clientSecret - Your app's client secret
+     * @returns {undefined}
+     */
+    setClientSecret(clientSecret) {
+        this.clientSecret = clientSecret;
     }
-    const fetchOptions = {
-      method: 'POST',
-    };
 
-    fetchOptions.headers = headers;
+    /**
+     * Get the client secret
+     * @returns {String} Client secret
+     */
+    getClientSecret() {
+        return this.clientSecret;
+    }
 
-    return this.fetch(refreshUrl, fetchOptions)
-      .then((res) => parseResponse(res))
-      .then((res) => {
-        this.setAccessToken(res.result.access_token);
-        this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.result.expires_in));
-      });
-  }
+    /**
+     * Gets the refresh token
+     * @returns {String} Refresh token
+     */
+    getRefreshToken() {
+        return this.refreshToken;
+    }
 
-  /**
-   * An authentication process that works with cordova applications.
-   * @param {successCallback} successCallback
-   * @param {errorCallback} errorCallback
-   */
-  authenticateWithCordova(successCallback, errorCallback) {
-    const redirectUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
-    this.getAuthenticationUrl(redirectUrl)
-      .then((url) => {
-        let removed = false;
-        const browser = window.open(url, '_blank');
+    /**
+     * Sets the refresh token
+     * @param refreshToken - A refresh token
+     */
+    setRefreshToken(refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 
-        function onLoadError(event) {
-          // Workaround to fix wrong behavior on cordova-plugin-inappbrowser
-          if (event.code !== -999) {
-            // Try to avoid a browser crash on browser.close().
-            window.setTimeout(() => { browser.close(); }, 10);
-            errorCallback();
-          }
+    /**
+     * Gets the access token's expiration date
+     * @returns {Date} date of token expiration
+     */
+    getAccessTokenExpiresAt() {
+        return this.accessTokenExpiresAt;
+    }
+
+    /**
+     * Sets the access token's expiration date
+     * @param accessTokenExpiresAt - new expiration date
+     */
+    setAccessTokenExpiresAt(accessTokenExpiresAt) {
+        this.accessTokenExpiresAt = accessTokenExpiresAt;
+    }
+
+    /**
+     * Sets the code verifier for PKCE flow
+     * @param {String} codeVerifier - new code verifier 
+     */
+    setCodeVerifier(codeVerifier) {
+        this.codeVerifier = codeVerifier;
+    }
+
+    /**
+     * Gets the code verifier for PKCE flow
+     * @returns {String} - code verifier for PKCE
+     */
+    getCodeVerifier() {
+        return this.codeVerifier;
+    }
+
+    generateCodeChallenge() {
+        const encoder = new Encoder();
+        const codeData = encoder.encode(this.codeVerifier);
+        let codeChallenge;
+        if (isBrowserEnv()) {
+            return crypto.subtle.digest('SHA-256', codeData)
+                .then((digestedHash) => {
+                    const b64ed = btoa(String.fromCharCode.apply(null, new Uint8Array(digestedHash)))
+                    codeChallenge = createBrowserSafeString(b64ed).substr(0, 128);
+                    this.codeChallenge = codeChallenge;
+                });
+        }
+        const digestedHash = crypto.createHash('sha256').update(codeData).digest();
+        codeChallenge = createBrowserSafeString(digestedHash);
+        this.codeChallenge = codeChallenge;
+        return Promise.resolve();
+    }
+
+    generatePKCECodes() {
+        let codeVerifier;
+        if (isBrowserEnv()) {
+            const array = new Uint8Array(PKCELength);
+            const randomValueArray = crypto.getRandomValues(array);
+            const base64String = btoa(randomValueArray);
+            codeVerifier = createBrowserSafeString(base64String).substr(0, 128);
+        } else {
+            const randomBytes = crypto.randomBytes(PKCELength);
+            codeVerifier = createBrowserSafeString(randomBytes).substr(0, 128);
+        }
+        this.codeVerifier = codeVerifier;
+
+        return this.generateCodeChallenge();
+    }
+
+    /**
+     * Get a URL that can be used to authenticate users for the Dropbox API.
+     * @arg {String} redirectUri - A URL to redirect the user to after
+     * authenticating. This must be added to your app through the admin interface.
+     * @arg {String} [state] - State that will be returned in the redirect URL to help
+     * prevent cross site scripting attacks.
+     * @arg {String} [authType] - auth type, defaults to 'token', other option is 'code'
+     * @arg {String} [tokenAccessType] - type of token to request.  From the following:
+     * null - creates a token with the app default (either legacy or online)
+     * legacy - creates one long-lived token with no expiration
+     * online - create one short-lived token with an expiration
+     * offline - create one short-lived token with an expiration with a refresh token
+     * @arg {Array<String>} [scope] - scopes to request for the grant
+     * @arg {String} [includeGrantedScopes] - whether or not to include previously granted scopes.
+     * From the following:
+     * user - include user scopes in the grant
+     * team - include team scopes in the grant
+     * Note: if this user has never linked the app, include_granted_scopes must be None
+     * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use on
+     * client apps which doesn't call your server. It is less secure than non-PKCE flow but
+     * can be used if you are unable to safely retrieve your app secret
+     * @returns {Promise<String>} - Url to send user to for Dropbox API authentication
+     * returned in a promise
+     */
+    getAuthenticationUrl(redirectUri, state, authType = 'token', tokenAccessType = null, scope = null, includeGrantedScopes = 'none', usePKCE = false) {
+        const clientId = this.getClientId();
+        const baseUrl = BaseAuthorizeUrl;
+
+        if (!clientId) {
+            throw new Error('A client id is required. You can set the client id using .setClientId().');
+        }
+        if (authType !== 'code' && !redirectUri) {
+            throw new Error('A redirect uri is required.');
+        }
+        if (!GrantTypes.includes(authType)) {
+            throw new Error('Authorization type must be code or token');
+        }
+        if (tokenAccessType && !TokenAccessTypes.includes(tokenAccessType)) {
+            throw new Error('Token Access Type must be legacy, offline, or online');
+        }
+        if (scope && !(scope instanceof Array)) {
+            throw new Error('Scope must be an array of strings');
+        }
+        if (!IncludeGrantedScopes.includes(includeGrantedScopes)) {
+            throw new Error('includeGrantedScopes must be none, user, or team');
         }
 
-        function onLoadStop(event) {
-          const errorLabel = '&error=';
-          const errorIndex = event.url.indexOf(errorLabel);
+        let authUrl;
+        if (authType === 'code') {
+            authUrl = `${baseUrl}?response_type=code&client_id=${clientId}`;
+        } else {
+            authUrl = `${baseUrl}?response_type=token&client_id=${clientId}`;
+        }
 
-          if (errorIndex > -1) {
-            // Try to avoid a browser crash on browser.close().
-            window.setTimeout(() => { browser.close(); }, 10);
-            errorCallback();
-          } else {
-            const tokenLabel = '#access_token=';
-            let tokenIndex = event.url.indexOf(tokenLabel);
-            const tokenTypeIndex = event.url.indexOf('&token_type=');
-            if (tokenIndex > -1) {
-              tokenIndex += tokenLabel.length;
-              // Try to avoid a browser crash on browser.close().
-              window.setTimeout(() => { browser.close(); }, 10);
+        if (redirectUri) {
+            authUrl += `&redirect_uri=${redirectUri}`;
+        }
+        if (state) {
+            authUrl += `&state=${state}`;
+        }
+        if (tokenAccessType) {
+            authUrl += `&token_access_type=${tokenAccessType}`;
+        }
+        if (scope) {
+            authUrl += `&scope=${scope.join(' ')}`;
+        }
+        if (includeGrantedScopes !== 'none') {
+            authUrl += `&include_granted_scopes=${includeGrantedScopes}`;
+        }
+        if (usePKCE) {
+            return this.generatePKCECodes()
+                .then(() => {
+                    authUrl += '&code_challenge_method=S256';
+                    authUrl += `&code_challenge=${this.codeChallenge}`;
+                    return authUrl;
+                });
+        }
+        return Promise.resolve(authUrl);
+    }
 
-              const accessToken = event.url.substring(tokenIndex, tokenTypeIndex);
-              successCallback(accessToken);
+    /**
+     * Get an OAuth2 access token from an OAuth2 Code.
+     * @arg {String} redirectUri - A URL to redirect the user to after
+     * authenticating. This must be added to your app through the admin interface.
+     * @arg {String} code - An OAuth2 code.
+     * @returns {Object} An object containing the token and related info (if applicable)
+     */
+    getAccessTokenFromCode(redirectUri, code) {
+        const clientId = this.getClientId();
+        const clientSecret = this.getClientSecret();
+
+        if (!clientId) {
+            throw new Error('A client id is required. You can set the client id using .setClientId().');
+        }
+        let path = BaseTokenUrl;
+        path += '?grant_type=authorization_code';
+        path += `&code=${code}`;
+        path += `&client_id=${clientId}`;
+
+        if (clientSecret) {
+            path += `&client_secret=${clientSecret}`;
+        } else {
+            if (!this.codeVerifier) {
+                throw new Error('You must use PKCE when generating the authorization URL to not include a client secret');
             }
-          }
+            path += `&code_verifier=${this.codeVerifier}`;
+        }
+        if (redirectUri) {
+            path += `&redirect_uri=${redirectUri}`;
         }
 
-        function onExit() {
-          if (removed) {
-            return;
-          }
-          browser.removeEventListener('loaderror', onLoadError);
-          browser.removeEventListener('loadstop', onLoadStop);
-          browser.removeEventListener('exit', onExit);
-          removed = true;
+        const fetchOptions = {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        };
+        return this.fetch(path, fetchOptions)
+            .then((res) => parseResponse(res));
+    }
+
+    /**
+     * Checks if a token is needed, can be refreshed and if the token is expired.
+     * If so, attempts to refresh access token
+     * @returns {Promise<*>}
+     */
+    checkAndRefreshAccessToken() {
+        const canRefresh = this.getRefreshToken() && this.getClientId();
+        const needsRefresh = !this.getAccessTokenExpiresAt() ||
+            (new Date(Date.now() + TokenExpirationBuffer)) >= this.getAccessTokenExpiresAt();
+        const needsToken = !this.getAccessToken();
+        if ((needsRefresh || needsToken) && canRefresh) {
+            return this.refreshAccessToken();
+        }
+        return Promise.resolve();
+    }
+
+    /**
+     * Refreshes the access token using the refresh token, if available
+     * @arg {Array<String>} scope - a subset of scopes from the original
+     * refresh to acquire with an access token
+     * @returns {Promise<*>}
+     */
+    refreshAccessToken(scope = null) {
+        let refreshUrl = BaseTokenUrl;
+        const clientId = this.getClientId();
+        const clientSecret = this.getClientSecret();
+
+        if (!clientId) {
+            throw new Error('A client id is required. You can set the client id using .setClientId().');
+        }
+        if (scope && !(scope instanceof Array)) {
+            throw new Error('Scope must be an array of strings');
         }
 
-        browser.addEventListener('loaderror', onLoadError);
-        browser.addEventListener('loadstop', onLoadStop);
-        browser.addEventListener('exit', onExit);
-      });
-  }
+        const headers = {};
+        headers['Content-Type'] = 'application/json';
+        refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
+        refreshUrl += `&client_id=${clientId}`;
+        if (clientSecret) {
+            refreshUrl += `&client_secret=${clientSecret}`;
+        }
+        if (scope) {
+            refreshUrl += `&scope=${scope.join(' ')}`;
+        }
+        const fetchOptions = {
+            method: 'POST',
+        };
+
+        fetchOptions.headers = headers;
+
+        return this.fetch(refreshUrl, fetchOptions)
+            .then((res) => parseResponse(res))
+            .then((res) => {
+                this.setAccessToken(res.result.access_token);
+                this.setAccessTokenExpiresAt(getTokenExpiresAtDate(res.result.expires_in));
+            });
+    }
+
+    /**
+     * An authentication process that works with cordova applications.
+     * @param {successCallback} successCallback
+     * @param {errorCallback} errorCallback
+     */
+    authenticateWithCordova(successCallback, errorCallback) {
+        const redirectUrl = 'https://www.dropbox.com/1/oauth2/redirect_receiver';
+        this.getAuthenticationUrl(redirectUrl)
+            .then((url) => {
+                let removed = false;
+                const browser = window.open(url, '_blank');
+
+                function onLoadError(event) {
+                    // Workaround to fix wrong behavior on cordova-plugin-inappbrowser
+                    if (event.code !== -999) {
+                        // Try to avoid a browser crash on browser.close().
+                        window.setTimeout(() => { browser.close(); }, 10);
+                        errorCallback();
+                    }
+                }
+
+                function onLoadStop(event) {
+                    const errorLabel = '&error=';
+                    const errorIndex = event.url.indexOf(errorLabel);
+
+                    if (errorIndex > -1) {
+                        // Try to avoid a browser crash on browser.close().
+                        window.setTimeout(() => { browser.close(); }, 10);
+                        errorCallback();
+                    } else {
+                        const tokenLabel = '#access_token=';
+                        let tokenIndex = event.url.indexOf(tokenLabel);
+                        const tokenTypeIndex = event.url.indexOf('&token_type=');
+                        if (tokenIndex > -1) {
+                            tokenIndex += tokenLabel.length;
+                            // Try to avoid a browser crash on browser.close().
+                            window.setTimeout(() => { browser.close(); }, 10);
+
+                            const accessToken = event.url.substring(tokenIndex, tokenTypeIndex);
+                            successCallback(accessToken);
+                        }
+                    }
+                }
+
+                function onExit() {
+                    if (removed) {
+                        return;
+                    }
+                    browser.removeEventListener('loaderror', onLoadError);
+                    browser.removeEventListener('loadstop', onLoadStop);
+                    browser.removeEventListener('exit', onExit);
+                    removed = true;
+                }
+
+                browser.addEventListener('loaderror', onLoadError);
+                browser.addEventListener('loadstop', onLoadStop);
+                browser.addEventListener('exit', onExit);
+            });
+    }
 }

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -5,382 +5,382 @@ import { Dropbox, DropboxAuth } from '../../index.js';
 
 chai.use(chaiAsPromised);
 describe('DropboxAuth', () => {
-    describe('accessToken', () => {
-        it('can be set in the constructor', () => {
-            const dbx = new Dropbox({ accessToken: 'foo' });
-            chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
-        });
-
-        it('is undefined if not set in constructor', () => {
-            const dbx = new Dropbox();
-            chai.assert.equal(dbx.auth.getAccessToken(), undefined);
-        });
-
-        it('can be set after being instantiated', () => {
-            const dbx = new Dropbox();
-            dbx.auth.setAccessToken('foo');
-            chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
-        });
+  describe('accessToken', () => {
+    it('can be set in the constructor', () => {
+      const dbx = new Dropbox({ accessToken: 'foo' });
+      chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
     });
 
-    describe('clientId', () => {
-        it('can be set in the constructor', () => {
-            const dbx = new Dropbox({ clientId: 'foo' });
-            chai.assert.equal(dbx.auth.getClientId(), 'foo');
-        });
-
-        it('is undefined if not set in constructor', () => {
-            const dbx = new Dropbox();
-            chai.assert.equal(dbx.auth.getClientId(), undefined);
-        });
-
-        it('can be set after being instantiated', () => {
-            const dbx = new Dropbox();
-            dbx.auth.setClientId('foo');
-            chai.assert.equal(dbx.auth.getClientId(), 'foo');
-        });
+    it('is undefined if not set in constructor', () => {
+      const dbx = new Dropbox();
+      chai.assert.equal(dbx.auth.getAccessToken(), undefined);
     });
 
-    describe('getAuthenticationUrl()', () => {
-        it('throws an error if the client id isn\'t set', () => {
-            const dbx = new Dropbox();
-            chai.assert.throws(
-                DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth, 'https://redirecturl.com'),
-                Error,
-                'A client id is required. You can set the client id using .setClientId().',
-            );
-        });
+    it('can be set after being instantiated', () => {
+      const dbx = new Dropbox();
+      dbx.auth.setAccessToken('foo');
+      chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
+    });
+  });
 
-        it('throws an error if the redirect url isn\'t set', () => {
-            const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-            chai.assert.throws(
-                DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth),
-                Error,
-                'A redirect uri is required.',
-            );
-        });
+  describe('clientId', () => {
+    it('can be set in the constructor', () => {
+      const dbx = new Dropbox({ clientId: 'foo' });
+      chai.assert.equal(dbx.auth.getClientId(), 'foo');
+    });
 
-        it('throws an error if the redirect url isn\'t set and type is code', () => {
-            const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-            return chai.expect(
-                dbx.auth.getAuthenticationUrl('', null, 'code'),
-            ).to.eventually.deep.equal('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID');
-        });
+    it('is undefined if not set in constructor', () => {
+      const dbx = new Dropbox();
+      chai.assert.equal(dbx.auth.getClientId(), undefined);
+    });
 
-        const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-        for (const redirectUri of['', 'localhost']) {
-            for (const state of['', 'state']) {
-                for (const tokenAccessType of[null, 'legacy', 'offline', 'online']) {
-                    for (const scope of[null, ['files.metadata.read', 'files.metadata.write']]) {
-                        for (const includeGrantedScopes of['none', 'user', 'team']) {
-                            const input = {
-                                redirectUri,
-                                state,
-                                tokenAccessType,
-                                scope,
-                                includeGrantedScopes,
-                            };
-                            it(`returns correct auth url with all combinations of valid input. redirectUri: ${redirectUri}, state: ${state}, 
+    it('can be set after being instantiated', () => {
+      const dbx = new Dropbox();
+      dbx.auth.setClientId('foo');
+      chai.assert.equal(dbx.auth.getClientId(), 'foo');
+    });
+  });
+
+  describe('getAuthenticationUrl()', () => {
+    it('throws an error if the client id isn\'t set', () => {
+      const dbx = new Dropbox();
+      chai.assert.throws(
+        DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth, 'https://redirecturl.com'),
+        Error,
+        'A client id is required. You can set the client id using .setClientId().',
+      );
+    });
+
+    it('throws an error if the redirect url isn\'t set', () => {
+      const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+      chai.assert.throws(
+        DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth),
+        Error,
+        'A redirect uri is required.',
+      );
+    });
+
+    it('throws an error if the redirect url isn\'t set and type is code', () => {
+      const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+      return chai.expect(
+        dbx.auth.getAuthenticationUrl('', null, 'code'),
+      ).to.eventually.deep.equal('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID');
+    });
+
+    const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+    for (const redirectUri of ['', 'localhost']) {
+      for (const state of ['', 'state']) {
+        for (const tokenAccessType of [null, 'legacy', 'offline', 'online']) {
+          for (const scope of [null, ['files.metadata.read', 'files.metadata.write']]) {
+            for (const includeGrantedScopes of ['none', 'user', 'team']) {
+              const input = {
+                redirectUri,
+                state,
+                tokenAccessType,
+                scope,
+                includeGrantedScopes,
+              };
+              it(`returns correct auth url with all combinations of valid input. redirectUri: ${redirectUri}, state: ${state}, 
                 tokenAccessType: ${tokenAccessType}, scope: ${scope}, includeGrantedScopes: ${includeGrantedScopes}`, (done) => {
-                                dbx.auth.getAuthenticationUrl(redirectUri, state, 'code', tokenAccessType, scope, includeGrantedScopes) // eslint-disable-line no-await-in-loop
-                                    .then((url) => {
-                                        chai.assert(url.startsWith('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID'));
+                dbx.auth.getAuthenticationUrl(redirectUri, state, 'code', tokenAccessType, scope, includeGrantedScopes) // eslint-disable-line no-await-in-loop
+                  .then((url) => {
+                    chai.assert(url.startsWith('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID'));
 
-                                        if (redirectUri) {
-                                            chai.assert(url.includes(`&redirect_uri=${redirectUri}`));
-                                        } else {
-                                            chai.assert(!url.includes('&redirect_uri='));
-                                        }
-
-                                        if (state) {
-                                            chai.assert(url.includes(`&state=${state}`));
-                                        } else {
-                                            chai.assert(!url.includes('&state='));
-                                        }
-
-                                        if (tokenAccessType) {
-                                            chai.assert(url.includes(`&token_access_type=${tokenAccessType}`));
-                                        } else {
-                                            chai.assert(!url.includes('&token_access_type='));
-                                        }
-
-                                        if (scope) {
-                                            chai.assert(url.includes(`&scope=${scope.join(' ')}`));
-                                        } else {
-                                            chai.assert(!url.includes('&scope='));
-                                        }
-
-                                        if (includeGrantedScopes !== 'none') {
-                                            chai.assert(url.includes(`&include_granted_scopes=${includeGrantedScopes}`));
-                                        } else {
-                                            chai.assert(!url.includes('&include_granted_scopes='));
-                                        }
-                                        done();
-                                    })
-                                    .catch(done);
-                            });
-                        }
+                    if (redirectUri) {
+                      chai.assert(url.includes(`&redirect_uri=${redirectUri}`));
+                    } else {
+                      chai.assert(!url.includes('&redirect_uri='));
                     }
-                }
+
+                    if (state) {
+                      chai.assert(url.includes(`&state=${state}`));
+                    } else {
+                      chai.assert(!url.includes('&state='));
+                    }
+
+                    if (tokenAccessType) {
+                      chai.assert(url.includes(`&token_access_type=${tokenAccessType}`));
+                    } else {
+                      chai.assert(!url.includes('&token_access_type='));
+                    }
+
+                    if (scope) {
+                      chai.assert(url.includes(`&scope=${scope.join(' ')}`));
+                    } else {
+                      chai.assert(!url.includes('&scope='));
+                    }
+
+                    if (includeGrantedScopes !== 'none') {
+                      chai.assert(url.includes(`&include_granted_scopes=${includeGrantedScopes}`));
+                    } else {
+                      chai.assert(!url.includes('&include_granted_scopes='));
+                    }
+                    done();
+                  })
+                  .catch(done);
+              });
             }
+          }
         }
+      }
+    }
+  });
+
+  describe('clientSecret', () => {
+    it('can be set in the constructor', () => {
+      const dbx = new Dropbox({ clientSecret: 'foo' });
+      chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
     });
 
-    describe('clientSecret', () => {
-        it('can be set in the constructor', () => {
-            const dbx = new Dropbox({ clientSecret: 'foo' });
-            chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
-        });
-
-        it('is undefined if not set in constructor', () => {
-            const dbx = new Dropbox();
-            chai.assert.equal(dbx.auth.getClientSecret(), undefined);
-        });
-
-        it('can be set after being instantiated', () => {
-            const dbx = new Dropbox();
-            dbx.auth.setClientSecret('foo');
-            chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
-        });
+    it('is undefined if not set in constructor', () => {
+      const dbx = new Dropbox();
+      chai.assert.equal(dbx.auth.getClientSecret(), undefined);
     });
 
-    describe('refreshToken', () => {
-        it('can be set in the constructor', () => {
-            const dbxAuth = new DropboxAuth({ refreshToken: 'foo' });
-            chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
-        });
+    it('can be set after being instantiated', () => {
+      const dbx = new Dropbox();
+      dbx.auth.setClientSecret('foo');
+      chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
+    });
+  });
 
-        it('is undefined if not set in constructor', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.equal(dbxAuth.getRefreshToken(), undefined);
-        });
-
-        it('can be set after being instantiated', () => {
-            const dbxAuth = new DropboxAuth();
-            dbxAuth.setRefreshToken('foo');
-            chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
-        });
+  describe('refreshToken', () => {
+    it('can be set in the constructor', () => {
+      const dbxAuth = new DropboxAuth({ refreshToken: 'foo' });
+      chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
     });
 
-    describe('accessTokenExpiresAt', () => {
-        it('can be set in the constructor', () => {
-            const date = new Date(2020, 11, 30);
-            const dbxAuth = new DropboxAuth({ accessTokenExpiresAt: date });
-            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
-        });
-
-        it('is undefined if not set in constructor', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), undefined);
-        });
-
-        it('can be set after being instantiated', () => {
-            const dbxAuth = new DropboxAuth();
-            const date = new Date(2020, 11, 30);
-            dbxAuth.setAccessTokenExpiresAt(date);
-            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
-        });
+    it('is undefined if not set in constructor', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.equal(dbxAuth.getRefreshToken(), undefined);
     });
 
-    describe('codeVerifier', () => {
-        it('is undefined when constructed', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.equal(dbxAuth.getCodeVerifier(), undefined);
-        });
+    it('can be set after being instantiated', () => {
+      const dbxAuth = new DropboxAuth();
+      dbxAuth.setRefreshToken('foo');
+      chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
+    });
+  });
 
-        it('can be set after being instantiated', () => {
-            const dbxAuth = new DropboxAuth();
-            const verifier = 'abcdef';
-            dbxAuth.setCodeVerifier(verifier);
-            chai.assert.equal(dbxAuth.getCodeVerifier(), verifier);
-        });
+  describe('accessTokenExpiresAt', () => {
+    it('can be set in the constructor', () => {
+      const date = new Date(2020, 11, 30);
+      const dbxAuth = new DropboxAuth({ accessTokenExpiresAt: date });
+      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
     });
 
-    describe('generatePKCECodes', () => {
-        it('saves a new code verifier on Auth obj', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.equal(dbxAuth.codeVerifier, undefined);
-            dbxAuth.generatePKCECodes();
-            chai.assert.isTrue(!!dbxAuth.codeVerifier);
-        });
-
-        it('creates a code verifier of the correct length', () => {
-            const dbxAuth = new DropboxAuth();
-            dbxAuth.generatePKCECodes();
-            chai.assert.equal(dbxAuth.codeVerifier.length, 128);
-        });
-
-        it('saves a new code challenge on Auth obj', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.equal(dbxAuth.codeChallenge, undefined);
-            dbxAuth.generatePKCECodes();
-            chai.assert.isTrue(!!dbxAuth.codeChallenge);
-        });
-
-        it('gets called when using PKCE flow', (done) => {
-            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-            const pkceSpy = sinon.spy(dbxAuth, 'generatePKCECodes');
-            dbxAuth.getAuthenticationUrl('test', null, undefined, undefined, undefined, undefined, true)
-                .then(() => {
-                    chai.assert.isTrue(pkceSpy.calledOnce);
-                    done();
-                })
-                .catch(done);
-        });
-
-        it('generates valid code challenge from verifier (Node)', (done) => {
-            const dbxAuth = new DropboxAuth();
-            const verifier = "NTUsMjIsMzYsMTY4LDIyLDEzNywyNDMsOTYsMTIxLDIxNSwxNDAsMTYwLDMwLDE1LDIzMSw1NiwzMCwyMTIsMTQyLDIyMywxMzMsMTIsMjI1LDIzOCwxMDcsMjQ1LDM0";
-            dbxAuth.setCodeVerifier(verifier);
-            dbxAuth.generateCodeChallenge()
-                .then(() => {
-                    chai.assert.equal(dbxAuth.codeChallenge, "fKco8CJrMUeyji-FJ83wxnx2bqK6BOqzefPamApt3Nc");
-                    done();
-                })
-                .catch(done);
-        });
+    it('is undefined if not set in constructor', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), undefined);
     });
 
-    describe('getAccessTokenFromCode', () => {
-        it('throws an error without a clientID', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.throws(
-                DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
-                Error,
-                'A client id is required. You can set the client id using .setClientId().',
-            );
-        });
+    it('can be set after being instantiated', () => {
+      const dbxAuth = new DropboxAuth();
+      const date = new Date(2020, 11, 30);
+      dbxAuth.setAccessTokenExpiresAt(date);
+      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
+    });
+  });
 
-        it('throws an error when not provided a client secret or code challenge', () => {
-            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-            chai.assert.throws(
-                DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
-                Error,
-                'You must use PKCE when generating the authorization URL to not include a client secret',
-            );
-        });
-
-        it('sets the right path for fetch request', () => {
-            const dbxAuth = new DropboxAuth({
-                clientId: 'foo',
-                clientSecret: 'bar',
-            });
-
-            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-            dbxAuth.getAccessTokenFromCode('foo', 'bar');
-            const path = dbxAuth.fetch.getCall(0).args[0];
-            chai.assert.isTrue(fetchSpy.calledOnce);
-            chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar&redirect_uri=foo', path);
-        });
-
-        it('sets the right path without a redirect uri', () => {
-            const dbxAuth = new DropboxAuth({
-                clientId: 'foo',
-                clientSecret: 'bar',
-            });
-
-            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-            dbxAuth.getAccessTokenFromCode(undefined, 'bar');
-            const path = dbxAuth.fetch.getCall(0).args[0];
-            chai.assert.isTrue(fetchSpy.calledOnce);
-            chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar', path);
-        });
-
-        it('sets the correct headers for fetch request', () => {
-            const dbxAuth = new DropboxAuth({
-                clientId: 'foo',
-                clientSecret: 'bar',
-            });
-
-            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-            dbxAuth.getAccessTokenFromCode('foo', 'bar');
-            const { headers } = dbxAuth.fetch.getCall(0).args[1];
-            chai.assert.isTrue(fetchSpy.calledOnce);
-            chai.assert.equal(headers['Content-Type'], 'application/x-www-form-urlencoded');
-        });
+  describe('codeVerifier', () => {
+    it('is undefined when constructed', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.equal(dbxAuth.getCodeVerifier(), undefined);
     });
 
-    describe('checkAndRefreshAccessToken', () => {
-        it('does not refresh without refresh token or clientId', () => {
-            const dbxAuth = new DropboxAuth();
-            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-            dbxAuth.checkAndRefreshAccessToken();
-            chai.assert.isTrue(refreshSpy.notCalled);
-        });
+    it('can be set after being instantiated', () => {
+      const dbxAuth = new DropboxAuth();
+      const verifier = 'abcdef';
+      dbxAuth.setCodeVerifier(verifier);
+      chai.assert.equal(dbxAuth.getCodeVerifier(), verifier);
+    });
+  });
 
-        it('doesn\'t refresh token when not past expiration time', () => {
-            const currentDate = new Date();
-            const dbxAuth = new DropboxAuth({
-                accessTokenExpiresAt: currentDate.setHours(currentDate.getHours() + 2),
-            });
-            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-            dbxAuth.checkAndRefreshAccessToken();
-            chai.assert.isTrue(refreshSpy.notCalled);
-        });
-
-        it('refreshes token when past expiration', () => {
-            const dbxAuth = new DropboxAuth({
-                accessTokenExpiresAt: new Date(2019, 11, 19),
-                clientId: '123',
-                refreshToken: 'foo',
-            });
-
-            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-            dbxAuth.checkAndRefreshAccessToken();
-            chai.assert.isTrue(refreshSpy.calledOnce);
-        });
+  describe('generatePKCECodes', () => {
+    it('saves a new code verifier on Auth obj', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.equal(dbxAuth.codeVerifier, undefined);
+      dbxAuth.generatePKCECodes();
+      chai.assert.isTrue(!!dbxAuth.codeVerifier);
     });
 
-    describe('refreshAccessToken', () => {
-        it('throws an error when not provided with a clientId', () => {
-            const dbxAuth = new DropboxAuth();
-            chai.assert.throws(
-                DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth),
-                Error,
-                'A client id is required. You can set the client id using .setClientId().',
-            );
-        });
-
-        it('throws an error when provided an argument that is not a list', () => {
-            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-            chai.assert.throws(
-                DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth, 'not a list'),
-                Error,
-                'Scope must be an array of strings',
-            );
-        });
-
-        const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
-
-        it('sets the correct refresh url (no scope passed)', () => {
-            const dbxAuth = new DropboxAuth({
-                clientId: 'foo',
-                clientSecret: 'bar',
-            });
-
-            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-            dbxAuth.refreshAccessToken();
-            chai.assert.isTrue(fetchSpy.calledOnce);
-            const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-            const { headers } = dbxAuth.fetch.getCall(0).args[1];
-            chai.assert.equal(refreshUrl, testRefreshUrl);
-            chai.assert.equal(headers['Content-Type'], 'application/json');
-        });
-
-        it('sets the correct refresh url (scope passed)', () => {
-            const dbxAuth = new DropboxAuth({
-                clientId: 'foo',
-                clientSecret: 'bar',
-            });
-
-            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-            dbxAuth.refreshAccessToken(['files.metadata.read']);
-            chai.assert.isTrue(fetchSpy.calledOnce);
-            const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-            const { headers } = dbxAuth.fetch.getCall(0).args[1];
-            const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
-            chai.assert.equal(refreshUrl, testScopeUrl);
-            chai.assert.equal(headers['Content-Type'], 'application/json');
-        });
+    it('creates a code verifier of the correct length', () => {
+      const dbxAuth = new DropboxAuth();
+      dbxAuth.generatePKCECodes();
+      chai.assert.equal(dbxAuth.codeVerifier.length, 128);
     });
+
+    it('saves a new code challenge on Auth obj', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.equal(dbxAuth.codeChallenge, undefined);
+      dbxAuth.generatePKCECodes();
+      chai.assert.isTrue(!!dbxAuth.codeChallenge);
+    });
+
+    it('gets called when using PKCE flow', (done) => {
+      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+      const pkceSpy = sinon.spy(dbxAuth, 'generatePKCECodes');
+      dbxAuth.getAuthenticationUrl('test', null, undefined, undefined, undefined, undefined, true)
+        .then(() => {
+          chai.assert.isTrue(pkceSpy.calledOnce);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('generates valid code challenge from verifier (Node)', (done) => {
+      const dbxAuth = new DropboxAuth();
+      const verifier = 'NTUsMjIsMzYsMTY4LDIyLDEzNywyNDMsOTYsMTIxLDIxNSwxNDAsMTYwLDMwLDE1LDIzMSw1NiwzMCwyMTIsMTQyLDIyMywxMzMsMTIsMjI1LDIzOCwxMDcsMjQ1LDM0';
+      dbxAuth.setCodeVerifier(verifier);
+      dbxAuth.generateCodeChallenge()
+        .then(() => {
+          chai.assert.equal(dbxAuth.codeChallenge, 'fKco8CJrMUeyji-FJ83wxnx2bqK6BOqzefPamApt3Nc');
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('getAccessTokenFromCode', () => {
+    it('throws an error without a clientID', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.throws(
+        DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
+        Error,
+        'A client id is required. You can set the client id using .setClientId().',
+      );
+    });
+
+    it('throws an error when not provided a client secret or code challenge', () => {
+      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+      chai.assert.throws(
+        DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
+        Error,
+        'You must use PKCE when generating the authorization URL to not include a client secret',
+      );
+    });
+
+    it('sets the right path for fetch request', () => {
+      const dbxAuth = new DropboxAuth({
+        clientId: 'foo',
+        clientSecret: 'bar',
+      });
+
+      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+      dbxAuth.getAccessTokenFromCode('foo', 'bar');
+      const path = dbxAuth.fetch.getCall(0).args[0];
+      chai.assert.isTrue(fetchSpy.calledOnce);
+      chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar&redirect_uri=foo', path);
+    });
+
+    it('sets the right path without a redirect uri', () => {
+      const dbxAuth = new DropboxAuth({
+        clientId: 'foo',
+        clientSecret: 'bar',
+      });
+
+      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+      dbxAuth.getAccessTokenFromCode(undefined, 'bar');
+      const path = dbxAuth.fetch.getCall(0).args[0];
+      chai.assert.isTrue(fetchSpy.calledOnce);
+      chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar', path);
+    });
+
+    it('sets the correct headers for fetch request', () => {
+      const dbxAuth = new DropboxAuth({
+        clientId: 'foo',
+        clientSecret: 'bar',
+      });
+
+      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+      dbxAuth.getAccessTokenFromCode('foo', 'bar');
+      const { headers } = dbxAuth.fetch.getCall(0).args[1];
+      chai.assert.isTrue(fetchSpy.calledOnce);
+      chai.assert.equal(headers['Content-Type'], 'application/x-www-form-urlencoded');
+    });
+  });
+
+  describe('checkAndRefreshAccessToken', () => {
+    it('does not refresh without refresh token or clientId', () => {
+      const dbxAuth = new DropboxAuth();
+      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+      dbxAuth.checkAndRefreshAccessToken();
+      chai.assert.isTrue(refreshSpy.notCalled);
+    });
+
+    it('doesn\'t refresh token when not past expiration time', () => {
+      const currentDate = new Date();
+      const dbxAuth = new DropboxAuth({
+        accessTokenExpiresAt: currentDate.setHours(currentDate.getHours() + 2),
+      });
+      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+      dbxAuth.checkAndRefreshAccessToken();
+      chai.assert.isTrue(refreshSpy.notCalled);
+    });
+
+    it('refreshes token when past expiration', () => {
+      const dbxAuth = new DropboxAuth({
+        accessTokenExpiresAt: new Date(2019, 11, 19),
+        clientId: '123',
+        refreshToken: 'foo',
+      });
+
+      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+      dbxAuth.checkAndRefreshAccessToken();
+      chai.assert.isTrue(refreshSpy.calledOnce);
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('throws an error when not provided with a clientId', () => {
+      const dbxAuth = new DropboxAuth();
+      chai.assert.throws(
+        DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth),
+        Error,
+        'A client id is required. You can set the client id using .setClientId().',
+      );
+    });
+
+    it('throws an error when provided an argument that is not a list', () => {
+      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+      chai.assert.throws(
+        DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth, 'not a list'),
+        Error,
+        'Scope must be an array of strings',
+      );
+    });
+
+    const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
+
+    it('sets the correct refresh url (no scope passed)', () => {
+      const dbxAuth = new DropboxAuth({
+        clientId: 'foo',
+        clientSecret: 'bar',
+      });
+
+      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+      dbxAuth.refreshAccessToken();
+      chai.assert.isTrue(fetchSpy.calledOnce);
+      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+      const { headers } = dbxAuth.fetch.getCall(0).args[1];
+      chai.assert.equal(refreshUrl, testRefreshUrl);
+      chai.assert.equal(headers['Content-Type'], 'application/json');
+    });
+
+    it('sets the correct refresh url (scope passed)', () => {
+      const dbxAuth = new DropboxAuth({
+        clientId: 'foo',
+        clientSecret: 'bar',
+      });
+
+      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+      dbxAuth.refreshAccessToken(['files.metadata.read']);
+      chai.assert.isTrue(fetchSpy.calledOnce);
+      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+      const { headers } = dbxAuth.fetch.getCall(0).args[1];
+      const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
+      chai.assert.equal(refreshUrl, testScopeUrl);
+      chai.assert.equal(headers['Content-Type'], 'application/json');
+    });
+  });
 });

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -5,356 +5,382 @@ import { Dropbox, DropboxAuth } from '../../index.js';
 
 chai.use(chaiAsPromised);
 describe('DropboxAuth', () => {
-  describe('accessToken', () => {
-    it('can be set in the constructor', () => {
-      const dbx = new Dropbox({ accessToken: 'foo' });
-      chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
+    describe('accessToken', () => {
+        it('can be set in the constructor', () => {
+            const dbx = new Dropbox({ accessToken: 'foo' });
+            chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
+        });
+
+        it('is undefined if not set in constructor', () => {
+            const dbx = new Dropbox();
+            chai.assert.equal(dbx.auth.getAccessToken(), undefined);
+        });
+
+        it('can be set after being instantiated', () => {
+            const dbx = new Dropbox();
+            dbx.auth.setAccessToken('foo');
+            chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
+        });
     });
 
-    it('is undefined if not set in constructor', () => {
-      const dbx = new Dropbox();
-      chai.assert.equal(dbx.auth.getAccessToken(), undefined);
+    describe('clientId', () => {
+        it('can be set in the constructor', () => {
+            const dbx = new Dropbox({ clientId: 'foo' });
+            chai.assert.equal(dbx.auth.getClientId(), 'foo');
+        });
+
+        it('is undefined if not set in constructor', () => {
+            const dbx = new Dropbox();
+            chai.assert.equal(dbx.auth.getClientId(), undefined);
+        });
+
+        it('can be set after being instantiated', () => {
+            const dbx = new Dropbox();
+            dbx.auth.setClientId('foo');
+            chai.assert.equal(dbx.auth.getClientId(), 'foo');
+        });
     });
 
-    it('can be set after being instantiated', () => {
-      const dbx = new Dropbox();
-      dbx.auth.setAccessToken('foo');
-      chai.assert.equal(dbx.auth.getAccessToken(), 'foo');
-    });
-  });
+    describe('getAuthenticationUrl()', () => {
+        it('throws an error if the client id isn\'t set', () => {
+            const dbx = new Dropbox();
+            chai.assert.throws(
+                DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth, 'https://redirecturl.com'),
+                Error,
+                'A client id is required. You can set the client id using .setClientId().',
+            );
+        });
 
-  describe('clientId', () => {
-    it('can be set in the constructor', () => {
-      const dbx = new Dropbox({ clientId: 'foo' });
-      chai.assert.equal(dbx.auth.getClientId(), 'foo');
-    });
+        it('throws an error if the redirect url isn\'t set', () => {
+            const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+            chai.assert.throws(
+                DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth),
+                Error,
+                'A redirect uri is required.',
+            );
+        });
 
-    it('is undefined if not set in constructor', () => {
-      const dbx = new Dropbox();
-      chai.assert.equal(dbx.auth.getClientId(), undefined);
-    });
+        it('throws an error if the redirect url isn\'t set and type is code', () => {
+            const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+            return chai.expect(
+                dbx.auth.getAuthenticationUrl('', null, 'code'),
+            ).to.eventually.deep.equal('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID');
+        });
 
-    it('can be set after being instantiated', () => {
-      const dbx = new Dropbox();
-      dbx.auth.setClientId('foo');
-      chai.assert.equal(dbx.auth.getClientId(), 'foo');
-    });
-  });
-
-  describe('getAuthenticationUrl()', () => {
-    it('throws an error if the client id isn\'t set', () => {
-      const dbx = new Dropbox();
-      chai.assert.throws(
-        DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth, 'https://redirecturl.com'),
-        Error,
-        'A client id is required. You can set the client id using .setClientId().',
-      );
-    });
-
-    it('throws an error if the redirect url isn\'t set', () => {
-      const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-      chai.assert.throws(
-        DropboxAuth.prototype.getAuthenticationUrl.bind(dbx.auth),
-        Error,
-        'A redirect uri is required.',
-      );
-    });
-
-    it('throws an error if the redirect url isn\'t set and type is code', () => {
-      const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-      return chai.expect(
-        dbx.auth.getAuthenticationUrl('', null, 'code'),
-      ).to.eventually.deep.equal('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID');
-    });
-
-    const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
-    for (const redirectUri of ['', 'localhost']) {
-      for (const state of ['', 'state']) {
-        for (const tokenAccessType of [null, 'legacy', 'offline', 'online']) {
-          for (const scope of [null, ['files.metadata.read', 'files.metadata.write']]) {
-            for (const includeGrantedScopes of ['none', 'user', 'team']) {
-              const input = {
-                redirectUri,
-                state,
-                tokenAccessType,
-                scope,
-                includeGrantedScopes,
-              };
-              it(`returns correct auth url with all combinations of valid input. redirectUri: ${redirectUri}, state: ${state}, 
+        const dbx = new Dropbox({ clientId: 'CLIENT_ID' });
+        for (const redirectUri of['', 'localhost']) {
+            for (const state of['', 'state']) {
+                for (const tokenAccessType of[null, 'legacy', 'offline', 'online']) {
+                    for (const scope of[null, ['files.metadata.read', 'files.metadata.write']]) {
+                        for (const includeGrantedScopes of['none', 'user', 'team']) {
+                            const input = {
+                                redirectUri,
+                                state,
+                                tokenAccessType,
+                                scope,
+                                includeGrantedScopes,
+                            };
+                            it(`returns correct auth url with all combinations of valid input. redirectUri: ${redirectUri}, state: ${state}, 
                 tokenAccessType: ${tokenAccessType}, scope: ${scope}, includeGrantedScopes: ${includeGrantedScopes}`, (done) => {
-                dbx.auth.getAuthenticationUrl(redirectUri, state, 'code', tokenAccessType, scope, includeGrantedScopes) // eslint-disable-line no-await-in-loop
-                  .then((url) => {
-                    chai.assert(url.startsWith('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID'));
+                                dbx.auth.getAuthenticationUrl(redirectUri, state, 'code', tokenAccessType, scope, includeGrantedScopes) // eslint-disable-line no-await-in-loop
+                                    .then((url) => {
+                                        chai.assert(url.startsWith('https://www.dropbox.com/oauth2/authorize?response_type=code&client_id=CLIENT_ID'));
 
-                    if (redirectUri) {
-                      chai.assert(url.includes(`&redirect_uri=${redirectUri}`));
-                    } else {
-                      chai.assert(!url.includes('&redirect_uri='));
-                    }
+                                        if (redirectUri) {
+                                            chai.assert(url.includes(`&redirect_uri=${redirectUri}`));
+                                        } else {
+                                            chai.assert(!url.includes('&redirect_uri='));
+                                        }
 
-                    if (state) {
-                      chai.assert(url.includes(`&state=${state}`));
-                    } else {
-                      chai.assert(!url.includes('&state='));
-                    }
+                                        if (state) {
+                                            chai.assert(url.includes(`&state=${state}`));
+                                        } else {
+                                            chai.assert(!url.includes('&state='));
+                                        }
 
-                    if (tokenAccessType) {
-                      chai.assert(url.includes(`&token_access_type=${tokenAccessType}`));
-                    } else {
-                      chai.assert(!url.includes('&token_access_type='));
-                    }
+                                        if (tokenAccessType) {
+                                            chai.assert(url.includes(`&token_access_type=${tokenAccessType}`));
+                                        } else {
+                                            chai.assert(!url.includes('&token_access_type='));
+                                        }
 
-                    if (scope) {
-                      chai.assert(url.includes(`&scope=${scope.join(' ')}`));
-                    } else {
-                      chai.assert(!url.includes('&scope='));
-                    }
+                                        if (scope) {
+                                            chai.assert(url.includes(`&scope=${scope.join(' ')}`));
+                                        } else {
+                                            chai.assert(!url.includes('&scope='));
+                                        }
 
-                    if (includeGrantedScopes !== 'none') {
-                      chai.assert(url.includes(`&include_granted_scopes=${includeGrantedScopes}`));
-                    } else {
-                      chai.assert(!url.includes('&include_granted_scopes='));
+                                        if (includeGrantedScopes !== 'none') {
+                                            chai.assert(url.includes(`&include_granted_scopes=${includeGrantedScopes}`));
+                                        } else {
+                                            chai.assert(!url.includes('&include_granted_scopes='));
+                                        }
+                                        done();
+                                    })
+                                    .catch(done);
+                            });
+                        }
                     }
-                    done();
-                  })
-                  .catch(done);
-              });
+                }
             }
-          }
         }
-      }
-    }
-  });
-
-  describe('clientSecret', () => {
-    it('can be set in the constructor', () => {
-      const dbx = new Dropbox({ clientSecret: 'foo' });
-      chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
     });
 
-    it('is undefined if not set in constructor', () => {
-      const dbx = new Dropbox();
-      chai.assert.equal(dbx.auth.getClientSecret(), undefined);
+    describe('clientSecret', () => {
+        it('can be set in the constructor', () => {
+            const dbx = new Dropbox({ clientSecret: 'foo' });
+            chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
+        });
+
+        it('is undefined if not set in constructor', () => {
+            const dbx = new Dropbox();
+            chai.assert.equal(dbx.auth.getClientSecret(), undefined);
+        });
+
+        it('can be set after being instantiated', () => {
+            const dbx = new Dropbox();
+            dbx.auth.setClientSecret('foo');
+            chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
+        });
     });
 
-    it('can be set after being instantiated', () => {
-      const dbx = new Dropbox();
-      dbx.auth.setClientSecret('foo');
-      chai.assert.equal(dbx.auth.getClientSecret(), 'foo');
-    });
-  });
+    describe('refreshToken', () => {
+        it('can be set in the constructor', () => {
+            const dbxAuth = new DropboxAuth({ refreshToken: 'foo' });
+            chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
+        });
 
-  describe('refreshToken', () => {
-    it('can be set in the constructor', () => {
-      const dbxAuth = new DropboxAuth({ refreshToken: 'foo' });
-      chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
-    });
+        it('is undefined if not set in constructor', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.equal(dbxAuth.getRefreshToken(), undefined);
+        });
 
-    it('is undefined if not set in constructor', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.equal(dbxAuth.getRefreshToken(), undefined);
-    });
-
-    it('can be set after being instantiated', () => {
-      const dbxAuth = new DropboxAuth();
-      dbxAuth.setRefreshToken('foo');
-      chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
-    });
-  });
-
-  describe('accessTokenExpiresAt', () => {
-    it('can be set in the constructor', () => {
-      const date = new Date(2020, 11, 30);
-      const dbxAuth = new DropboxAuth({ accessTokenExpiresAt: date });
-      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
+        it('can be set after being instantiated', () => {
+            const dbxAuth = new DropboxAuth();
+            dbxAuth.setRefreshToken('foo');
+            chai.assert.equal(dbxAuth.getRefreshToken(), 'foo');
+        });
     });
 
-    it('is undefined if not set in constructor', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), undefined);
+    describe('accessTokenExpiresAt', () => {
+        it('can be set in the constructor', () => {
+            const date = new Date(2020, 11, 30);
+            const dbxAuth = new DropboxAuth({ accessTokenExpiresAt: date });
+            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
+        });
+
+        it('is undefined if not set in constructor', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), undefined);
+        });
+
+        it('can be set after being instantiated', () => {
+            const dbxAuth = new DropboxAuth();
+            const date = new Date(2020, 11, 30);
+            dbxAuth.setAccessTokenExpiresAt(date);
+            chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
+        });
     });
 
-    it('can be set after being instantiated', () => {
-      const dbxAuth = new DropboxAuth();
-      const date = new Date(2020, 11, 30);
-      dbxAuth.setAccessTokenExpiresAt(date);
-      chai.assert.equal(dbxAuth.getAccessTokenExpiresAt(), date);
-    });
-  });
+    describe('codeVerifier', () => {
+        it('is undefined when constructed', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.equal(dbxAuth.getCodeVerifier(), undefined);
+        });
 
-  describe('generatePKCECodes', () => {
-    it('saves a new code verifier on Auth obj', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.equal(dbxAuth.codeVerifier, undefined);
-      dbxAuth.generatePKCECodes();
-      chai.assert.isTrue(!!dbxAuth.codeVerifier);
+        it('can be set after being instantiated', () => {
+            const dbxAuth = new DropboxAuth();
+            const verifier = 'abcdef';
+            dbxAuth.setCodeVerifier(verifier);
+            chai.assert.equal(dbxAuth.getCodeVerifier(), verifier);
+        });
     });
 
-    it('creates a code verifier of the correct length', () => {
-      const dbxAuth = new DropboxAuth();
-      dbxAuth.generatePKCECodes();
-      chai.assert.equal(dbxAuth.codeVerifier.length, 128);
+    describe('generatePKCECodes', () => {
+        it('saves a new code verifier on Auth obj', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.equal(dbxAuth.codeVerifier, undefined);
+            dbxAuth.generatePKCECodes();
+            chai.assert.isTrue(!!dbxAuth.codeVerifier);
+        });
+
+        it('creates a code verifier of the correct length', () => {
+            const dbxAuth = new DropboxAuth();
+            dbxAuth.generatePKCECodes();
+            chai.assert.equal(dbxAuth.codeVerifier.length, 128);
+        });
+
+        it('saves a new code challenge on Auth obj', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.equal(dbxAuth.codeChallenge, undefined);
+            dbxAuth.generatePKCECodes();
+            chai.assert.isTrue(!!dbxAuth.codeChallenge);
+        });
+
+        it('gets called when using PKCE flow', (done) => {
+            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+            const pkceSpy = sinon.spy(dbxAuth, 'generatePKCECodes');
+            dbxAuth.getAuthenticationUrl('test', null, undefined, undefined, undefined, undefined, true)
+                .then(() => {
+                    chai.assert.isTrue(pkceSpy.calledOnce);
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('generates valid code challenge from verifier (Node)', (done) => {
+            const dbxAuth = new DropboxAuth();
+            const verifier = "NTUsMjIsMzYsMTY4LDIyLDEzNywyNDMsOTYsMTIxLDIxNSwxNDAsMTYwLDMwLDE1LDIzMSw1NiwzMCwyMTIsMTQyLDIyMywxMzMsMTIsMjI1LDIzOCwxMDcsMjQ1LDM0";
+            dbxAuth.setCodeVerifier(verifier);
+            dbxAuth.generateCodeChallenge()
+                .then(() => {
+                    chai.assert.equal(dbxAuth.codeChallenge, "fKco8CJrMUeyji-FJ83wxnx2bqK6BOqzefPamApt3Nc");
+                    done();
+                })
+                .catch(done);
+        });
     });
 
-    it('saves a new code challenge on Auth obj', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.equal(dbxAuth.codeChallenge, undefined);
-      dbxAuth.generatePKCECodes();
-      chai.assert.isTrue(!!dbxAuth.codeChallenge);
+    describe('getAccessTokenFromCode', () => {
+        it('throws an error without a clientID', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.throws(
+                DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
+                Error,
+                'A client id is required. You can set the client id using .setClientId().',
+            );
+        });
+
+        it('throws an error when not provided a client secret or code challenge', () => {
+            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+            chai.assert.throws(
+                DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
+                Error,
+                'You must use PKCE when generating the authorization URL to not include a client secret',
+            );
+        });
+
+        it('sets the right path for fetch request', () => {
+            const dbxAuth = new DropboxAuth({
+                clientId: 'foo',
+                clientSecret: 'bar',
+            });
+
+            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+            dbxAuth.getAccessTokenFromCode('foo', 'bar');
+            const path = dbxAuth.fetch.getCall(0).args[0];
+            chai.assert.isTrue(fetchSpy.calledOnce);
+            chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar&redirect_uri=foo', path);
+        });
+
+        it('sets the right path without a redirect uri', () => {
+            const dbxAuth = new DropboxAuth({
+                clientId: 'foo',
+                clientSecret: 'bar',
+            });
+
+            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+            dbxAuth.getAccessTokenFromCode(undefined, 'bar');
+            const path = dbxAuth.fetch.getCall(0).args[0];
+            chai.assert.isTrue(fetchSpy.calledOnce);
+            chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar', path);
+        });
+
+        it('sets the correct headers for fetch request', () => {
+            const dbxAuth = new DropboxAuth({
+                clientId: 'foo',
+                clientSecret: 'bar',
+            });
+
+            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+            dbxAuth.getAccessTokenFromCode('foo', 'bar');
+            const { headers } = dbxAuth.fetch.getCall(0).args[1];
+            chai.assert.isTrue(fetchSpy.calledOnce);
+            chai.assert.equal(headers['Content-Type'], 'application/x-www-form-urlencoded');
+        });
     });
 
-    it('gets called when using PKCE flow', (done) => {
-      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-      const pkceSpy = sinon.spy(dbxAuth, 'generatePKCECodes');
-      dbxAuth.getAuthenticationUrl('test', null, undefined, undefined, undefined, undefined, true)
-        .then(() => {
-          chai.assert.isTrue(pkceSpy.calledOnce);
-          done();
-        })
-        .catch(done);
-    });
-  });
+    describe('checkAndRefreshAccessToken', () => {
+        it('does not refresh without refresh token or clientId', () => {
+            const dbxAuth = new DropboxAuth();
+            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+            dbxAuth.checkAndRefreshAccessToken();
+            chai.assert.isTrue(refreshSpy.notCalled);
+        });
 
-  describe('getAccessTokenFromCode', () => {
-    it('throws an error without a clientID', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.throws(
-        DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
-        Error,
-        'A client id is required. You can set the client id using .setClientId().',
-      );
-    });
+        it('doesn\'t refresh token when not past expiration time', () => {
+            const currentDate = new Date();
+            const dbxAuth = new DropboxAuth({
+                accessTokenExpiresAt: currentDate.setHours(currentDate.getHours() + 2),
+            });
+            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+            dbxAuth.checkAndRefreshAccessToken();
+            chai.assert.isTrue(refreshSpy.notCalled);
+        });
 
-    it('throws an error when not provided a client secret or code challenge', () => {
-      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-      chai.assert.throws(
-        DropboxAuth.prototype.getAccessTokenFromCode.bind(dbxAuth, 'foo', 'bar'),
-        Error,
-        'You must use PKCE when generating the authorization URL to not include a client secret',
-      );
-    });
+        it('refreshes token when past expiration', () => {
+            const dbxAuth = new DropboxAuth({
+                accessTokenExpiresAt: new Date(2019, 11, 19),
+                clientId: '123',
+                refreshToken: 'foo',
+            });
 
-    it('sets the right path for fetch request', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
-      });
-
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.getAccessTokenFromCode('foo', 'bar');
-      const path = dbxAuth.fetch.getCall(0).args[0];
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar&redirect_uri=foo', path);
+            const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
+            dbxAuth.checkAndRefreshAccessToken();
+            chai.assert.isTrue(refreshSpy.calledOnce);
+        });
     });
 
-    it('sets the right path without a redirect uri', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
-      });
+    describe('refreshAccessToken', () => {
+        it('throws an error when not provided with a clientId', () => {
+            const dbxAuth = new DropboxAuth();
+            chai.assert.throws(
+                DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth),
+                Error,
+                'A client id is required. You can set the client id using .setClientId().',
+            );
+        });
 
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.getAccessTokenFromCode(undefined, 'bar');
-      const path = dbxAuth.fetch.getCall(0).args[0];
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      chai.assert.equal('https://api.dropboxapi.com/oauth2/token?grant_type=authorization_code&code=bar&client_id=foo&client_secret=bar', path);
+        it('throws an error when provided an argument that is not a list', () => {
+            const dbxAuth = new DropboxAuth({ clientId: 'foo' });
+            chai.assert.throws(
+                DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth, 'not a list'),
+                Error,
+                'Scope must be an array of strings',
+            );
+        });
+
+        const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
+
+        it('sets the correct refresh url (no scope passed)', () => {
+            const dbxAuth = new DropboxAuth({
+                clientId: 'foo',
+                clientSecret: 'bar',
+            });
+
+            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+            dbxAuth.refreshAccessToken();
+            chai.assert.isTrue(fetchSpy.calledOnce);
+            const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+            const { headers } = dbxAuth.fetch.getCall(0).args[1];
+            chai.assert.equal(refreshUrl, testRefreshUrl);
+            chai.assert.equal(headers['Content-Type'], 'application/json');
+        });
+
+        it('sets the correct refresh url (scope passed)', () => {
+            const dbxAuth = new DropboxAuth({
+                clientId: 'foo',
+                clientSecret: 'bar',
+            });
+
+            const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+            dbxAuth.refreshAccessToken(['files.metadata.read']);
+            chai.assert.isTrue(fetchSpy.calledOnce);
+            const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+            const { headers } = dbxAuth.fetch.getCall(0).args[1];
+            const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
+            chai.assert.equal(refreshUrl, testScopeUrl);
+            chai.assert.equal(headers['Content-Type'], 'application/json');
+        });
     });
-
-    it('sets the correct headers for fetch request', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
-      });
-
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.getAccessTokenFromCode('foo', 'bar');
-      const { headers } = dbxAuth.fetch.getCall(0).args[1];
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      chai.assert.equal(headers['Content-Type'], 'application/x-www-form-urlencoded');
-    });
-  });
-
-  describe('checkAndRefreshAccessToken', () => {
-    it('does not refresh without refresh token or clientId', () => {
-      const dbxAuth = new DropboxAuth();
-      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-      dbxAuth.checkAndRefreshAccessToken();
-      chai.assert.isTrue(refreshSpy.notCalled);
-    });
-
-    it('doesn\'t refresh token when not past expiration time', () => {
-      const currentDate = new Date();
-      const dbxAuth = new DropboxAuth({
-        accessTokenExpiresAt: currentDate.setHours(currentDate.getHours() + 2),
-      });
-      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-      dbxAuth.checkAndRefreshAccessToken();
-      chai.assert.isTrue(refreshSpy.notCalled);
-    });
-
-    it('refreshes token when past expiration', () => {
-      const dbxAuth = new DropboxAuth({
-        accessTokenExpiresAt: new Date(2019, 11, 19),
-        clientId: '123',
-        refreshToken: 'foo',
-      });
-
-      const refreshSpy = sinon.spy(dbxAuth, 'refreshAccessToken');
-      dbxAuth.checkAndRefreshAccessToken();
-      chai.assert.isTrue(refreshSpy.calledOnce);
-    });
-  });
-
-  describe('refreshAccessToken', () => {
-    it('throws an error when not provided with a clientId', () => {
-      const dbxAuth = new DropboxAuth();
-      chai.assert.throws(
-        DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth),
-        Error,
-        'A client id is required. You can set the client id using .setClientId().',
-      );
-    });
-
-    it('throws an error when provided an argument that is not a list', () => {
-      const dbxAuth = new DropboxAuth({ clientId: 'foo' });
-      chai.assert.throws(
-        DropboxAuth.prototype.refreshAccessToken.bind(dbxAuth, 'not a list'),
-        Error,
-        'Scope must be an array of strings',
-      );
-    });
-
-    const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
-
-    it('sets the correct refresh url (no scope passed)', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
-      });
-
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.refreshAccessToken();
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { headers } = dbxAuth.fetch.getCall(0).args[1];
-      chai.assert.equal(refreshUrl, testRefreshUrl);
-      chai.assert.equal(headers['Content-Type'], 'application/json');
-    });
-
-    it('sets the correct refresh url (scope passed)', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
-      });
-
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.refreshAccessToken(['files.metadata.read']);
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { headers } = dbxAuth.fetch.getCall(0).args[1];
-      const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
-      chai.assert.equal(refreshUrl, testScopeUrl);
-      chai.assert.equal(headers['Content-Type'], 'application/json');
-    });
-  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,6 +120,18 @@ export class DropboxAuth {
   getAccessTokenExpiresAt(): Date;
 
   /**
+    * Sets the code verifier for PKCE flow
+    * @param {String} codeVerifier - new code verifier 
+    */
+   setCodeVerifier(codeVerifier: string): void;
+
+   /**
+     * Gets the code verifier for PKCE flow
+     * @returns {String} - code verifier for PKCE
+     */
+   getCodeVerifier(): string;
+
+  /**
    * Checks if a token is needed, can be refreshed and if the token is expired.
    * If so, attempts to refresh access token
    * @returns {Promise<*>}


### PR DESCRIPTION
- Fix PKCE in browsers by addressing base 64 encoding difference between server and client
- Add Browser PKCE example first introduced in [#593](https://github.com/dropbox/dropbox-sdk-js/pull/593)
  - Uses window.sessionStorage for redirect handling
- Add node validation tests for PKCE
- Add new `setCodeVerifier` and `getCodeVerifier` methods to handle state between redirects
- Break generation of code verifier and code challenge to allow for easier testing with hard coded values