### PR TITLE
feat(auth): refresh access token request using body params

### DIFF
--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -22,6 +22,8 @@ export interface DropboxAuthOptions {
   domainDelimiter?: string;
   // An object (in the form of header: value) designed to set custom headers to use during a request.
   customHeaders?: object;
+  // Whether request data is sent on body or as URL params. Defaults to false.
+  dataOnBody?: boolean;
 }
 
 export class DropboxAuth {

--- a/src/auth.js
+++ b/src/auth.js
@@ -349,7 +349,7 @@ export default class DropboxAuth {
      * @returns {Promise<*>}
      */
   refreshAccessToken(scope = null) {
-    let refreshUrl = OAuth2TokenUrl(this.domain, this.domainDelimiter);
+    const refreshUrl = OAuth2TokenUrl(this.domain, this.domainDelimiter);
     const clientId = this.getClientId();
     const clientSecret = this.getClientSecret();
 
@@ -362,19 +362,18 @@ export default class DropboxAuth {
 
     const headers = {};
     headers['Content-Type'] = 'application/json';
-    refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
-    refreshUrl += `&client_id=${clientId}`;
-    if (clientSecret) {
-      refreshUrl += `&client_secret=${clientSecret}`;
-    }
-    if (scope) {
-      refreshUrl += `&scope=${scope.join(' ')}`;
-    }
-    const fetchOptions = {
-      method: 'POST',
-    };
 
-    fetchOptions.headers = headers;
+    const body = { grant_type: 'refresh_token', client_id: clientId, refresh_token: this.getRefreshToken() };
+
+    if (clientSecret) {
+      body.client_secret = clientSecret;
+    }
+
+    if (scope) {
+      body.scope = scope.join(' ');
+    }
+
+    const fetchOptions = { body, headers, method: 'POST' };
 
     return this.fetch(refreshUrl, fetchOptions)
       .then((res) => parseResponse(res))

--- a/src/auth.js
+++ b/src/auth.js
@@ -55,6 +55,8 @@ const IncludeGrantedScopes = ['none', 'user', 'team'];
  * subdomain. This should only be used for testing as scaffolding.
  * @arg {Object} [options.customHeaders] - An object (in the form of header: value) designed to set
  * custom headers to use during a request.
+ * @arg {Boolean} [options.dataOnBody] - Whether request data is sent on body or as URL params.
+  * Defaults to false.
 */
 export default class DropboxAuth {
   constructor(options) {
@@ -70,6 +72,7 @@ export default class DropboxAuth {
     this.domain = options.domain;
     this.domainDelimiter = options.domainDelimiter;
     this.customHeaders = options.customHeaders;
+    this.dataOnBody = options.dataOnBody;
   }
 
   /**
@@ -349,7 +352,6 @@ export default class DropboxAuth {
      * @returns {Promise<*>}
      */
   refreshAccessToken(scope = null) {
-    const refreshUrl = OAuth2TokenUrl(this.domain, this.domainDelimiter);
     const clientId = this.getClientId();
     const clientSecret = this.getClientSecret();
 
@@ -360,20 +362,33 @@ export default class DropboxAuth {
       throw new Error('Scope must be an array of strings');
     }
 
-    const headers = {};
-    headers['Content-Type'] = 'application/json';
+    let refreshUrl = OAuth2TokenUrl(this.domain, this.domainDelimiter);
+    const fetchOptions = {
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    };
 
-    const body = { grant_type: 'refresh_token', client_id: clientId, refresh_token: this.getRefreshToken() };
+    if (this.dataOnBody) {
+      const body = { grant_type: 'refresh_token', client_id: clientId, refresh_token: this.getRefreshToken() };
 
-    if (clientSecret) {
-      body.client_secret = clientSecret;
+      if (clientSecret) {
+        body.client_secret = clientSecret;
+      }
+      if (scope) {
+        body.scope = scope.join(' ');
+      }
+
+      fetchOptions.body = body;
+    } else {
+      refreshUrl += `?grant_type=refresh_token&refresh_token=${this.getRefreshToken()}`;
+      refreshUrl += `&client_id=${clientId}`;
+      if (clientSecret) {
+        refreshUrl += `&client_secret=${clientSecret}`;
+      }
+      if (scope) {
+        refreshUrl += `&scope=${scope.join(' ')}`;
+      }
     }
-
-    if (scope) {
-      body.scope = scope.join(' ');
-    }
-
-    const fetchOptions = { body, headers, method: 'POST' };
 
     return this.fetch(refreshUrl, fetchOptions)
       .then((res) => parseResponse(res))

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -160,6 +160,18 @@ describe('DropboxAuth', () => {
     });
   });
 
+  describe('dataOnBody', () => {
+    it('can be set in the constructor', () => {
+      const dbx = new DropboxAuth({ dataOnBody: true });
+      chai.assert.equal(dbx.dataOnBody, true);
+    });
+
+    it('is undefined if not set in constructor', () => {
+      const dbx = new DropboxAuth();
+      chai.assert.equal(dbx.dataOnBody, undefined);
+    });
+  });
+
   describe('refreshToken', () => {
     it('can be set in the constructor', () => {
       const dbxAuth = new DropboxAuth({ refreshToken: 'foo' });
@@ -366,9 +378,7 @@ describe('DropboxAuth', () => {
       );
     });
 
-    const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token';
-
-    it('sets the correct refresh body (no scope passed)', () => {
+    it('sets request content type to json', () => {
       const dbxAuth = new DropboxAuth({
         clientId: 'foo',
         clientSecret: 'bar',
@@ -377,33 +387,97 @@ describe('DropboxAuth', () => {
       const fetchSpy = sinon.spy(dbxAuth, 'fetch');
       dbxAuth.refreshAccessToken();
       chai.assert.isTrue(fetchSpy.calledOnce);
-      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { body, headers } = dbxAuth.fetch.getCall(0).args[1];
-      chai.assert.equal(refreshUrl, testRefreshUrl);
+
+      const { headers } = dbxAuth.fetch.getCall(0).args[1];
       chai.assert.equal(headers['Content-Type'], 'application/json');
-      chai.assert.equal(body.grant_type, 'refresh_token');
-      chai.assert.equal(body.client_id, 'foo');
-      chai.assert.equal(body.client_secret, 'bar');
-      chai.assert.notProperty(body, 'scope');
     });
 
-    it('sets the correct refresh body (scope passed)', () => {
-      const dbxAuth = new DropboxAuth({
-        clientId: 'foo',
-        clientSecret: 'bar',
+    describe('when dataOnBody flag is enabled', () => {
+      const dataOnBody = true;
+
+      it('does the request without URL parameters', () => {
+        const dbxAuth = new DropboxAuth({
+          clientId: 'foo',
+          clientSecret: 'bar',
+          dataOnBody,
+        });
+
+        const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+        dbxAuth.refreshAccessToken(['files.metadata.read']);
+        chai.assert.isTrue(fetchSpy.calledOnce);
+        const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+
+        chai.assert.equal(refreshUrl, 'https://api.dropboxapi.com/oauth2/token');
       });
 
-      const fetchSpy = sinon.spy(dbxAuth, 'fetch');
-      dbxAuth.refreshAccessToken(['files.metadata.read']);
-      chai.assert.isTrue(fetchSpy.calledOnce);
-      const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { body, headers } = dbxAuth.fetch.getCall(0).args[1];
-      chai.assert.equal(refreshUrl, testRefreshUrl);
-      chai.assert.equal(headers['Content-Type'], 'application/json');
-      chai.assert.equal(body.grant_type, 'refresh_token');
-      chai.assert.equal(body.client_id, 'foo');
-      chai.assert.equal(body.client_secret, 'bar');
-      chai.assert.equal(body.scope, 'files.metadata.read');
+      it('sends the client id and secret in the body', () => {
+        const dbxAuth = new DropboxAuth({
+          clientId: 'foo',
+          clientSecret: 'bar',
+          dataOnBody,
+        });
+
+        const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+        dbxAuth.refreshAccessToken();
+        chai.assert.isTrue(fetchSpy.calledOnce);
+
+        const { body } = dbxAuth.fetch.getCall(0).args[1];
+        chai.assert.equal(body.client_id, 'foo');
+        chai.assert.equal(body.client_secret, 'bar');
+      });
+
+      it('sends the scope in the body when passed', () => {
+        const dbxAuth = new DropboxAuth({
+          clientId: 'foo',
+          clientSecret: 'bar',
+          dataOnBody,
+        });
+
+        const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+        dbxAuth.refreshAccessToken(['files.metadata.read']);
+        chai.assert.isTrue(fetchSpy.calledOnce);
+
+        const { body } = dbxAuth.fetch.getCall(0).args[1];
+        chai.assert.equal(body.scope, 'files.metadata.read');
+      });
+    });
+
+    describe('when dataOnBody flag is disabled', () => {
+      const dataOnBody = false;
+      const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
+
+      it('sets the correct refresh url (no scope passed)', () => {
+        const dbxAuth = new DropboxAuth({
+          clientId: 'foo',
+          clientSecret: 'bar',
+          dataOnBody,
+        });
+
+        const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+        dbxAuth.refreshAccessToken();
+        chai.assert.isTrue(fetchSpy.calledOnce);
+        const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+        const { headers } = dbxAuth.fetch.getCall(0).args[1];
+        chai.assert.equal(refreshUrl, testRefreshUrl);
+        chai.assert.equal(headers['Content-Type'], 'application/json');
+      });
+
+      it('sets the correct refresh url (scope passed)', () => {
+        const dbxAuth = new DropboxAuth({
+          clientId: 'foo',
+          clientSecret: 'bar',
+          dataOnBody,
+        });
+
+        const fetchSpy = sinon.spy(dbxAuth, 'fetch');
+        dbxAuth.refreshAccessToken(['files.metadata.read']);
+        chai.assert.isTrue(fetchSpy.calledOnce);
+        const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
+        const { headers } = dbxAuth.fetch.getCall(0).args[1];
+        const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
+        chai.assert.equal(refreshUrl, testScopeUrl);
+        chai.assert.equal(headers['Content-Type'], 'application/json');
+      });
     });
   });
 });

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -366,9 +366,9 @@ describe('DropboxAuth', () => {
       );
     });
 
-    const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token?grant_type=refresh_token&refresh_token=undefined&client_id=foo&client_secret=bar';
+    const testRefreshUrl = 'https://api.dropboxapi.com/oauth2/token';
 
-    it('sets the correct refresh url (no scope passed)', () => {
+    it('sets the correct refresh body (no scope passed)', () => {
       const dbxAuth = new DropboxAuth({
         clientId: 'foo',
         clientSecret: 'bar',
@@ -378,12 +378,16 @@ describe('DropboxAuth', () => {
       dbxAuth.refreshAccessToken();
       chai.assert.isTrue(fetchSpy.calledOnce);
       const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { headers } = dbxAuth.fetch.getCall(0).args[1];
+      const { body, headers } = dbxAuth.fetch.getCall(0).args[1];
       chai.assert.equal(refreshUrl, testRefreshUrl);
       chai.assert.equal(headers['Content-Type'], 'application/json');
+      chai.assert.equal(body.grant_type, 'refresh_token');
+      chai.assert.equal(body.client_id, 'foo');
+      chai.assert.equal(body.client_secret, 'bar');
+      chai.assert.notProperty(body, 'scope');
     });
 
-    it('sets the correct refresh url (scope passed)', () => {
+    it('sets the correct refresh body (scope passed)', () => {
       const dbxAuth = new DropboxAuth({
         clientId: 'foo',
         clientSecret: 'bar',
@@ -393,10 +397,13 @@ describe('DropboxAuth', () => {
       dbxAuth.refreshAccessToken(['files.metadata.read']);
       chai.assert.isTrue(fetchSpy.calledOnce);
       const refreshUrl = dbxAuth.fetch.getCall(0).args[0];
-      const { headers } = dbxAuth.fetch.getCall(0).args[1];
-      const testScopeUrl = `${testRefreshUrl}&scope=files.metadata.read`;
-      chai.assert.equal(refreshUrl, testScopeUrl);
+      const { body, headers } = dbxAuth.fetch.getCall(0).args[1];
+      chai.assert.equal(refreshUrl, testRefreshUrl);
       chai.assert.equal(headers['Content-Type'], 'application/json');
+      chai.assert.equal(body.grant_type, 'refresh_token');
+      chai.assert.equal(body.client_id, 'foo');
+      chai.assert.equal(body.client_secret, 'bar');
+      chai.assert.equal(body.scope, 'files.metadata.read');
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,8 @@ export interface DropboxAuthOptions {
   domainDelimiter?: string;
   // An object (in the form of header: value) designed to set custom headers to use during a request.
   customHeaders?: object;
+  // Whether request data is sent on body or as URL params. Defaults to false.
+  dataOnBody?: boolean;
 }
 
 export class DropboxAuth {


### PR DESCRIPTION
When refreshing authorization access token, send the end point parameters via body instead of URL.

This prevents intermediate proxies or logs to accidentally (or not) expose secret values.

Fix #813

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `npm test` pass?
- [x] Does `npm run build` pass?
- [x] Does `npm run lint` pass?