### PR TITLE
Dropbox SDK is now aware of the service worker environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "10.28.0",
+    "version": "10.29.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "10.28.0",
+    "version": "10.29.0",
     "registry": "npm",
     "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
     "main": "cjs/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,6 +57,10 @@ export function isBrowserEnv() {
   return typeof window !== 'undefined';
 }
 
+export function isWorkerEnv() {
+  return typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope; // eslint-disable-line no-restricted-globals
+}
+
 export function createBrowserSafeString(toBeConverted) {
   const convertedString = toBeConverted.toString('base64')
     .replace(/\+/g, '-')

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,4 +1,3 @@
-import { fail } from 'assert';
 import chai from 'chai';
 import {
   baseApiUrl,
@@ -6,6 +5,7 @@ import {
   isWindowOrWorker,
   OAuth2AuthorizationUrl,
   OAuth2TokenUrl,
+  isWorkerEnv,
 } from '../../src/utils.js';
 
 describe('Dropbox utils', () => {
@@ -79,5 +79,11 @@ describe('isWindowOrWorker', () => {
   it('returns false when not window or of type WorkerGlobalScope', () => {
     const testEnv = isWindowOrWorker();
     chai.assert.isFalse(testEnv);
+  });
+});
+
+describe('isWorkerEnv', () => {
+  it('returns false when not running in a service worker env', () => {
+    chai.assert.isFalse(isWorkerEnv());
   });
 });


### PR DESCRIPTION
When running the current version of Dropbox SDK in a service worker environment, `fetch` and `crypto` API will make issues.

The root cause of the issues is that service worker uses its own global space than that of browsers and NodeJS envs. Hence, in this PR, a function `isWorkerEnv` is introduced, and if SDK runs on a service worker, `fetch` and `crypto` API is fetched from the worker's global space.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `npm test` pass?
- [x] Does `npm run build` pass?
- [x] Does `npm run lint` pass?