### PR TITLE
Automated Spec Update

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -693,6 +693,7 @@ routes.filesDownload = function (arg) {
  * less than 20 GB in size and any single file within must be less than 4 GB in
  * size. The resulting zip must have fewer than 10,000 total file and folder
  * entries, including the top level folder. The input cannot be a single file.
+ * Note: this endpoint does not support HTTP range requests.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#filesDownloadZip
@@ -1997,7 +1998,7 @@ routes.sharingGetSharedLinkFile = function (arg) {
  * @returns {Promise.<DropboxResponse<(SharingFileLinkMetadata|SharingFolderLinkMetadata|SharingSharedLinkMetadata)>, DropboxResponseError.<SharingSharedLinkError>>}
  */
 routes.sharingGetSharedLinkMetadata = function (arg) {
-  return this.request('sharing/get_shared_link_metadata', arg, 'user', 'api', 'rpc', 'sharing.read');
+  return this.request('sharing/get_shared_link_metadata', arg, 'app, user', 'api', 'rpc', 'sharing.read');
 };
 
 /**
@@ -2673,39 +2674,39 @@ routes.teamGroupsUpdate = function (arg) {
  * Creates new legal hold policy. Note: Legal Holds is a paid add-on. Not all
  * teams have the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsCreatePolicy
  * @arg {TeamLegalHoldsPolicyCreateArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsPolicyCreateError>>}
  */
 routes.teamLegalHoldsCreatePolicy = function (arg) {
-  return this.request('team/legal_holds/create_policy', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/create_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
  * Gets a legal hold by Id. Note: Legal Holds is a paid add-on. Not all teams
  * have the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsGetPolicy
  * @arg {TeamLegalHoldsGetPolicyArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsGetPolicyError>>}
  */
 routes.teamLegalHoldsGetPolicy = function (arg) {
-  return this.request('team/legal_holds/get_policy', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/get_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
  * List the file metadata that's under the hold. Note: Legal Holds is a paid
  * add-on. Not all teams have the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListHeldRevisions
  * @arg {TeamLegalHoldsListHeldRevisionsArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListHeldRevisionResult>, DropboxResponseError.<TeamLegalHoldsListHeldRevisionsError>>}
  */
 routes.teamLegalHoldsListHeldRevisions = function (arg) {
-  return this.request('team/legal_holds/list_held_revisions', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/list_held_revisions', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
@@ -2713,52 +2714,52 @@ routes.teamLegalHoldsListHeldRevisions = function (arg) {
  * is a paid add-on. Not all teams have the feature. Permission : Team member
  * file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListHeldRevisionsContinue
  * @arg {TeamLegalHoldsListHeldRevisionsContinueArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListHeldRevisionResult>, DropboxResponseError.<TeamLegalHoldsListHeldRevisionsError>>}
  */
 routes.teamLegalHoldsListHeldRevisionsContinue = function (arg) {
-  return this.request('team/legal_holds/list_held_revisions_continue', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/list_held_revisions_continue', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
  * Lists legal holds on a team. Note: Legal Holds is a paid add-on. Not all
  * teams have the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListPolicies
  * @arg {TeamLegalHoldsListPoliciesArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListPoliciesResult>, DropboxResponseError.<TeamLegalHoldsListPoliciesError>>}
  */
 routes.teamLegalHoldsListPolicies = function (arg) {
-  return this.request('team/legal_holds/list_policies', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/list_policies', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
  * Releases a legal hold by Id. Note: Legal Holds is a paid add-on. Not all
  * teams have the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsReleasePolicy
  * @arg {TeamLegalHoldsPolicyReleaseArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamLegalHoldsPolicyReleaseError>>}
  */
 routes.teamLegalHoldsReleasePolicy = function (arg) {
-  return this.request('team/legal_holds/release_policy', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/release_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
  * Updates a legal hold. Note: Legal Holds is a paid add-on. Not all teams have
  * the feature. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.member
+ *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsUpdatePolicy
  * @arg {TeamLegalHoldsPolicyUpdateArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsPolicyUpdateError>>}
  */
 routes.teamLegalHoldsUpdatePolicy = function (arg) {
-  return this.request('team/legal_holds/update_policy', arg, 'team', 'api', 'rpc', 'team_data.member');
+  return this.request('team/legal_holds/update_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
 };
 
 /**
@@ -3471,13 +3472,13 @@ routes.teamReportsGetStorage = function (arg) {
  * Sets an archived team folder's status to active. Permission : Team member
  * file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderActivate
  * @arg {TeamTeamFolderIdArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderActivateError>>}
  */
 routes.teamTeamFolderActivate = function (arg) {
-  return this.request('team/team_folder/activate', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/activate', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
@@ -3485,26 +3486,26 @@ routes.teamTeamFolderActivate = function (arg) {
  * file members. This endpoint cannot be used for teams that have a shared team
  * space. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderArchive
  * @arg {TeamTeamFolderArchiveArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderArchiveLaunch>, DropboxResponseError.<TeamTeamFolderArchiveError>>}
  */
 routes.teamTeamFolderArchive = function (arg) {
-  return this.request('team/team_folder/archive', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/archive', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
  * Returns the status of an asynchronous job for archiving a team folder.
  * Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderArchiveCheck
  * @arg {AsyncPollArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderArchiveJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
 routes.teamTeamFolderArchiveCheck = function (arg) {
-  return this.request('team/team_folder/archive/check', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/archive/check', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
@@ -3512,88 +3513,88 @@ routes.teamTeamFolderArchiveCheck = function (arg) {
  * used for teams that do not already have a shared team space. Permission :
  * Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderCreate
  * @arg {TeamTeamFolderCreateArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderCreateError>>}
  */
 routes.teamTeamFolderCreate = function (arg) {
-  return this.request('team/team_folder/create', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/create', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
  * Retrieves metadata for team folders. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderGetInfo
  * @arg {TeamTeamFolderIdListArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<Array.<TeamTeamFolderGetInfoItem>>, DropboxResponseError.<void>>}
  */
 routes.teamTeamFolderGetInfo = function (arg) {
-  return this.request('team/team_folder/get_info', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/get_info', arg, 'team', 'api', 'rpc', 'team_data.content.read');
 };
 
 /**
  * Lists all team folders. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderList
  * @arg {TeamTeamFolderListArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderListResult>, DropboxResponseError.<TeamTeamFolderListError>>}
  */
 routes.teamTeamFolderList = function (arg) {
-  return this.request('team/team_folder/list', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/list', arg, 'team', 'api', 'rpc', 'team_data.content.read');
 };
 
 /**
  * Once a cursor has been retrieved from team_folder/list, use this to paginate
  * through all team folders. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderListContinue
  * @arg {TeamTeamFolderListContinueArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderListResult>, DropboxResponseError.<TeamTeamFolderListContinueError>>}
  */
 routes.teamTeamFolderListContinue = function (arg) {
-  return this.request('team/team_folder/list/continue', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/list/continue', arg, 'team', 'api', 'rpc', 'team_data.content.read');
 };
 
 /**
  * Permanently deletes an archived team folder. This endpoint cannot be used for
  * teams that have a shared team space. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderPermanentlyDelete
  * @arg {TeamTeamFolderIdArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamTeamFolderPermanentlyDeleteError>>}
  */
 routes.teamTeamFolderPermanentlyDelete = function (arg) {
-  return this.request('team/team_folder/permanently_delete', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/permanently_delete', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
  * Changes an active team folder's name. Permission : Team member file access.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderRename
  * @arg {TeamTeamFolderRenameArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderRenameError>>}
  */
 routes.teamTeamFolderRename = function (arg) {
-  return this.request('team/team_folder/rename', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/rename', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**
  * Updates the sync settings on a team folder or its contents.  Use of this
  * endpoint requires that the team has team selective sync enabled.
  * Route attributes:
- *   scope: team_data.team_space
+ *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderUpdateSyncSettings
  * @arg {TeamTeamFolderUpdateSyncSettingsArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderUpdateSyncSettingsError>>}
  */
 routes.teamTeamFolderUpdateSyncSettings = function (arg) {
-  return this.request('team/team_folder/update_sync_settings', arg, 'team', 'api', 'rpc', 'team_data.team_space');
+  return this.request('team/team_folder/update_sync_settings', arg, 'team', 'api', 'rpc', 'team_data.content.write');
 };
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -7218,6 +7218,8 @@ only present when needed to discriminate between multiple possible subtypes.
  * Sensitivity level.
  * @property {TeamLogRecipientsConfiguration} [recipients_settings] - Recipient
  * settings.
+ * @property {string} [text] - Text.
+ * @property {string} [excluded_file_extensions] - Excluded file extensions.
  */
 
 /**
@@ -14287,7 +14289,7 @@ subtypes.
 
 /**
  * @typedef {Object} TeamLogPlacementRestriction
- * @property {('australia_only'|'europe_only'|'japan_only'|'none'|'uk_only'|'other')} .tag - Tag identifying the union variant.
+ * @property {('australia_only'|'europe_only'|'japan_only'|'none'|'uk_only'|'us_s3_only'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "10.29.0",
+    "version": "10.30.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "10.29.0",
+    "version": "10.30.0",
     "registry": "npm",
     "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
     "main": "cjs/index.js",

--- a/types/dropbox_types.d.ts
+++ b/types/dropbox_types.d.ts
@@ -15948,6 +15948,14 @@
        * Recipient settings.
        */
       recipients_settings?: RecipientsConfiguration;
+      /**
+       * Text.
+       */
+      text?: string;
+      /**
+       * Excluded file extensions.
+       */
+      excluded_file_extensions?: string;
     }
 
     export interface AdminAlertingAlertSensitivityHigh {
@@ -31734,11 +31742,15 @@
       '.tag': 'uk_only';
     }
 
+    export interface PlacementRestrictionUsS3Only {
+      '.tag': 'us_s3_only';
+    }
+
     export interface PlacementRestrictionOther {
       '.tag': 'other';
     }
 
-    export type PlacementRestriction = PlacementRestrictionAustraliaOnly | PlacementRestrictionEuropeOnly | PlacementRestrictionJapanOnly | PlacementRestrictionNone | PlacementRestrictionUkOnly | PlacementRestrictionOther;
+    export type PlacementRestriction = PlacementRestrictionAustraliaOnly | PlacementRestrictionEuropeOnly | PlacementRestrictionJapanOnly | PlacementRestrictionNone | PlacementRestrictionUkOnly | PlacementRestrictionUsS3Only | PlacementRestrictionOther;
 
     export interface PolicyTypeDisposition {
       '.tag': 'disposition';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -943,7 +943,7 @@ export class Dropbox {
      * be less than 20 GB in size and any single file within must be less than 4
      * GB in size. The resulting zip must have fewer than 10,000 total file and
      * folder entries, including the top level folder. The input cannot be a
-     * single file.
+     * single file. Note: this endpoint does not support HTTP range requests.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -2955,7 +2955,7 @@ export class Dropbox {
      * all teams have the feature. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyCreateError>.
@@ -2968,7 +2968,7 @@ export class Dropbox {
      * teams have the feature. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsGetPolicyError>.
@@ -2982,7 +2982,7 @@ export class Dropbox {
      * access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListHeldRevisionsError>.
@@ -2996,7 +2996,7 @@ export class Dropbox {
      * member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListHeldRevisionsError>.
@@ -3009,7 +3009,7 @@ export class Dropbox {
      * teams have the feature. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListPoliciesError>.
@@ -3022,7 +3022,7 @@ export class Dropbox {
      * teams have the feature. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyReleaseError>.
@@ -3035,7 +3035,7 @@ export class Dropbox {
      * have the feature. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.member
+     *   scope: team_data.governance.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyUpdateError>.
@@ -3766,7 +3766,7 @@ export class Dropbox {
      * file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderActivateError>.
@@ -3780,7 +3780,7 @@ export class Dropbox {
      * shared team space. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderArchiveError>.
@@ -3793,7 +3793,7 @@ export class Dropbox {
      * Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
@@ -3807,7 +3807,7 @@ export class Dropbox {
      * Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderCreateError>.
@@ -3820,7 +3820,7 @@ export class Dropbox {
      * access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.read
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
@@ -3832,7 +3832,7 @@ export class Dropbox {
      * Lists all team folders. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.read
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderListError>.
@@ -3845,7 +3845,7 @@ export class Dropbox {
      * paginate through all team folders. Permission : Team member file access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.read
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderListContinueError>.
@@ -3859,7 +3859,7 @@ export class Dropbox {
      * access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderPermanentlyDeleteError>.
@@ -3872,7 +3872,7 @@ export class Dropbox {
      * access.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderRenameError>.
@@ -3885,7 +3885,7 @@ export class Dropbox {
      * endpoint requires that the team has team selective sync enabled.
      *
      * Route attributes:
-     *   scope: team_data.team_space
+     *   scope: team_data.content.write
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderUpdateSyncSettingsError>.


### PR DESCRIPTION
Automated Spec Update 
 69f7bb2ea7702db5564f12549efb23956c5d6329 

 Change Notes:

files Namespace
- Update examples

shared_links Namespace
- Update get_shared_link_metadata route to include app and user auth

team_folders Namespace
- Update team_folder/create, team_folder/rename, team_folder/list, team_folder/list/continue, team_folder/get_info, team_folder/activate, team_folder/archive, team_folder/archive/check, team_folder/permanently_delete, team_folder/update_sync_settings routes to include updated scopes

team_legal_holds Namespace
- Update legal_holds/create_policy, legal_holds/get_policy, legal_holds/list_policies, legal_holds/list_held_revisions, legal_holds/list_held_revisions_continue, legal_holds/update_policy, legal_holds/release_policy routes to include updated scopes
team_log_generated Namespace
- Update AdminAlertingAlertConfiguration to include text and excluded_file_extensions
- Update PlacementRestriction to include us_s3_only
- Update examples

Co-authored-by: Brent Bumann <bbumann@dropbox.com>

 ef6b1680d9a05ec7475f503149d771e44db913a2 

 Change Notes:

files Namespace
- Add upload_session/start_batch  routes
- Add UploadSessionStartBatchArg, UploadSessionStartBatchResult structs

team_log_generated Namespace
- Add ExternalDriveBackupEligibilityStatusCheckedDetails, ExternalDriveBackupStatusChangedDetails, ExternalDriveBackupEligibilityStatusCheckedType, ExternalDriveBackupStatusChangedType structs
- Add ExternalDriveBackupEligibilityStatus, ExternalDriveBackupStatus unions

Co-authored-by: Brent Bumann <bbumann@dropbox.com>