### PR TITLE
fix: crash on node v21 (#1130)

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -55,7 +55,7 @@ export default class DropboxAuth {
       crypto = self.crypto;
       /* eslint-enable no-restricted-globals */
     } else {
-      fetch = require('node-fetch'); // eslint-disable-line global-require
+      fetch = options.fetch || require('node-fetch'); // eslint-disable-line global-require
       crypto = require('crypto'); // eslint-disable-line global-require
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Fix of an issue from #1130 related to `node-fetch` and deprecated `punycode`

<img width="936" alt="image" src="https://github.com/dropbox/dropbox-sdk-js/assets/1573141/6c07ae4f-851f-4dd8-8f11-7e95419bd513">

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `npm test` pass?
- [x] Does `npm run build` pass?
- [x] Does `npm run lint` pass?