### PR TITLE
Update GitHub Actions to latest versions and Node.js to 22/24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         node: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
@@ -38,33 +38,45 @@ jobs:
           npm run build
           npm run test:build
   Integration:
-    continue-on-error: true
+    # Fork PRs cannot assume the AWS OIDC role used to fetch credentials.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+      contents: read
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest]
         node: [22, 24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
         run: npm install
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-js-repo
+          aws-region: us-west-2
+      - name: Get integration credentials from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CREDS,api-sdk-integration-test-creds
+          parse-json-secrets: true
       - name: Run Integration Tests
         env:
-          LEGACY_USER_DROPBOX_TOKEN: ${{ secrets.LEGACY_USER_DROPBOX_TOKEN }}
-          LEGACY_USER_CLIENT_ID: ${{ secrets.LEGACY_USER_CLIENT_ID }}
-          LEGACY_USER_CLIENT_SECRET: ${{ secrets.LEGACY_USER_CLIENT_SECRET }}
-          LEGACY_USER_REFRESH_TOKEN: ${{ secrets.LEGACY_USER_REFRESH_TOKEN }}
-          SCOPED_USER_DROPBOX_TOKEN: ${{ secrets.SCOPED_USER_DROPBOX_TOKEN }}
-          SCOPED_USER_CLIENT_ID: ${{ secrets.SCOPED_USER_CLIENT_ID }}
-          SCOPED_USER_CLIENT_SECRET: ${{ secrets.SCOPED_USER_CLIENT_SECRET }}
-          SCOPED_USER_REFRESH_TOKEN: ${{ secrets.SCOPED_USER_REFRESH_TOKEN }}
-          SCOPED_TEAM_DROPBOX_TOKEN: ${{ secrets.SCOPED_TEAM_DROPBOX_TOKEN }}
-          SCOPED_TEAM_CLIENT_ID: ${{ secrets.SCOPED_TEAM_CLIENT_ID }}
-          SCOPED_TEAM_CLIENT_SECRET: ${{ secrets.SCOPED_TEAM_CLIENT_SECRET }}
-          SCOPED_TEAM_REFRESH_TOKEN: ${{ secrets.SCOPED_TEAM_REFRESH_TOKEN }}
-          DROPBOX_SHARED_LINK: ${{ secrets.DROPBOX_SHARED_LINK }}
+          SCOPED_USER_CLIENT_ID: ${{ env.CREDS_SCOPED_USER_CLIENT_ID }}
+          SCOPED_USER_CLIENT_SECRET: ${{ env.CREDS_SCOPED_USER_CLIENT_SECRET }}
+          SCOPED_USER_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_USER_REFRESH_TOKEN }}
+          SCOPED_TEAM_CLIENT_ID: ${{ env.CREDS_SCOPED_TEAM_CLIENT_ID }}
+          SCOPED_TEAM_CLIENT_SECRET: ${{ env.CREDS_SCOPED_TEAM_CLIENT_SECRET }}
+          SCOPED_TEAM_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_TEAM_REFRESH_TOKEN }}
+          DROPBOX_SHARED_LINK: ${{ env.CREDS_DROPBOX_SHARED_LINK }}
         run: npm run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   CI:
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 24, 26]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js environment
@@ -38,11 +38,12 @@ jobs:
           npm run build
           npm run test:build
   Integration:
+    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 24, 26]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,41 +5,33 @@ on:
 
 jobs:
   CI:
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [10, 11, 12, 13, 14]
+        node: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
-        run: |
-          npm install
+        run: npm install
       - name: Run Build
-        run: |
-          npm run build
+        run: npm run build
       - name: Run Examples Builds
         run: |
           cd examples/typescript/
           npm install
           npm run build
-          cd ../..
       - name: Run Linter
-        run: |
-          npm run lint
+        run: npm run lint
       - name: Run Unit Tests
-        run: |
-          npm run test:unit
-      - name: Run TypeScipt Tests
-        run: |
-          npm run test:typescript
+        run: npm run test:unit
+      - name: Run TypeScript Tests
+        run: npm run test:typescript
       - name: Run Build Tests
-        if: matrix.node >= 12 # "type" = "module" was introduced in node v12 so lower versions will fail ESM tests
         run: |
           npm run clean
           npm run build
@@ -49,16 +41,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [14] # Can only be ran on 14 because it relies on fs/promises
+        node: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
-        run: |
-          npm install
+        run: npm install
       - name: Run Integration Tests
         env:
           LEGACY_USER_DROPBOX_TOKEN: ${{ secrets.LEGACY_USER_DROPBOX_TOKEN }}
@@ -74,5 +65,4 @@ jobs:
           SCOPED_TEAM_CLIENT_SECRET: ${{ secrets.SCOPED_TEAM_CLIENT_SECRET }}
           SCOPED_TEAM_REFRESH_TOKEN: ${{ secrets.SCOPED_TEAM_REFRESH_TOKEN }}
           DROPBOX_SHARED_LINK: ${{ secrets.DROPBOX_SHARED_LINK }}
-        run: |
-          npm run test:integration
+        run: npm run test:integration

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,7 @@
 name: CodeCov
 on:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
   schedule:
@@ -11,33 +11,30 @@ jobs:
   Unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '22'
       - name: Install SDK
-        run: |
-          npm install
+        run: npm install
       - name: Generate Unit Test Coverage
-        run: |
-          npm run coverage:unit
+        run: npm run coverage:unit
       - name: Publish Coverage
-        uses: codecov/codecov-action@v1.5.0
+        uses: codecov/codecov-action@v5
         with:
           flags: unit
           fail_ci_if_error: true
   Integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '22'
       - name: Install SDK
-        run: |
-          npm install
+        run: npm install
       - name: Generate Integration Test Coverage
         env:
           LEGACY_USER_DROPBOX_TOKEN: ${{ secrets.LEGACY_USER_DROPBOX_TOKEN }}
@@ -53,10 +50,9 @@ jobs:
           SCOPED_TEAM_CLIENT_SECRET: ${{ secrets.SCOPED_TEAM_CLIENT_SECRET }}
           SCOPED_TEAM_REFRESH_TOKEN: ${{ secrets.SCOPED_TEAM_REFRESH_TOKEN }}
           DROPBOX_SHARED_LINK: ${{ secrets.DROPBOX_SHARED_LINK }}
-        run: |
-          npm run coverage:integration
+        run: npm run coverage:integration
       - name: Publish Coverage
-        uses: codecov/codecov-action@v1.5.0
+        uses: codecov/codecov-action@v5
         with:
           flags: integration
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,48 +11,97 @@ jobs:
   Unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
       - name: Install SDK
         run: npm install
       - name: Generate Unit Test Coverage
         run: npm run coverage:unit
-      - name: Publish Coverage
-        uses: codecov/codecov-action@v5
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: unit-coverage
+          path: coverage/lcov.info
+  CoverageUpload:
+    needs: Unit
+    # Fork PRs cannot assume the AWS OIDC role used to fetch the Codecov token.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-coverage
+          path: coverage
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-js-repo
+          aws-region: us-west-2
+      - name: Get Codecov token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CODECOV_TOKEN,codecov-token-dropbox-sdk-js
+          parse-json-secrets: false
+      - name: Publish Coverage
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
           flags: unit
           fail_ci_if_error: true
   Integration:
+    # Fork PRs cannot assume the AWS OIDC role used to fetch credentials.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
       - name: Install SDK
         run: npm install
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-js-repo
+          aws-region: us-west-2
+      - name: Get integration credentials from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CREDS,api-sdk-integration-test-creds
+          parse-json-secrets: true
+      - name: Get Codecov token from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        with:
+          secret-ids: |
+            CODECOV_TOKEN,codecov-token-dropbox-sdk-js
+          parse-json-secrets: false
       - name: Generate Integration Test Coverage
         env:
-          LEGACY_USER_DROPBOX_TOKEN: ${{ secrets.LEGACY_USER_DROPBOX_TOKEN }}
-          LEGACY_USER_CLIENT_ID: ${{ secrets.LEGACY_USER_CLIENT_ID }}
-          LEGACY_USER_CLIENT_SECRET: ${{ secrets.LEGACY_USER_CLIENT_SECRET }}
-          LEGACY_USER_REFRESH_TOKEN: ${{ secrets.LEGACY_USER_REFRESH_TOKEN }}
-          SCOPED_USER_DROPBOX_TOKEN: ${{ secrets.SCOPED_USER_DROPBOX_TOKEN }}
-          SCOPED_USER_CLIENT_ID: ${{ secrets.SCOPED_USER_CLIENT_ID }}
-          SCOPED_USER_CLIENT_SECRET: ${{ secrets.SCOPED_USER_CLIENT_SECRET }}
-          SCOPED_USER_REFRESH_TOKEN: ${{ secrets.SCOPED_USER_REFRESH_TOKEN }}
-          SCOPED_TEAM_DROPBOX_TOKEN: ${{ secrets.SCOPED_TEAM_DROPBOX_TOKEN }}
-          SCOPED_TEAM_CLIENT_ID: ${{ secrets.SCOPED_TEAM_CLIENT_ID }}
-          SCOPED_TEAM_CLIENT_SECRET: ${{ secrets.SCOPED_TEAM_CLIENT_SECRET }}
-          SCOPED_TEAM_REFRESH_TOKEN: ${{ secrets.SCOPED_TEAM_REFRESH_TOKEN }}
-          DROPBOX_SHARED_LINK: ${{ secrets.DROPBOX_SHARED_LINK }}
+          SCOPED_USER_CLIENT_ID: ${{ env.CREDS_SCOPED_USER_CLIENT_ID }}
+          SCOPED_USER_CLIENT_SECRET: ${{ env.CREDS_SCOPED_USER_CLIENT_SECRET }}
+          SCOPED_USER_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_USER_REFRESH_TOKEN }}
+          SCOPED_TEAM_CLIENT_ID: ${{ env.CREDS_SCOPED_TEAM_CLIENT_ID }}
+          SCOPED_TEAM_CLIENT_SECRET: ${{ env.CREDS_SCOPED_TEAM_CLIENT_SECRET }}
+          SCOPED_TEAM_REFRESH_TOKEN: ${{ env.CREDS_SCOPED_TEAM_REFRESH_TOKEN }}
+          DROPBOX_SHARED_LINK: ${{ env.CREDS_DROPBOX_SHARED_LINK }}
         run: npm run coverage:integration
       - name: Publish Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
+          token: ${{ env.CODECOV_TOKEN }}
           flags: integration
           fail_ci_if_error: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,18 +2,18 @@ name: Update Documentation
 
 on:
   push:
-    branches: 
+    branches:
       - main
 
 jobs:
   npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2.1.5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           registry-url: https://npm.pkg.github.com/
-          node-version: 14
+          node-version: 22
       - name: Build Package
         run: |
           npm install
@@ -21,8 +21,8 @@ jobs:
       - name: Build Documentation
         run: npm run generate-docs
       - name: Push Documentation
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          ACCESS_TOKEN: ${{ secrets.GH_PAGES_PUBLISH_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs # The folder the action should deploy.
+          token: ${{ secrets.GH_PAGES_PUBLISH_TOKEN }}
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/npm_upload.yml
+++ b/.github/workflows/npm_upload.yml
@@ -12,15 +12,15 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-node@v2.1.5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 22
       - name: Build Package
         run: |
           npm install
           npm run build
       - name: NPM Publish
-        uses: JS-DevTools/npm-publish@v1.4.3
+        uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -8,15 +8,15 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.12'
       - name: Setup Node.JS environment
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 22
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time
@@ -26,8 +26,7 @@ jobs:
       - name: Update SDK Version
         run: npm version --commit-hooks false --git-tag-version false minor
       - name: Install SDK
-        run: |
-          npm install
+        run: npm install
       - name: Update Modules
         run: |
           git submodule init
@@ -35,14 +34,14 @@ jobs:
       - name: Generate Branch Name
         id: git-branch
         run: |
-          echo "::set-output name=branch::spec_update_${{ steps.current-time.outputs.formattedTime }}"
+          echo "branch=spec_update_${{ steps.current-time.outputs.formattedTime }}" >> "$GITHUB_OUTPUT"
       - name: Generate Num Diffs
         id: git-diff-num
         run: |
           cd generator/
           diffs=$(git diff --submodule dropbox-api-spec | grep ">" | wc -l)
           echo "Number of Spec diffs: $diffs"
-          echo "::set-output name=num-diff::$diffs"
+          echo "num-diff=$diffs" >> "$GITHUB_OUTPUT"
           cd ..
       - name: Generate Diff
         id: git-diff
@@ -54,7 +53,7 @@ jobs:
           commit="${commit//$'\n'/'%0A'}"
           commit="${commit//$'\r'/'%0D'}"
           echo "Commit Message: $commit"
-          echo "::set-output name=commit::$commit"
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
           cd ../..
       - name: Generate New Routes
         run: |
@@ -64,7 +63,7 @@ jobs:
           python generate_routes.py
           cd ..
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3.9.1
+        uses: peter-evans/create-pull-request@v7
         if: steps.git-diff-num.outputs.num-diff != 0
         with:
           token: ${{ secrets.SPEC_UPDATE_TOKEN }}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -371,12 +371,11 @@ routes.fileRequestsGet = function (arg) {
  * the app folder.
  * Route attributes:
  *   scope: file_requests.read
- * @function Dropbox#fileRequestsListV2
- * @arg {FileRequestsListFileRequestsArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsV2Result>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
+ * @function Dropbox#fileRequestsList
+ * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsResult>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
  */
-routes.fileRequestsListV2 = function (arg) {
-  return this.request('file_requests/list_v2', arg, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsList = function () {
+  return this.request('file_requests/list', null, 'user', 'api', 'rpc', 'file_requests.read');
 };
 
 /**
@@ -385,11 +384,12 @@ routes.fileRequestsListV2 = function (arg) {
  * the app folder.
  * Route attributes:
  *   scope: file_requests.read
- * @function Dropbox#fileRequestsList
- * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsResult>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
+ * @function Dropbox#fileRequestsListV2
+ * @arg {FileRequestsListFileRequestsArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsV2Result>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
  */
-routes.fileRequestsList = function () {
-  return this.request('file_requests/list', null, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsListV2 = function (arg) {
+  return this.request('file_requests/list_v2', arg, 'user', 'api', 'rpc', 'file_requests.read');
 };
 
 /**
@@ -454,6 +454,20 @@ routes.filesAlphaUpload = function (arg) {
  * source path is a folder all its contents will be copied.
  * Route attributes:
  *   scope: files.content.write
+ * @function Dropbox#filesCopy
+ * @deprecated
+ * @arg {FilesRelocationArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
+ */
+routes.filesCopy = function (arg) {
+  return this.request('files/copy', arg, 'user', 'api', 'rpc', 'files.content.write');
+};
+
+/**
+ * Copy a file or folder to a different location in the user's Dropbox. If the
+ * source path is a folder all its contents will be copied.
+ * Route attributes:
+ *   scope: files.content.write
  * @function Dropbox#filesCopyV2
  * @arg {FilesRelocationArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<FilesRelocationResult>, DropboxResponseError.<FilesRelocationError>>}
@@ -463,17 +477,18 @@ routes.filesCopyV2 = function (arg) {
 };
 
 /**
- * Copy a file or folder to a different location in the user's Dropbox. If the
- * source path is a folder all its contents will be copied.
+ * Copy multiple files or folders to different locations at once in the user's
+ * Dropbox. This route will return job ID immediately and do the async copy job
+ * in background. Please use copy_batch/check to check the job status.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesCopy
+ * @function Dropbox#filesCopyBatch
  * @deprecated
- * @arg {FilesRelocationArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
+ * @arg {FilesRelocationBatchArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesCopy = function (arg) {
-  return this.request('files/copy', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatch = function (arg) {
+  return this.request('files/copy_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -494,18 +509,17 @@ routes.filesCopyBatchV2 = function (arg) {
 };
 
 /**
- * Copy multiple files or folders to different locations at once in the user's
- * Dropbox. This route will return job ID immediately and do the async copy job
- * in background. Please use copy_batch/check to check the job status.
+ * Returns the status of an asynchronous job for copy_batch. If success, it
+ * returns list of results for each entry.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesCopyBatch
+ * @function Dropbox#filesCopyBatchCheck
  * @deprecated
- * @arg {FilesRelocationBatchArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
+ * @arg {AsyncPollArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesCopyBatch = function (arg) {
-  return this.request('files/copy_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatchCheck = function (arg) {
+  return this.request('files/copy_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -519,20 +533,6 @@ routes.filesCopyBatch = function (arg) {
  */
 routes.filesCopyBatchCheckV2 = function (arg) {
   return this.request('files/copy_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
-};
-
-/**
- * Returns the status of an asynchronous job for copy_batch. If success, it
- * returns list of results for each entry.
- * Route attributes:
- *   scope: files.content.write
- * @function Dropbox#filesCopyBatchCheck
- * @deprecated
- * @arg {AsyncPollArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
- */
-routes.filesCopyBatchCheck = function (arg) {
-  return this.request('files/copy_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -565,18 +565,6 @@ routes.filesCopyReferenceSave = function (arg) {
  * Create a folder at a given path.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesCreateFolderV2
- * @arg {FilesCreateFolderArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesCreateFolderResult>, DropboxResponseError.<FilesCreateFolderError>>}
- */
-routes.filesCreateFolderV2 = function (arg) {
-  return this.request('files/create_folder_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
-};
-
-/**
- * Create a folder at a given path.
- * Route attributes:
- *   scope: files.content.write
  * @function Dropbox#filesCreateFolder
  * @deprecated
  * @arg {FilesCreateFolderArg} arg - The request parameters.
@@ -584,6 +572,18 @@ routes.filesCreateFolderV2 = function (arg) {
  */
 routes.filesCreateFolder = function (arg) {
   return this.request('files/create_folder', arg, 'user', 'api', 'rpc', 'files.content.write');
+};
+
+/**
+ * Create a folder at a given path.
+ * Route attributes:
+ *   scope: files.content.write
+ * @function Dropbox#filesCreateFolderV2
+ * @arg {FilesCreateFolderArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FilesCreateFolderResult>, DropboxResponseError.<FilesCreateFolderError>>}
+ */
+routes.filesCreateFolderV2 = function (arg) {
+  return this.request('files/create_folder_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -624,12 +624,13 @@ routes.filesCreateFolderBatchCheck = function (arg) {
  * DeletedMetadata object.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesDeleteV2
+ * @function Dropbox#filesDelete
+ * @deprecated
  * @arg {FilesDeleteArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesDeleteResult>, DropboxResponseError.<FilesDeleteError>>}
+ * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesDeleteError>>}
  */
-routes.filesDeleteV2 = function (arg) {
-  return this.request('files/delete_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDelete = function (arg) {
+  return this.request('files/delete', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -640,13 +641,12 @@ routes.filesDeleteV2 = function (arg) {
  * DeletedMetadata object.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesDelete
- * @deprecated
+ * @function Dropbox#filesDeleteV2
  * @arg {FilesDeleteArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesDeleteError>>}
+ * @returns {Promise.<DropboxResponse<FilesDeleteResult>, DropboxResponseError.<FilesDeleteError>>}
  */
-routes.filesDelete = function (arg) {
-  return this.request('files/delete', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDeleteV2 = function (arg) {
+  return this.request('files/delete_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -969,6 +969,20 @@ routes.filesLockFileBatch = function (arg) {
 
 /**
  * Move a file or folder to a different location in the user's Dropbox. If the
+ * source path is a folder all its contents will be moved.
+ * Route attributes:
+ *   scope: files.content.write
+ * @function Dropbox#filesMove
+ * @deprecated
+ * @arg {FilesRelocationArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
+ */
+routes.filesMove = function (arg) {
+  return this.request('files/move', arg, 'user', 'api', 'rpc', 'files.content.write');
+};
+
+/**
+ * Move a file or folder to a different location in the user's Dropbox. If the
  * source path is a folder all its contents will be moved. Note that we do not
  * currently support case-only renaming.
  * Route attributes:
@@ -982,17 +996,18 @@ routes.filesMoveV2 = function (arg) {
 };
 
 /**
- * Move a file or folder to a different location in the user's Dropbox. If the
- * source path is a folder all its contents will be moved.
+ * Move multiple files or folders to different locations at once in the user's
+ * Dropbox. This route will return job ID immediately and do the async moving
+ * job in background. Please use move_batch/check to check the job status.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesMove
+ * @function Dropbox#filesMoveBatch
  * @deprecated
- * @arg {FilesRelocationArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
+ * @arg {FilesRelocationBatchArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesMove = function (arg) {
-  return this.request('files/move', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatch = function (arg) {
+  return this.request('files/move_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -1014,18 +1029,17 @@ routes.filesMoveBatchV2 = function (arg) {
 };
 
 /**
- * Move multiple files or folders to different locations at once in the user's
- * Dropbox. This route will return job ID immediately and do the async moving
- * job in background. Please use move_batch/check to check the job status.
+ * Returns the status of an asynchronous job for move_batch. If success, it
+ * returns list of results for each entry.
  * Route attributes:
  *   scope: files.content.write
- * @function Dropbox#filesMoveBatch
+ * @function Dropbox#filesMoveBatchCheck
  * @deprecated
- * @arg {FilesRelocationBatchArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
+ * @arg {AsyncPollArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesMoveBatch = function (arg) {
-  return this.request('files/move_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatchCheck = function (arg) {
+  return this.request('files/move_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -1039,20 +1053,6 @@ routes.filesMoveBatch = function (arg) {
  */
 routes.filesMoveBatchCheckV2 = function (arg) {
   return this.request('files/move_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
-};
-
-/**
- * Returns the status of an asynchronous job for move_batch. If success, it
- * returns list of results for each entry.
- * Route attributes:
- *   scope: files.content.write
- * @function Dropbox#filesMoveBatchCheck
- * @deprecated
- * @arg {AsyncPollArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
- */
-routes.filesMoveBatchCheck = function (arg) {
-  return this.request('files/move_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
 };
 
 /**
@@ -1324,24 +1324,6 @@ routes.filesUpload = function (arg) {
 };
 
 /**
- * Append more data to an upload session. When the parameter close is set, this
- * call will close the session. A single request should not upload more than 150
- * MB. The maximum size of a file one can upload to an upload session is 350 GB.
- * Calls to this endpoint will count as data transport calls for any Dropbox
- * Business teams with a limit on the number of data transport calls allowed per
- * month. For more information, see the Data transport limit page
- * https://www.dropbox.com/developers/reference/data-transport-limit.
- * Route attributes:
- *   scope: files.content.write
- * @function Dropbox#filesUploadSessionAppendV2
- * @arg {FilesUploadSessionAppendArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesUploadSessionAppendError>>}
- */
-routes.filesUploadSessionAppendV2 = function (arg) {
-  return this.request('files/upload_session/append_v2', arg, 'user', 'content', 'upload', 'files.content.write');
-};
-
-/**
  * Append more data to an upload session. A single request should not upload
  * more than 150 MB. The maximum size of a file one can upload to an upload
  * session is 350 GB. Calls to this endpoint will count as data transport calls
@@ -1357,6 +1339,24 @@ routes.filesUploadSessionAppendV2 = function (arg) {
  */
 routes.filesUploadSessionAppend = function (arg) {
   return this.request('files/upload_session/append', arg, 'user', 'content', 'upload', 'files.content.write');
+};
+
+/**
+ * Append more data to an upload session. When the parameter close is set, this
+ * call will close the session. A single request should not upload more than 150
+ * MB. The maximum size of a file one can upload to an upload session is 350 GB.
+ * Calls to this endpoint will count as data transport calls for any Dropbox
+ * Business teams with a limit on the number of data transport calls allowed per
+ * month. For more information, see the Data transport limit page
+ * https://www.dropbox.com/developers/reference/data-transport-limit.
+ * Route attributes:
+ *   scope: files.content.write
+ * @function Dropbox#filesUploadSessionAppendV2
+ * @arg {FilesUploadSessionAppendArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesUploadSessionAppendError>>}
+ */
+routes.filesUploadSessionAppendV2 = function (arg) {
+  return this.request('files/upload_session/append_v2', arg, 'user', 'content', 'upload', 'files.content.write');
 };
 
 /**
@@ -2945,12 +2945,12 @@ routes.teamMemberSpaceLimitsSetCustomQuota = function (arg) {
  * 'active'.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersAddV2
- * @arg {TeamMembersAddV2Arg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersAddLaunchV2Result>, DropboxResponseError.<void>>}
+ * @function Dropbox#teamMembersAdd
+ * @arg {TeamMembersAddArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersAddLaunch>, DropboxResponseError.<void>>}
  */
-routes.teamMembersAddV2 = function (arg) {
-  return this.request('team/members/add_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAdd = function (arg) {
+  return this.request('team/members/add', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -2967,25 +2967,12 @@ routes.teamMembersAddV2 = function (arg) {
  * 'active'.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersAdd
- * @arg {TeamMembersAddArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersAddLaunch>, DropboxResponseError.<void>>}
+ * @function Dropbox#teamMembersAddV2
+ * @arg {TeamMembersAddV2Arg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersAddLaunchV2Result>, DropboxResponseError.<void>>}
  */
-routes.teamMembersAdd = function (arg) {
-  return this.request('team/members/add', arg, 'team', 'api', 'rpc', 'members.write');
-};
-
-/**
- * Once an async_job_id is returned from members/add_v2 , use this to poll the
- * status of the asynchronous request. Permission : Team member management.
- * Route attributes:
- *   scope: members.write
- * @function Dropbox#teamMembersAddJobStatusGetV2
- * @arg {AsyncPollArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersAddJobStatusV2Result>, DropboxResponseError.<AsyncPollError>>}
- */
-routes.teamMembersAddJobStatusGetV2 = function (arg) {
-  return this.request('team/members/add/job_status/get_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAddV2 = function (arg) {
+  return this.request('team/members/add_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -3002,15 +2989,16 @@ routes.teamMembersAddJobStatusGet = function (arg) {
 };
 
 /**
- * Deletes a team member's profile photo. Permission : Team member management.
+ * Once an async_job_id is returned from members/add_v2 , use this to poll the
+ * status of the asynchronous request. Permission : Team member management.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersDeleteProfilePhotoV2
- * @arg {TeamMembersDeleteProfilePhotoArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersDeleteProfilePhotoError>>}
+ * @function Dropbox#teamMembersAddJobStatusGetV2
+ * @arg {AsyncPollArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersAddJobStatusV2Result>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamMembersDeleteProfilePhotoV2 = function (arg) {
-  return this.request('team/members/delete_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAddJobStatusGetV2 = function (arg) {
+  return this.request('team/members/add/job_status/get_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -3023,6 +3011,18 @@ routes.teamMembersDeleteProfilePhotoV2 = function (arg) {
  */
 routes.teamMembersDeleteProfilePhoto = function (arg) {
   return this.request('team/members/delete_profile_photo', arg, 'team', 'api', 'rpc', 'members.write');
+};
+
+/**
+ * Deletes a team member's profile photo. Permission : Team member management.
+ * Route attributes:
+ *   scope: members.write
+ * @function Dropbox#teamMembersDeleteProfilePhotoV2
+ * @arg {TeamMembersDeleteProfilePhotoArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersDeleteProfilePhotoError>>}
+ */
+routes.teamMembersDeleteProfilePhotoV2 = function (arg) {
+  return this.request('team/members/delete_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -3043,20 +3043,6 @@ routes.teamMembersGetAvailableTeamMemberRoles = function () {
  * IDs (or emails) that cannot be matched to a valid team member.
  * Route attributes:
  *   scope: members.read
- * @function Dropbox#teamMembersGetInfoV2
- * @arg {TeamMembersGetInfoV2Arg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersGetInfoV2Result>, DropboxResponseError.<TeamMembersGetInfoError>>}
- */
-routes.teamMembersGetInfoV2 = function (arg) {
-  return this.request('team/members/get_info_v2', arg, 'team', 'api', 'rpc', 'members.read');
-};
-
-/**
- * Returns information about multiple team members. Permission : Team
- * information This endpoint will return MembersGetInfoItem.id_not_found, for
- * IDs (or emails) that cannot be matched to a valid team member.
- * Route attributes:
- *   scope: members.read
  * @function Dropbox#teamMembersGetInfo
  * @arg {TeamMembersGetInfoArgs} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamMembersGetInfoError>>}
@@ -3066,15 +3052,17 @@ routes.teamMembersGetInfo = function (arg) {
 };
 
 /**
- * Lists members of a team. Permission : Team information.
+ * Returns information about multiple team members. Permission : Team
+ * information This endpoint will return MembersGetInfoItem.id_not_found, for
+ * IDs (or emails) that cannot be matched to a valid team member.
  * Route attributes:
  *   scope: members.read
- * @function Dropbox#teamMembersListV2
- * @arg {TeamMembersListArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListError>>}
+ * @function Dropbox#teamMembersGetInfoV2
+ * @arg {TeamMembersGetInfoV2Arg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersGetInfoV2Result>, DropboxResponseError.<TeamMembersGetInfoError>>}
  */
-routes.teamMembersListV2 = function (arg) {
-  return this.request('team/members/list_v2', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersGetInfoV2 = function (arg) {
+  return this.request('team/members/get_info_v2', arg, 'team', 'api', 'rpc', 'members.read');
 };
 
 /**
@@ -3090,16 +3078,15 @@ routes.teamMembersList = function (arg) {
 };
 
 /**
- * Once a cursor has been retrieved from members/list_v2, use this to paginate
- * through all team members. Permission : Team information.
+ * Lists members of a team. Permission : Team information.
  * Route attributes:
  *   scope: members.read
- * @function Dropbox#teamMembersListContinueV2
- * @arg {TeamMembersListContinueArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListContinueError>>}
+ * @function Dropbox#teamMembersListV2
+ * @arg {TeamMembersListArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListError>>}
  */
-routes.teamMembersListContinueV2 = function (arg) {
-  return this.request('team/members/list/continue_v2', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersListV2 = function (arg) {
+  return this.request('team/members/list_v2', arg, 'team', 'api', 'rpc', 'members.read');
 };
 
 /**
@@ -3113,6 +3100,19 @@ routes.teamMembersListContinueV2 = function (arg) {
  */
 routes.teamMembersListContinue = function (arg) {
   return this.request('team/members/list/continue', arg, 'team', 'api', 'rpc', 'members.read');
+};
+
+/**
+ * Once a cursor has been retrieved from members/list_v2, use this to paginate
+ * through all team members. Permission : Team information.
+ * Route attributes:
+ *   scope: members.read
+ * @function Dropbox#teamMembersListContinueV2
+ * @arg {TeamMembersListContinueArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListContinueError>>}
+ */
+routes.teamMembersListContinueV2 = function (arg) {
+  return this.request('team/members/list/continue_v2', arg, 'team', 'api', 'rpc', 'members.read');
 };
 
 /**
@@ -3252,18 +3252,6 @@ routes.teamMembersSendWelcomeEmail = function (arg) {
  * Updates a team member's permissions. Permission : Team member management.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersSetAdminPermissionsV2
- * @arg {TeamMembersSetPermissions2Arg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamMembersSetPermissions2Result>, DropboxResponseError.<TeamMembersSetPermissions2Error>>}
- */
-routes.teamMembersSetAdminPermissionsV2 = function (arg) {
-  return this.request('team/members/set_admin_permissions_v2', arg, 'team', 'api', 'rpc', 'members.write');
-};
-
-/**
- * Updates a team member's permissions. Permission : Team member management.
- * Route attributes:
- *   scope: members.write
  * @function Dropbox#teamMembersSetAdminPermissions
  * @arg {TeamMembersSetPermissionsArg} arg - The request parameters.
  * @returns {Promise.<DropboxResponse<TeamMembersSetPermissionsResult>, DropboxResponseError.<TeamMembersSetPermissionsError>>}
@@ -3273,15 +3261,15 @@ routes.teamMembersSetAdminPermissions = function (arg) {
 };
 
 /**
- * Updates a team member's profile. Permission : Team member management.
+ * Updates a team member's permissions. Permission : Team member management.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersSetProfileV2
- * @arg {TeamMembersSetProfileArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfileError>>}
+ * @function Dropbox#teamMembersSetAdminPermissionsV2
+ * @arg {TeamMembersSetPermissions2Arg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamMembersSetPermissions2Result>, DropboxResponseError.<TeamMembersSetPermissions2Error>>}
  */
-routes.teamMembersSetProfileV2 = function (arg) {
-  return this.request('team/members/set_profile_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetAdminPermissionsV2 = function (arg) {
+  return this.request('team/members/set_admin_permissions_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -3297,15 +3285,15 @@ routes.teamMembersSetProfile = function (arg) {
 };
 
 /**
- * Updates a team member's profile photo. Permission : Team member management.
+ * Updates a team member's profile. Permission : Team member management.
  * Route attributes:
  *   scope: members.write
- * @function Dropbox#teamMembersSetProfilePhotoV2
- * @arg {TeamMembersSetProfilePhotoArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfilePhotoError>>}
+ * @function Dropbox#teamMembersSetProfileV2
+ * @arg {TeamMembersSetProfileArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfileError>>}
  */
-routes.teamMembersSetProfilePhotoV2 = function (arg) {
-  return this.request('team/members/set_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetProfileV2 = function (arg) {
+  return this.request('team/members/set_profile_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**
@@ -3318,6 +3306,18 @@ routes.teamMembersSetProfilePhotoV2 = function (arg) {
  */
 routes.teamMembersSetProfilePhoto = function (arg) {
   return this.request('team/members/set_profile_photo', arg, 'team', 'api', 'rpc', 'members.write');
+};
+
+/**
+ * Updates a team member's profile photo. Permission : Team member management.
+ * Route attributes:
+ *   scope: members.write
+ * @function Dropbox#teamMembersSetProfilePhotoV2
+ * @arg {TeamMembersSetProfilePhotoArg} arg - The request parameters.
+ * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfilePhotoError>>}
+ */
+routes.teamMembersSetProfilePhotoV2 = function (arg) {
+  return this.request('team/members/set_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
 };
 
 /**

--- a/test/integration/team.js
+++ b/test/integration/team.js
@@ -1,12 +1,10 @@
 import chai from 'chai';
-import fs from 'fs/promises';
-import path from 'path';
 import { Dropbox, DropboxAuth } from '../../index.js';
 import { DropboxResponse } from '../../src/response.js';
+import { DropboxResponseError } from '../../src/error.js';
 
 const appInfo = {
   SCOPED: {
-    accessToken: process.env.SCOPED_TEAM_DROPBOX_TOKEN,
     clientId: process.env.SCOPED_TEAM_CLIENT_ID,
     clientSecret: process.env.SCOPED_TEAM_CLIENT_SECRET,
     refreshToken: process.env.SCOPED_TEAM_REFRESH_TOKEN,
@@ -65,9 +63,7 @@ for (const appType in appInfo) {
               chai.assert.equal(resp.status, 200, resp.result);
               chai.assert.isObject(resp.result);
               // testing to make sure that the token has been refreshed
-              chai.assert.notEqual(
-                dbxAuth.getAccessToken(), appInfo[appType].token,
-              );
+              chai.assert.isString(dbxAuth.getAccessToken());
               // comparing dates to make sure new token expiration is set
               chai.assert.isTrue(
                 dbxAuth.accessTokenExpiresAt > new Date(expirationBeforeRefresh),

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -8,14 +8,7 @@ import { DropboxResponse } from '../../src/response.js';
 import { DropboxResponseError } from '../../src/error.js';
 
 const appInfo = {
-  LEGACY: {
-    accessToken: process.env.LEGACY_USER_DROPBOX_TOKEN,
-    clientId: process.env.LEGACY_USER_CLIENT_ID,
-    clientSecret: process.env.LEGACY_USER_CLIENT_SECRET,
-    refreshToken: process.env.LEGACY_USER_REFRESH_TOKEN,
-  },
   SCOPED: {
-    accessToken: process.env.SCOPED_USER_DROPBOX_TOKEN,
     clientId: process.env.SCOPED_USER_CLIENT_ID,
     clientSecret: process.env.SCOPED_USER_CLIENT_SECRET,
     refreshToken: process.env.SCOPED_USER_REFRESH_TOKEN,
@@ -110,9 +103,7 @@ for (const appType in appInfo) {
               chai.assert.equal(resp.status, 200, resp.result);
               chai.assert.isObject(resp.result);
               // testing to make sure that the token has been refreshed
-              chai.assert.notEqual(
-                dbxAuth.getAccessToken(), appInfo[appType].token,
-              );
+              chai.assert.isString(dbxAuth.getAccessToken());
               // comparing dates to make sure new token expiration is set
               chai.assert.isTrue(
                 dbxAuth.accessTokenExpiresAt > new Date(expirationBeforeRefresh),
@@ -155,7 +146,7 @@ describe('incorrect auth', () => {
 
 describe('multiauth', () => {
   it('mulitauth request is successful', (done) => {
-    const dbxAuth = new DropboxAuth(appInfo.LEGACY);
+    const dbxAuth = new DropboxAuth(appInfo.SCOPED);
     const dbx = new Dropbox({ auth: dbxAuth });
     const arg = {
       resource: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -623,9 +623,8 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.ListFileRequestsError>.
-     * @param arg The request parameters.
      */
-    public fileRequestsListV2(arg: file_requests.ListFileRequestsArg): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
+    public fileRequestsList(): Promise<DropboxResponse<file_requests.ListFileRequestsResult>>;
 
     /**
      * Returns a list of file requests owned by this user. For apps with the app
@@ -637,8 +636,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.ListFileRequestsError>.
+     * @param arg The request parameters.
      */
-    public fileRequestsList(): Promise<DropboxResponse<file_requests.ListFileRequestsResult>>;
+    public fileRequestsListV2(arg: file_requests.ListFileRequestsArg): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
 
     /**
      * Once a cursor has been retrieved from listV2(), use this to paginate
@@ -706,9 +706,10 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RelocationError>.
+     * @deprecated
      * @param arg The request parameters.
      */
-    public filesCopyV2(arg: files.RelocationArg): Promise<DropboxResponse<files.RelocationResult>>;
+    public filesCopy(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Copy a file or folder to a different location in the user's Dropbox. If
@@ -719,10 +720,25 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RelocationError>.
+     * @param arg The request parameters.
+     */
+    public filesCopyV2(arg: files.RelocationArg): Promise<DropboxResponse<files.RelocationResult>>;
+
+    /**
+     * Copy multiple files or folders to different locations at once in the
+     * user's Dropbox. This route will return job ID immediately and do the
+     * async copy job in background. Please use copyBatchCheck() to check the
+     * job status.
+     *
+     * Route attributes:
+     *   scope: files.content.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
      */
-    public filesCopy(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesCopyBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
 
     /**
      * Copy multiple files or folders to different locations at once in the
@@ -742,20 +758,18 @@ export class Dropbox {
     public filesCopyBatchV2(arg: files.CopyBatchArg): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
 
     /**
-     * Copy multiple files or folders to different locations at once in the
-     * user's Dropbox. This route will return job ID immediately and do the
-     * async copy job in background. Please use copyBatchCheck() to check the
-     * job status.
+     * Returns the status of an asynchronous job for copyBatch(). If success, it
+     * returns list of results for each entry.
      *
      * Route attributes:
      *   scope: files.content.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<void>.
+     * DropboxResponseError<async.PollError>.
      * @deprecated
      * @param arg The request parameters.
      */
-    public filesCopyBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
+    public filesCopyBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for copyBatchV2(). It returns
@@ -769,20 +783,6 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public filesCopyBatchCheckV2(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
-
-    /**
-     * Returns the status of an asynchronous job for copyBatch(). If success, it
-     * returns list of results for each entry.
-     *
-     * Route attributes:
-     *   scope: files.content.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<async.PollError>.
-     * @deprecated
-     * @param arg The request parameters.
-     */
-    public filesCopyBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Get a copy reference to a file or folder. This reference string can be
@@ -819,9 +819,10 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.CreateFolderError>.
+     * @deprecated
      * @param arg The request parameters.
      */
-    public filesCreateFolderV2(arg: files.CreateFolderArg): Promise<DropboxResponse<files.CreateFolderResult>>;
+    public filesCreateFolder(arg: files.CreateFolderArg): Promise<DropboxResponse<files.FolderMetadata>>;
 
     /**
      * Create a folder at a given path.
@@ -831,10 +832,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.CreateFolderError>.
-     * @deprecated
      * @param arg The request parameters.
      */
-    public filesCreateFolder(arg: files.CreateFolderArg): Promise<DropboxResponse<files.FolderMetadata>>;
+    public filesCreateFolderV2(arg: files.CreateFolderArg): Promise<DropboxResponse<files.CreateFolderResult>>;
 
     /**
      * Create multiple folders at once. This route is asynchronous for large
@@ -878,9 +878,10 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DeleteError>.
+     * @deprecated
      * @param arg The request parameters.
      */
-    public filesDeleteV2(arg: files.DeleteArg): Promise<DropboxResponse<files.DeleteResult>>;
+    public filesDelete(arg: files.DeleteArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Delete the file or folder at a given path. If the path is a folder, all
@@ -894,10 +895,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DeleteError>.
-     * @deprecated
      * @param arg The request parameters.
      */
-    public filesDelete(arg: files.DeleteArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesDeleteV2(arg: files.DeleteArg): Promise<DropboxResponse<files.DeleteResult>>;
 
     /**
      * Delete multiple files/folders at once. This route is asynchronous, which
@@ -1228,6 +1228,20 @@ export class Dropbox {
 
     /**
      * Move a file or folder to a different location in the user's Dropbox. If
+     * the source path is a folder all its contents will be moved.
+     *
+     * Route attributes:
+     *   scope: files.content.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<files.RelocationError>.
+     * @deprecated
+     * @param arg The request parameters.
+     */
+    public filesMove(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+
+    /**
+     * Move a file or folder to a different location in the user's Dropbox. If
      * the source path is a folder all its contents will be moved. Note that we
      * do not currently support case-only renaming.
      *
@@ -1241,18 +1255,20 @@ export class Dropbox {
     public filesMoveV2(arg: files.RelocationArg): Promise<DropboxResponse<files.RelocationResult>>;
 
     /**
-     * Move a file or folder to a different location in the user's Dropbox. If
-     * the source path is a folder all its contents will be moved.
+     * Move multiple files or folders to different locations at once in the
+     * user's Dropbox. This route will return job ID immediately and do the
+     * async moving job in background. Please use moveBatchCheck() to check the
+     * job status.
      *
      * Route attributes:
      *   scope: files.content.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<files.RelocationError>.
+     * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
      */
-    public filesMove(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesMoveBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
 
     /**
      * Move multiple files or folders to different locations at once in the
@@ -1273,20 +1289,18 @@ export class Dropbox {
     public filesMoveBatchV2(arg: files.MoveBatchArg): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
 
     /**
-     * Move multiple files or folders to different locations at once in the
-     * user's Dropbox. This route will return job ID immediately and do the
-     * async moving job in background. Please use moveBatchCheck() to check the
-     * job status.
+     * Returns the status of an asynchronous job for moveBatch(). If success, it
+     * returns list of results for each entry.
      *
      * Route attributes:
      *   scope: files.content.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<void>.
+     * DropboxResponseError<async.PollError>.
      * @deprecated
      * @param arg The request parameters.
      */
-    public filesMoveBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
+    public filesMoveBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for moveBatchV2(). It returns
@@ -1300,20 +1314,6 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public filesMoveBatchCheckV2(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
-
-    /**
-     * Returns the status of an asynchronous job for moveBatch(). If success, it
-     * returns list of results for each entry.
-     *
-     * Route attributes:
-     *   scope: files.content.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<async.PollError>.
-     * @deprecated
-     * @param arg The request parameters.
-     */
-    public filesMoveBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Creates a new Paper doc with the provided content.
@@ -1579,25 +1579,6 @@ export class Dropbox {
     public filesUpload(arg: files.UploadArg): Promise<DropboxResponse<files.FileMetadata>>;
 
     /**
-     * Append more data to an upload session. When the parameter close is set,
-     * this call will close the session. A single request should not upload more
-     * than 150 MB. The maximum size of a file one can upload to an upload
-     * session is 350 GB. Calls to this endpoint will count as data transport
-     * calls for any Dropbox Business teams with a limit on the number of data
-     * transport calls allowed per month. For more information, see the [Data
-     * transport limit page]{@link
-     * https://www.dropbox.com/developers/reference/data-transport-limit}.
-     *
-     * Route attributes:
-     *   scope: files.content.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<files.UploadSessionAppendError>.
-     * @param arg The request parameters.
-     */
-    public filesUploadSessionAppendV2(arg: files.UploadSessionAppendArg): Promise<DropboxResponse<void>>;
-
-    /**
      * Append more data to an upload session. A single request should not upload
      * more than 150 MB. The maximum size of a file one can upload to an upload
      * session is 350 GB. Calls to this endpoint will count as data transport
@@ -1615,6 +1596,25 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public filesUploadSessionAppend(arg: files.UploadSessionCursor): Promise<DropboxResponse<void>>;
+
+    /**
+     * Append more data to an upload session. When the parameter close is set,
+     * this call will close the session. A single request should not upload more
+     * than 150 MB. The maximum size of a file one can upload to an upload
+     * session is 350 GB. Calls to this endpoint will count as data transport
+     * calls for any Dropbox Business teams with a limit on the number of data
+     * transport calls allowed per month. For more information, see the [Data
+     * transport limit page]{@link
+     * https://www.dropbox.com/developers/reference/data-transport-limit}.
+     *
+     * Route attributes:
+     *   scope: files.content.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<files.UploadSessionAppendError>.
+     * @param arg The request parameters.
+     */
+    public filesUploadSessionAppendV2(arg: files.UploadSessionAppendArg): Promise<DropboxResponse<void>>;
 
     /**
      * Finish an upload session and save the uploaded data to the given file
@@ -3232,7 +3232,7 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @param arg The request parameters.
      */
-    public teamMembersAddV2(arg: team.MembersAddV2Arg): Promise<DropboxResponse<team.MembersAddLaunchV2Result>>;
+    public teamMembersAdd(arg: team.MembersAddArg): Promise<DropboxResponse<team.MembersAddLaunch>>;
 
     /**
      * Adds members to a team. Permission : Team member management A maximum of
@@ -3254,7 +3254,20 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @param arg The request parameters.
      */
-    public teamMembersAdd(arg: team.MembersAddArg): Promise<DropboxResponse<team.MembersAddLaunch>>;
+    public teamMembersAddV2(arg: team.MembersAddV2Arg): Promise<DropboxResponse<team.MembersAddLaunchV2Result>>;
+
+    /**
+     * Once an async_job_id is returned from membersAdd() , use this to poll the
+     * status of the asynchronous request. Permission : Team member management.
+     *
+     * Route attributes:
+     *   scope: members.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<async.PollError>.
+     * @param arg The request parameters.
+     */
+    public teamMembersAddJobStatusGet(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatus>>;
 
     /**
      * Once an async_job_id is returned from membersAddV2() , use this to poll
@@ -3271,17 +3284,17 @@ export class Dropbox {
     public teamMembersAddJobStatusGetV2(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatusV2Result>>;
 
     /**
-     * Once an async_job_id is returned from membersAdd() , use this to poll the
-     * status of the asynchronous request. Permission : Team member management.
+     * Deletes a team member's profile photo. Permission : Team member
+     * management.
      *
      * Route attributes:
      *   scope: members.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<async.PollError>.
+     * DropboxResponseError<team.MembersDeleteProfilePhotoError>.
      * @param arg The request parameters.
      */
-    public teamMembersAddJobStatusGet(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatus>>;
+    public teamMembersDeleteProfilePhoto(arg: team.MembersDeleteProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
      * Deletes a team member's profile photo. Permission : Team member
@@ -3295,19 +3308,6 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public teamMembersDeleteProfilePhotoV2(arg: team.MembersDeleteProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
-
-    /**
-     * Deletes a team member's profile photo. Permission : Team member
-     * management.
-     *
-     * Route attributes:
-     *   scope: members.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersDeleteProfilePhotoError>.
-     * @param arg The request parameters.
-     */
-    public teamMembersDeleteProfilePhoto(arg: team.MembersDeleteProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
      * Get available TeamMemberRoles for the connected team. To be used with
@@ -3333,7 +3333,7 @@ export class Dropbox {
      * DropboxResponseError<team.MembersGetInfoError>.
      * @param arg The request parameters.
      */
-    public teamMembersGetInfoV2(arg: team.MembersGetInfoV2Arg): Promise<DropboxResponse<team.MembersGetInfoV2Result>>;
+    public teamMembersGetInfo(arg: team.MembersGetInfoArgs): Promise<DropboxResponse<team.MembersGetInfoResult>>;
 
     /**
      * Returns information about multiple team members. Permission : Team
@@ -3347,19 +3347,7 @@ export class Dropbox {
      * DropboxResponseError<team.MembersGetInfoError>.
      * @param arg The request parameters.
      */
-    public teamMembersGetInfo(arg: team.MembersGetInfoArgs): Promise<DropboxResponse<team.MembersGetInfoResult>>;
-
-    /**
-     * Lists members of a team. Permission : Team information.
-     *
-     * Route attributes:
-     *   scope: members.read
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersListError>.
-     * @param arg The request parameters.
-     */
-    public teamMembersListV2(arg: team.MembersListArg): Promise<DropboxResponse<team.MembersListV2Result>>;
+    public teamMembersGetInfoV2(arg: team.MembersGetInfoV2Arg): Promise<DropboxResponse<team.MembersGetInfoV2Result>>;
 
     /**
      * Lists members of a team. Permission : Team information.
@@ -3374,17 +3362,16 @@ export class Dropbox {
     public teamMembersList(arg: team.MembersListArg): Promise<DropboxResponse<team.MembersListResult>>;
 
     /**
-     * Once a cursor has been retrieved from membersListV2(), use this to
-     * paginate through all team members. Permission : Team information.
+     * Lists members of a team. Permission : Team information.
      *
      * Route attributes:
      *   scope: members.read
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersListContinueError>.
+     * DropboxResponseError<team.MembersListError>.
      * @param arg The request parameters.
      */
-    public teamMembersListContinueV2(arg: team.MembersListContinueArg): Promise<DropboxResponse<team.MembersListV2Result>>;
+    public teamMembersListV2(arg: team.MembersListArg): Promise<DropboxResponse<team.MembersListV2Result>>;
 
     /**
      * Once a cursor has been retrieved from membersList(), use this to paginate
@@ -3398,6 +3385,19 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public teamMembersListContinue(arg: team.MembersListContinueArg): Promise<DropboxResponse<team.MembersListResult>>;
+
+    /**
+     * Once a cursor has been retrieved from membersListV2(), use this to
+     * paginate through all team members. Permission : Team information.
+     *
+     * Route attributes:
+     *   scope: members.read
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<team.MembersListContinueError>.
+     * @param arg The request parameters.
+     */
+    public teamMembersListContinueV2(arg: team.MembersListContinueArg): Promise<DropboxResponse<team.MembersListV2Result>>;
 
     /**
      * Moves removed member's files to a different member. This endpoint
@@ -3544,10 +3544,10 @@ export class Dropbox {
      *   scope: members.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersSetPermissions2Error>.
+     * DropboxResponseError<team.MembersSetPermissionsError>.
      * @param arg The request parameters.
      */
-    public teamMembersSetAdminPermissionsV2(arg: team.MembersSetPermissions2Arg): Promise<DropboxResponse<team.MembersSetPermissions2Result>>;
+    public teamMembersSetAdminPermissions(arg: team.MembersSetPermissionsArg): Promise<DropboxResponse<team.MembersSetPermissionsResult>>;
 
     /**
      * Updates a team member's permissions. Permission : Team member management.
@@ -3556,22 +3556,10 @@ export class Dropbox {
      *   scope: members.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersSetPermissionsError>.
+     * DropboxResponseError<team.MembersSetPermissions2Error>.
      * @param arg The request parameters.
      */
-    public teamMembersSetAdminPermissions(arg: team.MembersSetPermissionsArg): Promise<DropboxResponse<team.MembersSetPermissionsResult>>;
-
-    /**
-     * Updates a team member's profile. Permission : Team member management.
-     *
-     * Route attributes:
-     *   scope: members.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersSetProfileError>.
-     * @param arg The request parameters.
-     */
-    public teamMembersSetProfileV2(arg: team.MembersSetProfileArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
+    public teamMembersSetAdminPermissionsV2(arg: team.MembersSetPermissions2Arg): Promise<DropboxResponse<team.MembersSetPermissions2Result>>;
 
     /**
      * Updates a team member's profile. Permission : Team member management.
@@ -3586,17 +3574,16 @@ export class Dropbox {
     public teamMembersSetProfile(arg: team.MembersSetProfileArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
-     * Updates a team member's profile photo. Permission : Team member
-     * management.
+     * Updates a team member's profile. Permission : Team member management.
      *
      * Route attributes:
      *   scope: members.write
      *
      * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.MembersSetProfilePhotoError>.
+     * DropboxResponseError<team.MembersSetProfileError>.
      * @param arg The request parameters.
      */
-    public teamMembersSetProfilePhotoV2(arg: team.MembersSetProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
+    public teamMembersSetProfileV2(arg: team.MembersSetProfileArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
 
     /**
      * Updates a team member's profile photo. Permission : Team member
@@ -3610,6 +3597,19 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public teamMembersSetProfilePhoto(arg: team.MembersSetProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
+
+    /**
+     * Updates a team member's profile photo. Permission : Team member
+     * management.
+     *
+     * Route attributes:
+     *   scope: members.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<team.MembersSetProfilePhotoError>.
+     * @param arg The request parameters.
+     */
+    public teamMembersSetProfilePhotoV2(arg: team.MembersSetProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
 
     /**
      * Suspend a member from a team. Permission : Team member management Exactly


### PR DESCRIPTION
## Summary

- Update GitHub Actions to current major versions: checkout v4, setup-node v4, setup-python v5, Codecov v5, npm-publish v3, github-pages-deploy v4, and create-pull-request v7.
- Update the Node.js CI matrix from 10–14 to 22 and 24.
- Update Python from 3.7 to 3.12 in the spec-update workflow.
- Replace deprecated `::set-output` usage with `$GITHUB_OUTPUT`.
- Authenticate integration and coverage workflows through GitHub OIDC and AWS Secrets Manager.
- Load scoped user/team refresh-token credentials and the Codecov token at runtime instead of storing long-lived GitHub Actions secrets.
- Skip credential-dependent jobs for fork pull requests.
- Update Stone to v3.5.2 and regenerate the JavaScript routes and TypeScript declarations.

## Validation

- SDK build succeeded.
- Unit and type tests: 220 passing.
- Package/build tests: 6 passing.
- Live Dropbox integration tests with scoped credentials: 13 passing.
- TypeScript examples build and ESLint passed.
- Regeneration was run twice and produced identical output.
