### PR TITLE
Use GitHub token for documentation deploy

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   npm:
     runs-on: ubuntu-latest
@@ -23,6 +26,5 @@ jobs:
       - name: Push Documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          token: ${{ secrets.GH_PAGES_PUBLISH_TOKEN }}
           branch: gh-pages
           folder: docs


### PR DESCRIPTION
## Summary

- Grant the documentation workflow `contents: write` permission.
- Remove the nonexistent `GH_PAGES_PUBLISH_TOKEN` override.
- Let `JamesIves/github-pages-deploy-action@v4` use the repository-scoped `GITHUB_TOKEN`.

## Root cause

The documentation build succeeded in [run 29474227907](https://github.com/dropbox/dropbox-sdk-js/actions/runs/29474227907), but the final push to `gh-pages` failed because `GH_PAGES_PUBLISH_TOKEN` is not configured. Passing the missing secret as the action's `token` input produced an unusable credential instead of using the action's default repository token.

## Impact

Documentation deployment can authenticate without a separate long-lived personal access token, using the workflow's explicitly scoped repository token.

## Validation

- Workflow YAML parsed successfully.
- `npm run generate-docs` succeeded.
- `git diff --check` passed.
