### PR TITLE
Improve JavaScript SDK documentation

### DIFF
--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -9,7 +9,7 @@
     "recurse": true
   },
   "templates": {
-    "systemName": "Dropbox Node SDK",
+    "systemName": "Dropbox JavaScript SDK",
     "theme": "cosmo"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dropbox JavaScript SDK
 
-[![node-current](https://img.shields.io/node/v/dropbox)](https://www.npmjs.com/package/dropbox)
-[![npm](https://img.shields.io/npm/v/dropbox)](https://www.npmjs.com/package/dropbox)
+[![Node.js 22 and 24](https://img.shields.io/badge/Node.js-22%20%7C%2024-339933?logo=nodedotjs&logoColor=white)](https://github.com/dropbox/dropbox-sdk-js/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/dropbox?logo=npm)](https://www.npmjs.com/package/dropbox)
 [![codecov](https://codecov.io/gh/dropbox/dropbox-sdk-js/branch/main/graph/badge.svg)](https://codecov.io/gh/dropbox/dropbox-sdk-js)
 
 The official Dropbox API v2 SDK for JavaScript.
@@ -19,6 +19,8 @@ that do not provide the required APIs.
 Create an app in the [Developer Console][devconsole], then install the SDK from
 npm. Published npm packages already contain CommonJS, ES module, browser, and
 TypeScript builds; applications do not need to build the SDK from source.
+Published versions and release history are available on the
+[npm versions page][npm-versions].
 
 ```sh
 npm install dropbox
@@ -142,6 +144,7 @@ This SDK is distributed under the MIT license, please see [LICENSE][license] for
 [dropbox-error]: https://dropbox.github.io/dropbox-sdk-js/DropboxResponseError.html
 [global-api]: https://dropbox.github.io/dropbox-sdk-js/global.html
 [examples]: https://github.com/dropbox/dropbox-sdk-js/tree/main/examples
+[npm-versions]: https://www.npmjs.com/package/dropbox?activeTab=versions
 [license]: https://github.com/dropbox/dropbox-sdk-js/blob/main/LICENSE
 [contributing]: https://github.com/dropbox/dropbox-sdk-js/blob/main/CONTRIBUTING.md
 [devconsole]: https://dropbox.com/developers/apps

--- a/README.md
+++ b/README.md
@@ -1,40 +1,117 @@
-[![Logo][logo]][repo]
+# Dropbox JavaScript SDK
 
 [![node-current](https://img.shields.io/node/v/dropbox)](https://www.npmjs.com/package/dropbox)
 [![npm](https://img.shields.io/npm/v/dropbox)](https://www.npmjs.com/package/dropbox)
 [![codecov](https://codecov.io/gh/dropbox/dropbox-sdk-js/branch/main/graph/badge.svg)](https://codecov.io/gh/dropbox/dropbox-sdk-js)
 
-The offical Dropbox SDK for Javascript.
+The official Dropbox API v2 SDK for JavaScript.
 
-Documentation can be found on [GitHub Pages][documentation]
+## Runtime support
+
+The SDK supports Node.js, modern web browsers, and Web Workers. Continuous
+integration currently tests Node.js 22 and 24. Browser and Worker environments
+must provide `Promise`, `fetch`, and `TextEncoder`; PKCE authentication also
+requires the Web Crypto API. Add polyfills when targeting older environments
+that do not provide the required APIs.
 
 ## Installation
 
-Create an app via the [Developer Console][devconsole]
+Create an app in the [Developer Console][devconsole], then install the SDK from
+npm. Published npm packages already contain CommonJS, ES module, browser, and
+TypeScript builds; applications do not need to build the SDK from source.
 
-Install via [npm](https://www.npmjs.com/)
-
-```
-$ npm install --save dropbox
-```
-
-Install from source:
-
-```
-$ git clone https://github.com/dropbox/dropbox-sdk-js.git
-$ cd dropbox-sdk-js
-$ npm install
+```sh
+npm install dropbox
 ```
 
-If you are using the repository from the browser, you can use any CDNs that hosts the Dropbox package by including a script tag with the link to the package. However, we highly recommend you do not directly import the latest version and instead choose a specific version. When we update and release a breaking change, this could break production code which we hope to avoid. Note, we follow [semver](https://semver.org/) naming conventions which means that any major version update could contain a breaking change.
+### Node.js
 
-After installation, follow one of our [Examples][examples] or read the [Documentation][documentation].
+```js
+const { Dropbox } = require('dropbox');
 
-You can also view our [OAuth guide][oauthguide].
+const dbx = new Dropbox({
+  accessToken: process.env.DROPBOX_ACCESS_TOKEN,
+});
+
+dbx.filesListFolder({ path: '' })
+  .then(({ result }) => console.log(result.entries))
+  .catch(console.error);
+```
+
+### Browser application with a bundler
+
+Webpack, Rollup, Vite, and similar tools can use the package's ES module build.
+
+```js
+import { Dropbox } from 'dropbox';
+
+const dbx = new Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN' });
+```
+
+### Browser application from a CDN
+
+The browser bundle exposes the SDK through the global `Dropbox` object. Pin an
+exact SDK version so a future breaking release cannot change your application
+unexpectedly.
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/dropbox@10.34.0/dist/Dropbox-sdk.min.js"></script>
+<script>
+  const dbx = new Dropbox.Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN' });
+</script>
+```
+
+Do not hard-code production access tokens in public source code.
+
+### Web Worker
+
+The same browser bundle can be loaded in a Worker:
+
+```js
+importScripts('https://cdn.jsdelivr.net/npm/dropbox@10.34.0/dist/Dropbox-sdk.min.js');
+
+const dbx = new Dropbox.Dropbox({ accessToken: 'YOUR_ACCESS_TOKEN' });
+```
+
+### Install from source
+
+Building is required only when developing the SDK itself or running examples
+directly from this repository.
+
+```sh
+git clone https://github.com/dropbox/dropbox-sdk-js.git
+cd dropbox-sdk-js
+npm install
+npm run build
+```
+
+## Browser authentication and PKCE
+
+Client-side applications cannot keep an app secret confidential. Never embed a
+Dropbox app secret in browser or Worker code. Use the OAuth authorization-code
+flow with PKCE and your app key instead. See the [browser PKCE example][pkce-example]
+and the [Dropbox OAuth guide][oauthguide]. PKCE requires a secure context and the
+Web Crypto API.
+
+Server applications can keep an app secret confidential and may use the regular
+authorization-code flow.
+
+## API reference
+
+- [Dropbox class][dropbox-class] — Dropbox API routes for files, sharing, users,
+  teams, and other namespaces.
+- [DropboxAuth class][dropbox-auth] — OAuth URLs, PKCE, access tokens, and token
+  refresh.
+- [DropboxResponseError class][dropbox-error] — errors returned by API requests.
+- [Global API][global-api] — exported authentication helpers.
+
+The complete generated [API reference][documentation] is published on GitHub
+Pages.
 
 ## Examples
 
-We provide [Examples][examples] to help get you started with a lot of the basic functionality in the SDK.  We provide most examples in both Javascript and Typescript with some having a Node equivalent.
+The [examples][examples] demonstrate common SDK operations. Most are available
+in both JavaScript and TypeScript, with additional Node.js OAuth examples.
 
 - **OAuth**
     - Auth - [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/auth) ] - A simple auth example to get an access token and list the files in the root of your Dropbox account.
@@ -59,12 +136,15 @@ If you need help that is not specific to this SDK, please reach out to [Dropbox 
 
 This SDK is distributed under the MIT license, please see [LICENSE][license] for more information.
 
-[logo]: https://cfl.dropboxstatic.com/static/images/sdk/javascript_banner.png
-[repo]: https://github.com/dropbox/dropbox-sdk-js
-[documentation]: https://dropbox.github.io/dropbox-sdk-js/
+[documentation]: https://dropbox.github.io/dropbox-sdk-js/Dropbox.html
+[dropbox-class]: https://dropbox.github.io/dropbox-sdk-js/Dropbox.html
+[dropbox-auth]: https://dropbox.github.io/dropbox-sdk-js/DropboxAuth.html
+[dropbox-error]: https://dropbox.github.io/dropbox-sdk-js/DropboxResponseError.html
+[global-api]: https://dropbox.github.io/dropbox-sdk-js/global.html
 [examples]: https://github.com/dropbox/dropbox-sdk-js/tree/main/examples
 [license]: https://github.com/dropbox/dropbox-sdk-js/blob/main/LICENSE
 [contributing]: https://github.com/dropbox/dropbox-sdk-js/blob/main/CONTRIBUTING.md
 [devconsole]: https://dropbox.com/developers/apps
 [oauthguide]: https://www.dropbox.com/lp/developers/reference/oauth-guide
+[pkce-example]: https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/pkce-browser
 [support]: https://www.dropbox.com/developers/contact

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ authorization-code flow.
 - [DropboxAuth class][dropbox-auth] — OAuth URLs, PKCE, access tokens, and token
   refresh.
 - [DropboxResponseError class][dropbox-error] — errors returned by API requests.
-- [Global API][global-api] — exported authentication helpers.
+- [Global API][global-api] — generated methods and route type definitions.
 
 The complete generated [API reference][documentation] is published on GitHub
 Pages.


### PR DESCRIPTION
## Summary

- document Node.js, browser, and Web Worker runtime support and requirements
- explain browser PKCE security and Web Crypto requirements
- clarify that npm packages are prebuilt and add Node.js, bundler, pinned CDN, and Worker examples
- link directly to generated API classes and remove the oversized banner
- rename the generated site to Dropbox JavaScript SDK

## Why

The existing landing page was Node-centric and unclear about browser packaging, supported environments, and safe client-side authentication. It also sent users through an oversized banner and a generic generated-docs landing page instead of directly to the useful API classes.

Closes #991.
Closes #1001.

## Validation

- `npm run generate-docs`
- generated local-link validation (8 links)
- served `index.html`, `Dropbox.html`, `DropboxAuth.html`, `DropboxResponseError.html`, and `global.html` locally; all returned HTTP 200
- `npm test` under Node.js 22: 220 tests passing
- `git diff --check`