### PR TITLE
Fix downloads with native fetch

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -44,13 +44,11 @@ export function parseDownloadResponse(res) {
   if (!res.ok) {
     return throwAsError(res);
   }
-  return new Promise((resolve) => {
-    if (isWindowOrWorker()) {
-      res.blob().then((data) => resolve(data));
-    } else {
-      res.buffer().then((data) => resolve(data));
-    }
-  }).then((data) => {
+  const dataPromise = isWindowOrWorker()
+    ? res.blob()
+    : res.arrayBuffer().then((data) => Buffer.from(data));
+
+  return dataPromise.then((data) => {
     const result = JSON.parse(res.headers.get('dropbox-api-result'));
 
     if (isWindowOrWorker()) {

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -54,6 +54,24 @@ for (const appType in appInfo) {
             })
             .catch(done);
         });
+
+        it('download request with native fetch returns a Buffer', (done) => {
+          const dbxWithNativeFetch = new Dropbox({ auth: dbxAuth, fetch: global.fetch });
+
+          dbxWithNativeFetch.sharingGetSharedLinkFile({
+            url: process.env.DROPBOX_SHARED_LINK,
+          })
+            .then((resp) => {
+              chai.assert.instanceOf(resp, DropboxResponse);
+              chai.assert.equal(resp.status, 200, resp.result);
+              chai.assert.isString(resp.result.name);
+              chai.assert.isTrue(Buffer.isBuffer(resp.result.fileBinary));
+              chai.assert.isAbove(resp.result.fileBinary.length, 0);
+
+              done();
+            })
+            .catch(done);
+        });
       });
 
       describe('upload', () => {

--- a/test/unit/response.js
+++ b/test/unit/response.js
@@ -65,6 +65,38 @@ describe('DropboxResponse', () => {
       return chai.assert.isFulfilled(parseDownloadResponse(response));
     });
 
+    it('parses a standards-compliant response as a Buffer', () => {
+      const init = {
+        status: 200,
+        headers: {
+          'dropbox-api-result': httpHeaderSafeJson({ name: 'test.bin' }),
+        },
+      };
+      const response = new global.Response(Buffer.from([0, 1, 255]), init);
+
+      return parseDownloadResponse(response).then((parsedResponse) => {
+        chai.assert.isTrue(Buffer.isBuffer(parsedResponse.result.fileBinary));
+        chai.assert.deepEqual([...parsedResponse.result.fileBinary], [0, 1, 255]);
+      });
+    });
+
+    it('propagates errors while reading the download body', () => {
+      const response = {
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => httpHeaderSafeJson({ name: 'test.bin' }),
+        },
+        arrayBuffer: () => Promise.reject(new Error('body read failed')),
+      };
+
+      return chai.assert.isRejected(
+        parseDownloadResponse(response),
+        Error,
+        'body read failed',
+      );
+    });
+
     it('throws an error when not a 200 status code', () => {
       const statusArray = [300, 400, 500];
       for (const status of statusArray) {


### PR DESCRIPTION
Fixes #1137.

## What changed

- Read Node download responses through the standard `Response.arrayBuffer()` API.
- Convert the resulting `ArrayBuffer` back to a Node `Buffer` to preserve the existing `fileBinary` contract.
- Propagate response body read failures instead of leaving the download promise unresolved.
- Add unit coverage using a native standards-compliant `Response` and a live integration test using native Node fetch.

## Why

The download parser called the node-fetch-specific `response.buffer()` extension. Native Node fetch and Bun return standards-compliant responses that expose `arrayBuffer()` but not `buffer()`, causing downloads to fail at runtime.

## Validation

- `npm test` — TypeScript checks and 222 unit tests passed
- `npm run lint`
- `npm run build`
- `npm run test:build` — 6 build compatibility tests passed
- Full live integration suite — 14 tests passed, including default node-fetch and native-fetch downloads
- `git diff --check`
