### PR TITLE
Fix DropboxAuth TypeScript return types

### DIFF
--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -73,10 +73,10 @@ export class DropboxAuth {
    * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use on
    * client apps which doesn't call your server. It is less secure than non-PKCE flow but
    * can be used if you are unable to safely retrieve your app secret
-   * @returns {Promise<String>} - Url to send user to for Dropbox API authentication
+   * @returns {Promise<string>} - Url to send user to for Dropbox API authentication
    * returned in a promise
    */
-  getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code', tokenAccessType?: null | 'legacy' | 'offline' | 'online', scope?: Array<String>, includeGrantedScopes?: 'none' | 'user' | 'team', usePKCE?: boolean): Promise<String>;
+  getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code', tokenAccessType?: null | 'legacy' | 'offline' | 'online', scope?: Array<String>, includeGrantedScopes?: 'none' | 'user' | 'team', usePKCE?: boolean): Promise<string>;
 
   /**
    * Get the client id
@@ -141,17 +141,17 @@ export class DropboxAuth {
   /**
    * Checks if a token is needed, can be refreshed and if the token is expired.
    * If so, attempts to refresh access token
-   * @returns {Promise<*>}
+   * @returns {Promise<void>}
    */
-  checkAndRefreshAccessToken(): void;
+  checkAndRefreshAccessToken(): Promise<void>;
 
   /**
    * Refreshes the access token using the refresh token, if available
    * @arg {List} scope - a subset of scopes from the original
    * refresh to acquire with an access token
-   * @returns {Promise<*>}
+   * @returns {Promise<void>}
    */
-  refreshAccessToken(scope?: Array<String>): void;
+  refreshAccessToken(scope?: Array<String>): Promise<void>;
 
 }
 
@@ -242,4 +242,3 @@ export class Dropbox {
   constructor(options: DropboxOptions);
 /*ROUTES*/
 }
-

--- a/test/types/types_test.js
+++ b/test/types/types_test.js
@@ -29,13 +29,13 @@ dropboxAuth.setClientId('myClientId');
 dropboxAuth.getClientId();
 dropboxAuth.setClientSecret('myClientSecret');
 // Test other methods
-dropboxAuth.getAuthenticationUrl('myRedirect');
+var authenticationUrl = dropboxAuth.getAuthenticationUrl('myRedirect');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'myState');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'myState', 'code');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'mystate', 'code', 'offline', ['scope', 'scope'], 'none', false);
 dropboxAuth.getAccessTokenFromCode('myRedirect', 'myCode');
-dropboxAuth.checkAndRefreshAccessToken();
-dropboxAuth.refreshAccessToken();
+var checkedAccessToken = dropboxAuth.checkAndRefreshAccessToken();
+var refreshedAccessToken = dropboxAuth.refreshAccessToken();
 dropboxAuth.refreshAccessToken(['files.metadata.read', 'files.metadata.write']);
 // Check Dropbox Constructor or Methods
 // Test config constructor

--- a/test/types/types_test.ts
+++ b/test/types/types_test.ts
@@ -33,13 +33,13 @@ dropboxAuth.getClientId();
 dropboxAuth.setClientSecret('myClientSecret');
 
 // Test other methods
-dropboxAuth.getAuthenticationUrl('myRedirect');
+const authenticationUrl: Promise<string> = dropboxAuth.getAuthenticationUrl('myRedirect');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'myState');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'myState', 'code');
 dropboxAuth.getAuthenticationUrl('myRedirect', 'mystate', 'code', 'offline', ['scope', 'scope'], 'none', false);
 dropboxAuth.getAccessTokenFromCode('myRedirect', 'myCode');
-dropboxAuth.checkAndRefreshAccessToken();
-dropboxAuth.refreshAccessToken();
+const checkedAccessToken: Promise<void> = dropboxAuth.checkAndRefreshAccessToken();
+const refreshedAccessToken: Promise<void> = dropboxAuth.refreshAccessToken();
 dropboxAuth.refreshAccessToken(['files.metadata.read', 'files.metadata.write']);
 
 // Check Dropbox Constructor or Methods

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,10 +74,10 @@ export class DropboxAuth {
    * @arg {boolean} [usePKCE] - Whether or not to use Sha256 based PKCE. PKCE should be only use on
    * client apps which doesn't call your server. It is less secure than non-PKCE flow but
    * can be used if you are unable to safely retrieve your app secret
-   * @returns {Promise<String>} - Url to send user to for Dropbox API authentication
+   * @returns {Promise<string>} - Url to send user to for Dropbox API authentication
    * returned in a promise
    */
-  getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code', tokenAccessType?: null | 'legacy' | 'offline' | 'online', scope?: Array<String>, includeGrantedScopes?: 'none' | 'user' | 'team', usePKCE?: boolean): Promise<String>;
+  getAuthenticationUrl(redirectUri: string, state?: string, authType?: 'token' | 'code', tokenAccessType?: null | 'legacy' | 'offline' | 'online', scope?: Array<String>, includeGrantedScopes?: 'none' | 'user' | 'team', usePKCE?: boolean): Promise<string>;
 
   /**
    * Get the client id
@@ -142,17 +142,17 @@ export class DropboxAuth {
   /**
    * Checks if a token is needed, can be refreshed and if the token is expired.
    * If so, attempts to refresh access token
-   * @returns {Promise<*>}
+   * @returns {Promise<void>}
    */
-  checkAndRefreshAccessToken(): void;
+  checkAndRefreshAccessToken(): Promise<void>;
 
   /**
    * Refreshes the access token using the refresh token, if available
    * @arg {List} scope - a subset of scopes from the original
    * refresh to acquire with an access token
-   * @returns {Promise<*>}
+   * @returns {Promise<void>}
    */
-  refreshAccessToken(scope?: Array<String>): void;
+  refreshAccessToken(scope?: Array<String>): Promise<void>;
 
 }
 
@@ -4077,4 +4077,3 @@ export class Dropbox {
      */
     public usersGetSpaceUsage(): Promise<DropboxResponse<users.SpaceUsage>>;
 }
-


### PR DESCRIPTION
Fixes #1128.
Fixes #1125.

## What changed

- Declare `DropboxAuth.checkAndRefreshAccessToken()` as returning `Promise<void>`.
- Declare `DropboxAuth.refreshAccessToken()` as returning `Promise<void>`.
- Correct `DropboxAuth.getAuthenticationUrl()` from `Promise<String>` to `Promise<string>`.
- Update the TypeScript template, regenerate the published declaration, and add compile-time regression coverage for all three return types.

## Why

The handwritten TypeScript template described the two refresh methods as returning `void`, even though both runtime paths return promises. It also used the boxed `String` type for the authentication URL instead of the primitive `string` type.

## Validation

- Regenerated declarations with `python3 generate_routes.py`
- `npm run test:typescript`
- Full test suite under Node 22 — 222 unit tests passed
- `npm run lint`
- `git diff --check`
- Packed the npm artifact and verified the corrected declarations in the shipped `types/index.d.ts`
