### PR TITLE
Use native fetch and fix ESM imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ The official Dropbox API v2 SDK for JavaScript.
 
 ## Runtime support
 
-The SDK supports Node.js, modern web browsers, and Web Workers. Continuous
-integration currently tests Node.js 22 and 24. Browser and Worker environments
-must provide `Promise`, `fetch`, and `TextEncoder`; PKCE authentication also
-requires the Web Crypto API. Add polyfills when targeting older environments
-that do not provide the required APIs.
+The SDK supports Node.js 22 and newer, modern web browsers, and Web Workers.
+Continuous integration currently tests Node.js 22 and 24, and Node.js uses its
+built-in `fetch` implementation. Browser and Worker environments must provide
+`Promise`, `fetch`, and `TextEncoder`; PKCE authentication also requires the Web
+Crypto API. Add polyfills when targeting older environments that do not provide
+the required APIs.
 
 ## Installation
 

--- a/examples/javascript/PKCE-backend/code_flow_example.js
+++ b/examples/javascript/PKCE-backend/code_flow_example.js
@@ -3,14 +3,12 @@
 // On the server logs, you should have the auth code, as well as the token
 // from exchanging it. This exchange is invisible to the app user
 
-const fetch = require('node-fetch');
 const app = require('express')();
 
 const hostname = 'localhost';
 const port = 3000;
 
 const config = {
-  fetch,
   clientId: '42zjexze6mfpf7x',
 };
 

--- a/examples/javascript/PKCE-backend/package.json
+++ b/examples/javascript/PKCE-backend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "PKCE-backend",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "dropbox": "file:../../../"
   }

--- a/examples/javascript/node/package-lock.json
+++ b/examples/javascript/node/package-lock.json
@@ -6,9 +6,6 @@
   "dependencies": {
     "dropbox": {
       "version": "file:../../..",
-      "requires": {
-        "node-fetch": "^2.6.1"
-      },
       "dependencies": {
         "@babel/cli": {
           "version": "7.11.6",
@@ -6873,11 +6870,6 @@
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             }
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-modules-regexp": {
           "version": "1.0.0",

--- a/examples/javascript/node/package.json
+++ b/examples/javascript/node/package.json
@@ -1,6 +1,9 @@
 {
   "name": "js-node-examples",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "dropbox": "file:../../../"
   }

--- a/examples/javascript/simple-backend/code_flow_example.js
+++ b/examples/javascript/simple-backend/code_flow_example.js
@@ -3,14 +3,12 @@
 // On the server logs, you should have the auth code, as well as the token
 // from exchanging it. This exchange is invisible to the app user
 
-const fetch = require('node-fetch');
 const app = require('express')();
 
 const hostname = 'localhost';
 const port = 3000;
 
 const config = {
-  fetch,
   clientId: 'APP_KEY_HERE',
   clientSecret: 'APP_SECRET_HERE',
 };

--- a/examples/javascript/simple-backend/package-lock.json
+++ b/examples/javascript/simple-backend/package-lock.json
@@ -6,9 +6,6 @@
   "dependencies": {
     "dropbox": {
       "version": "file:../../..",
-      "requires": {
-        "node-fetch": "^2.6.1"
-      },
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.1",
@@ -3983,11 +3980,6 @@
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             }
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "normalize-package-data": {
           "version": "2.4.0",

--- a/examples/javascript/simple-backend/package.json
+++ b/examples/javascript/simple-backend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "simple-backend",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "dropbox": "file:../../../"
   }

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -17,7 +17,7 @@
         "typescript": "^4.1.4"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=22"
       }
     },
     "../..": {
@@ -58,7 +58,7 @@
         "typescript": "^4.0.3"
       },
       "engines": {
-        "node": ">=0.10.3"
+        "node": ">=22"
       }
     },
     "../../node_modules/@babel/cli": {

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -24,9 +24,6 @@
       "name": "dropbox",
       "version": "10.33.0",
       "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1"
-      },
       "devDependencies": {
         "@babel/cli": "^7.11.6",
         "@babel/core": "^7.11.6",
@@ -34,7 +31,6 @@
         "@babel/register": "^7.11.5",
         "@testing-library/dom": "^7.24.5",
         "@types/node": "^14.11.2",
-        "@types/node-fetch": "^2.5.7",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
         "@typescript-eslint/parser": "^3.10.1",
         "babel-plugin-istanbul": "^6.0.0",
@@ -63,9 +59,6 @@
       },
       "engines": {
         "node": ">=0.10.3"
-      },
-      "peerDependencies": {
-        "@types/node-fetch": "^2.5.7"
       }
     },
     "../../node_modules/@babel/cli": {
@@ -1533,16 +1526,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
       "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
       "dev": true
-    },
-    "../../node_modules/@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
     },
     "../../node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.0.0",
@@ -5171,11 +5154,6 @@
         "path-to-regexp": "^1.7.0"
       }
     },
-    "../../node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "../../node_modules/node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
@@ -7737,7 +7715,6 @@
         "@babel/register": "^7.11.5",
         "@testing-library/dom": "^7.24.5",
         "@types/node": "^14.11.2",
-        "@types/node-fetch": "^2.5.7",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
         "@typescript-eslint/parser": "^3.10.1",
         "babel-plugin-istanbul": "^6.0.0",
@@ -7755,7 +7732,6 @@
         "jsdoc": "^3.6.6",
         "jsdom": "^16.4.0",
         "mocha": "^8.1.3",
-        "node-fetch": "^2.6.1",
         "nyc": "^15.1.0",
         "prompt": "^1.0.0",
         "rollup": "^2.28.2",
@@ -9249,16 +9225,6 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.23.tgz",
           "integrity": "sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==",
           "dev": true
-        },
-        "@types/node-fetch": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-          "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "form-data": "^3.0.0"
-          }
         },
         "@typescript-eslint/eslint-plugin": {
           "version": "4.0.0",
@@ -12970,11 +12936,6 @@
             "just-extend": "^4.0.2",
             "path-to-regexp": "^1.7.0"
           }
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "node-modules-regexp": {
           "version": "1.0.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=0.10"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3455,29 +3455,6 @@
       "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
       "dev": true
     },
-    "@types/node-fetch": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.11.tgz",
-      "integrity": "sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/yargs": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
@@ -7674,11 +7651,6 @@
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
       }
-    },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-modules-regexp": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "test": "test"
     },
     "engines": {
-        "node": ">=0.10.3"
+        "node": ">=22"
     },
     "contributors": [
         "Brad Rogers <brad12rogers@gmail.com>",
@@ -77,7 +77,6 @@
         "@babel/register": "^7.11.5",
         "@testing-library/dom": "^7.24.5",
         "@types/node": "^14.11.2",
-        "@types/node-fetch": "^2.5.7",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
         "@typescript-eslint/parser": "^3.10.1",
         "babel-plugin-istanbul": "^6.0.0",
@@ -103,11 +102,5 @@
         "rollup-plugin-terser": "^7.0.2",
         "sinon": "^9.0.3",
         "typescript": "^4.0.3"
-    },
-    "peerDependencies": {
-        "@types/node-fetch": "^2.5.7"
-    },
-    "dependencies": {
-        "node-fetch": "^2.6.1"
     }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -55,7 +55,9 @@ export default class DropboxAuth {
       crypto = self.crypto;
       /* eslint-enable no-restricted-globals */
     } else {
-      fetch = globalThis.fetch.bind(globalThis);
+      fetch = typeof globalThis.fetch === 'function'
+        ? globalThis.fetch.bind(globalThis)
+        : undefined;
       crypto = require('crypto'); // eslint-disable-line global-require
     }
 
@@ -66,6 +68,9 @@ export default class DropboxAuth {
     }
 
     this.fetch = options.fetch || fetch;
+    if (!this.fetch) {
+      throw new Error('A fetch implementation is required. Use Node.js 22 or later, or provide options.fetch.');
+    }
     this.accessToken = options.accessToken;
     this.accessTokenExpiresAt = options.accessTokenExpiresAt;
     this.refreshToken = options.refreshToken;

--- a/src/auth.js
+++ b/src/auth.js
@@ -55,7 +55,7 @@ export default class DropboxAuth {
       crypto = self.crypto;
       /* eslint-enable no-restricted-globals */
     } else {
-      fetch = require('node-fetch'); // eslint-disable-line global-require
+      fetch = globalThis.fetch.bind(globalThis);
       crypto = require('crypto'); // eslint-disable-line global-require
     }
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -145,6 +145,10 @@ export default class Dropbox {
           },
         };
 
+        if (contents && typeof contents.pipe === 'function') {
+          fetchOptions.duplex = 'half';
+        }
+
         this.setAuthHeaders(auth, fetchOptions);
         this.setCommonHeaders(fetchOptions);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { DEFAULT_API_DOMAIN, DEFAULT_DOMAIN, TEST_DOMAIN_MAPPINGS } from './constants';
+import { DEFAULT_API_DOMAIN, DEFAULT_DOMAIN, TEST_DOMAIN_MAPPINGS } from './constants.js';
 
 function getSafeUnicode(c) {
   const unicode = `000${c.charCodeAt(0).toString(16)}`.slice(-4);

--- a/test/build/node.js
+++ b/test/build/node.js
@@ -149,21 +149,27 @@ describe('Node Definitions', () => {
   describe('Built JS ESM entry point', () => {
     it('executes directly in Node', () => {
       const packageRoot = path.resolve(__dirname, '../..');
-      execFileSync(
-        process.execPath,
-        [
-          '--experimental-default-type=module',
-          '--input-type=module',
-          '--eval',
+      const esPackageJson = path.join(packageRoot, 'es/package.json');
+
+      fs.writeFileSync(esPackageJson, '{"type":"module"}\n');
+      try {
+        execFileSync(
+          process.execPath,
           [
-            "const sdk = await import('./es/index.js');",
-            "if (typeof sdk.Dropbox !== 'function' || typeof sdk.DropboxAuth !== 'function') {",
-            "  throw new Error('Built ES module did not expose the SDK entry points');",
-            '}',
-          ].join('\n'),
-        ],
-        { cwd: packageRoot, stdio: 'pipe' },
-      );
+            '--input-type=module',
+            '--eval',
+            [
+              "const sdk = await import('./es/index.js');",
+              "if (typeof sdk.Dropbox !== 'function' || typeof sdk.DropboxAuth !== 'function') {",
+              "  throw new Error('Built ES module did not expose the SDK entry points');",
+              '}',
+            ].join('\n'),
+          ],
+          { cwd: packageRoot, stdio: 'pipe' },
+        );
+      } finally {
+        fs.unlinkSync(esPackageJson);
+      }
     });
   });
 

--- a/test/build/node.js
+++ b/test/build/node.js
@@ -1,6 +1,20 @@
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
-const { exec } = require('child_process');
+const { exec, execFileSync, spawnSync } = require('child_process');
+
+const legacyFetchDependencies = ['node-fetch', 'whatwg-url', 'tr46'];
+
+const findLegacyFetchDependencies = (dependencies, matches = []) => {
+  Object.entries(dependencies || {}).forEach(([name, dependency]) => {
+    if (legacyFetchDependencies.includes(name)) {
+      matches.push(`${name}@${dependency.version}`);
+    }
+    findLegacyFetchDependencies(dependency.dependencies, matches);
+  });
+  return matches;
+};
 
 describe('Node Definitions', () => {
   describe('JS CJS Imports', () => {
@@ -130,5 +144,75 @@ describe('Node Definitions', () => {
     //     }
     //   });
     // });
+  });
+
+  describe('Built JS ESM entry point', () => {
+    it('executes directly in Node', () => {
+      const packageRoot = path.resolve(__dirname, '../..');
+      execFileSync(
+        process.execPath,
+        [
+          '--experimental-default-type=module',
+          '--input-type=module',
+          '--eval',
+          [
+            "const sdk = await import('./es/index.js');",
+            "if (typeof sdk.Dropbox !== 'function' || typeof sdk.DropboxAuth !== 'function') {",
+            "  throw new Error('Built ES module did not expose the SDK entry points');",
+            '}',
+          ].join('\n'),
+        ],
+        { cwd: packageRoot, stdio: 'pipe' },
+      );
+    });
+  });
+
+  describe('Runtime dependencies', () => {
+    let dirPath;
+
+    before(() => {
+      dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'dropbox-sdk-js-runtime-dependencies-'));
+      const npmCache = path.join(dirPath, '.npm-cache');
+      const packageRoot = path.resolve(__dirname, '../..');
+      const packOutput = execFileSync(
+        'npm',
+        ['pack', packageRoot, '--pack-destination', dirPath, '--cache', npmCache, '--json'],
+        { encoding: 'utf8' },
+      );
+      const [{ filename }] = JSON.parse(packOutput);
+      execFileSync(
+        'npm',
+        [
+          'install',
+          '--ignore-scripts',
+          '--no-save',
+          '--package-lock=false',
+          '--cache',
+          npmCache,
+          path.join(dirPath, filename),
+        ],
+        { cwd: dirPath, stdio: 'pipe' },
+      );
+    });
+
+    after(() => {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+    });
+
+    it('does not install the legacy fetch dependency chain', () => {
+      const npmList = spawnSync(
+        'npm',
+        ['ls', ...legacyFetchDependencies, '--all', '--json'],
+        { cwd: dirPath, encoding: 'utf8' },
+      );
+      if (!npmList.stdout) {
+        throw npmList.error || new Error(npmList.stderr);
+      }
+      const dependencyTree = JSON.parse(npmList.stdout);
+      const matches = [...new Set(findLegacyFetchDependencies(dependencyTree.dependencies))];
+      if (matches.length > 0) {
+        throw new Error(`Legacy fetch dependencies installed: ${matches.join(', ')}`);
+      }
+    });
   });
 });

--- a/test/build/node/js_cjs/package-lock.json
+++ b/test/build/node/js_cjs/package-lock.json
@@ -7,9 +7,6 @@
         "dropbox": {
             "version": "file:../../../..",
             "dev": true,
-            "requires": {
-                "node-fetch": "^2.6.1"
-            },
             "dependencies": {
                 "@babel/cli": {
                     "version": "7.11.6",
@@ -7386,12 +7383,6 @@
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                         }
                     }
-                },
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-                    "dev": true
                 },
                 "node-modules-regexp": {
                     "version": "1.0.0",

--- a/test/build/node/js_esm/package-lock.json
+++ b/test/build/node/js_esm/package-lock.json
@@ -7,9 +7,6 @@
         "dropbox": {
             "version": "file:../../../..",
             "dev": true,
-            "requires": {
-                "node-fetch": "^2.6.1"
-            },
             "dependencies": {
                 "@babel/cli": {
                     "version": "7.11.6",
@@ -7386,12 +7383,6 @@
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                         }
                     }
-                },
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-                    "dev": true
                 },
                 "node-modules-regexp": {
                     "version": "1.0.0",

--- a/test/build/node/ts_cjs/package-lock.json
+++ b/test/build/node/ts_cjs/package-lock.json
@@ -7,9 +7,6 @@
         "dropbox": {
             "version": "file:../../../..",
             "dev": true,
-            "requires": {
-                "node-fetch": "^2.6.1"
-            },
             "dependencies": {
                 "@babel/cli": {
                     "version": "7.11.6",
@@ -7386,12 +7383,6 @@
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                         }
                     }
-                },
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-                    "dev": true
                 },
                 "node-modules-regexp": {
                     "version": "1.0.0",

--- a/test/build/node/ts_es6/package-lock.json
+++ b/test/build/node/ts_es6/package-lock.json
@@ -7,9 +7,6 @@
         "dropbox": {
             "version": "file:../../../..",
             "dev": true,
-            "requires": {
-                "node-fetch": "^2.6.1"
-            },
             "dependencies": {
                 "@babel/cli": {
                     "version": "7.11.6",
@@ -7386,12 +7383,6 @@
                             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                         }
                     }
-                },
-                "node-fetch": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-                    "dev": true
                 },
                 "node-modules-regexp": {
                     "version": "1.0.0",

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { Readable } from 'stream';
 
 import chai from 'chai';
 
@@ -88,6 +89,41 @@ for (const appType in appInfo) {
                 })
                 .catch(done);
             });
+        });
+
+        it('upload request accepts a Node Readable with native fetch', (done) => {
+          const contents = 'native fetch readable upload';
+          const uploadPath = `/dropbox-sdk-js-readable-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
+          const dbxWithNativeFetch = new Dropbox({ auth: dbxAuth, fetch: global.fetch });
+          let uploaded = false;
+          let testError;
+          const cleanup = () => (uploaded
+            ? dbxWithNativeFetch.filesDeleteV2({ path: uploadPath })
+            : Promise.resolve());
+
+          dbxWithNativeFetch.filesUpload({
+            path: uploadPath,
+            contents: Readable.from([Buffer.from(contents)]),
+          })
+            .then((uploadResponse) => {
+              uploaded = true;
+
+              chai.assert.instanceOf(uploadResponse, DropboxResponse);
+              chai.assert.equal(uploadResponse.status, 200, uploadResponse.result);
+
+              return dbxWithNativeFetch.filesDownload({ path: uploadPath });
+            })
+            .then((downloadResponse) => {
+              chai.assert.instanceOf(downloadResponse, DropboxResponse);
+              chai.assert.equal(downloadResponse.status, 200, downloadResponse.result);
+              chai.assert.equal(downloadResponse.result.fileBinary.toString('utf8'), contents);
+            })
+            .catch((error) => {
+              testError = error;
+            })
+            .then(cleanup)
+            .then(() => done(testError))
+            .catch((cleanupError) => done(testError || cleanupError));
         });
       });
 

--- a/test/types/types_test.ts
+++ b/test/types/types_test.ts
@@ -5,7 +5,6 @@
  * and to perform a basic sanity check that types are exported as intended.
  */
 
-import { Headers } from 'node-fetch';
 import * as Dropbox from '../../types/index'; // eslint-disable-line
 
 // Check DropboxAuth Constructor and Methods

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -484,6 +484,7 @@ describe('DropboxAuth', () => {
   describe('fetch and crypto', () => {
     const windowRef = global.window;
     const selfRef = global.self;
+    const fetchRef = global.fetch;
     let spyOnFetch;
     let spyOnDigest;
     let spyOnIsBrowserEnv;
@@ -502,6 +503,10 @@ describe('DropboxAuth', () => {
       Object.defineProperty(global, 'self', {
         writable: true,
         value: selfRef,
+      });
+      Object.defineProperty(global, 'fetch', {
+        writable: true,
+        value: fetchRef,
       });
       spyOnIsBrowserEnv.restore();
       spyOnIsWorkerEnv.restore();
@@ -558,6 +563,19 @@ describe('DropboxAuth', () => {
       chai.assert(spyOnIsWorkerEnv.called);
       chai.assert(spyOnFetch.calledOnce);
       chai.assert(spyOnDigest.calledOnce);
+    });
+    it('uses an injected fetch when native fetch is unavailable', () => {
+      Object.defineProperty(global, 'fetch', {
+        writable: true,
+        value: undefined,
+      });
+      spyOnIsBrowserEnv.returns(false);
+      spyOnIsWorkerEnv.returns(false);
+
+      const dbxAuth = new DropboxAuth({ fetch: spyOnFetch });
+      dbxAuth.fetch();
+
+      chai.assert(spyOnFetch.calledOnce);
     });
   });
 });

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
+import { Readable } from 'stream';
 
 import { fail } from 'assert';
 import {
@@ -130,6 +131,24 @@ describe('Dropbox', () => {
       chai.assert.isTrue(uploadSpy.calledOnce);
       chai.assert.equal('path', dbx.uploadRequest.getCall(0).args[0]);
       chai.assert.deepEqual({}, dbx.uploadRequest.getCall(0).args[1]);
+    });
+
+    it('sets duplex for a Node Readable body', () => {
+      const fetchStub = sinon.stub().resolves(new Response('{}', { status: 200 }));
+      const auth = new DropboxAuth({ accessToken: 'token', fetch: fetchStub });
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+      const contents = Readable.from([Buffer.from('stream contents')]);
+
+      return dbx.uploadRequest(
+        '/files/upload',
+        { path: '/test.txt', contents },
+        USER_AUTH,
+        'content',
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.body, contents);
+        chai.assert.equal(fetchOptions.duplex, 'half');
+      });
     });
   });
 

--- a/test/unit/response.js
+++ b/test/unit/response.js
@@ -1,6 +1,5 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { Response } from 'node-fetch';
 import { httpHeaderSafeJson } from '../../src/utils';
 import {
   DropboxResponse,


### PR DESCRIPTION
Fixes #1101.
Fixes #1143.

## What changed

- Add the missing `.js` extension to the `src/utils.js` constants import.
- Add a build test that executes the generated ES-module entry point directly in Node.
- Use the native Node `fetch` implementation instead of the legacy `node-fetch` dependency.
- Continue honoring an injected `options.fetch` when native fetch is unavailable.
- Preserve Node `Readable` uploads by setting `duplex: 'half'` for stream bodies.
- Set the supported Node.js floor to 22 and align the executable examples with it.
- Remove `node-fetch`, `@types/node-fetch`, and their lockfile entries.
- Add a packed-consumer regression test that rejects the legacy `node-fetch -> whatwg-url -> tr46` chain.
- Use the standards-compliant global `Response` in tests.
- Add a real Dropbox integration test that uploads a `Readable`, downloads and verifies its contents, and deletes the temporary file.

## Why

The ES build contained one extensionless relative import, which native ESM resolution could not load. Separately, the CommonJS transport unconditionally required node-fetch 2, causing consumers to install an obsolete transitive dependency chain. A node-fetch 3 bump alone is not compatible with the SDK's current CommonJS `require()` architecture, so supported Node versions now use their built-in fetch implementation.

Node's native fetch also requires `duplex: 'half'` when a request body is a Node `Readable`. Adding it conditionally preserves stream upload compatibility from the previous node-fetch transport.

## Validation

- Full build: ES, CommonJS, UMD, and minified UMD
- Direct generated ES-module execution on Node.js 22 and 24
- Packed-consumer dependency test
- 224 unit tests
- TypeScript tests
- Full build compatibility suite
- 10 live Dropbox user integration tests, including native download and `Readable` upload coverage
- Complete Node.js 22/24 CI and live integration matrix on Ubuntu and macOS
- `npm run lint`
- `git diff --check`
