### PR TITLE
Add typed download response bodies

### DIFF
--- a/examples/typescript/download/download.ts
+++ b/examples/typescript/download/download.ts
@@ -17,11 +17,11 @@ prompt.get({
 }, (error: any, result: any) => {
   const dbx = new Dropbox({ accessToken: result.accessToken });
   dbx.sharingGetSharedLinkFile({ url: result.sharedLink })
-    .then((data: any) => {
-      // Note: The fileBinary field is not part of the Dropbox SDK
-      // specification, so it is not included in the TypeScript type.
-      // It is injected by the SDK.
-      fs.writeFile(data.result.name, (<any> data).result.fileBinary, { encoding: 'binary' }, (err) => {
+    .then((data) => {
+      if (!data.result.fileBinary) {
+        throw new Error('Expected fileBinary in a Node.js environment.');
+      }
+      fs.writeFile(data.result.name, data.result.fileBinary, { encoding: 'binary' }, (err) => {
         if (err) { throw err; }
         console.log(`File: ${data.result.name} saved.`);
       });

--- a/generator/generate_routes.py
+++ b/generator/generate_routes.py
@@ -36,6 +36,8 @@ _cmdline_parser.add_argument(
 def main():
     """The entry point for the program."""
 
+    os.environ.setdefault('PYTHONDONTWRITEBYTECODE', '1')
+
     args = _cmdline_parser.parse_args()
     verbose = args.verbose
 
@@ -66,6 +68,9 @@ def main():
         os.path.join(os.path.dirname(sys.argv[0]), '../types'))
     if verbose:
         print('Types template path: %s' % types_template_path)
+
+    typescript_client_backend_path = os.path.join(
+        typescript_template_path, 'dropbox_tsd_client.stoneg.py')
 
     upload_arg = {
         "match": ["style", "upload"],
@@ -103,7 +108,8 @@ def main():
     if verbose:
         print('Generating TSD client routes for user routes')
     subprocess.check_output(
-        (['python3', '-m', 'stone.cli', 'tsd_client', typescript_template_path] +
+        (['python3', '-m', 'stone.cli', typescript_client_backend_path,
+          typescript_template_path] +
          specs + ['-a', 'host', '-a', 'style', '-a', 'scope'] +
          ['--', 'index.d.tstemplate', 'index.d.ts', '--wrap-response-in', 'DropboxResponse', '--wrap-error-in', 'DropboxResponseError', '--import-namespaces', '--types-file', './dropbox_types', '-a', 'scope']),
         cwd=stone_path)

--- a/generator/typescript/dropbox_tsd_client.stoneg.py
+++ b/generator/typescript/dropbox_tsd_client.stoneg.py
@@ -1,0 +1,60 @@
+from stone.backends import tsd_client
+from stone.backends.tsd_helpers import fmt_error_type, fmt_func, fmt_type
+from stone.ir import Void
+
+
+class DropboxTSDClientBackend(tsd_client.TSDClientBackend):
+    """Generate SDK client declarations with download body types."""
+
+    def _generate_route(self, namespace, route):
+        function_name = fmt_func(namespace.name + '_' + route.name, route.version)
+        self.emit()
+        self.emit('/**')
+        if route.doc:
+            self.emit_wrapped_text(self.process_doc(route.doc, self._docf), prefix=' * ')
+            self.emit(' *')
+
+        attrs_lines = []
+        if self.args.attribute_comment and route.attrs:
+            for attribute in self.args.attribute_comment:
+                if attribute in route.attrs and route.attrs[attribute] is not None:
+                    attrs_lines.append(' *   {}: {}'.format(attribute, route.attrs[attribute]))
+        if attrs_lines:
+            self.emit(' * Route attributes:')
+            for attr_line in attrs_lines:
+                self.emit(attr_line)
+            self.emit(' *')
+
+        self.emit_wrapped_text(
+            'When an error occurs, the route rejects the promise with type {}.'.format(
+                fmt_error_type(
+                    route.error_data_type,
+                    wrap_error_in=self.args.wrap_error_in,
+                )
+            ),
+            prefix=' * ',
+        )
+        if route.deprecated:
+            self.emit(' * @deprecated')
+
+        if route.arg_data_type.__class__ != Void:
+            self.emit(' * @param arg The request parameters.')
+        self.emit(' */')
+
+        result_type = fmt_type(route.result_data_type)
+        if route.attrs.get('style') == 'download':
+            result_type = 'DropboxDownloadResult<{}>'.format(result_type)
+
+        if self.args.wrap_response_in:
+            return_type = 'Promise<{}<{}>>;'.format(
+                self.args.wrap_response_in,
+                result_type,
+            )
+        else:
+            return_type = 'Promise<{}>;'.format(result_type)
+
+        arg = ''
+        if route.arg_data_type.__class__ != Void:
+            arg = 'arg: {}'.format(fmt_type(route.arg_data_type))
+
+        self.emit('public {}({}): {}'.format(function_name, arg, return_type))

--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -3,6 +3,27 @@
 /*IMPORT*/
 export * from './dropbox_types';
 
+/** Binary download content returned by the SDK in Node.js environments. */
+export interface DropboxFileBinary extends Uint8Array {
+  toString(encoding?: string, start?: number, end?: number): string;
+}
+
+/** Blob download content returned by the SDK in browser and Worker environments. */
+export interface DropboxFileBlob {
+  readonly size: number;
+  readonly type: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  slice(start?: number, end?: number, contentType?: string): DropboxFileBlob;
+  stream(): any;
+  text(): Promise<string>;
+}
+
+/** API result augmented with the downloaded file content for the current environment. */
+export type DropboxDownloadResult<T> = T & (
+  | { fileBinary: DropboxFileBinary; fileBlob?: never }
+  | { fileBinary?: never; fileBlob: DropboxFileBlob }
+);
+
 export interface DropboxAuthOptions {
   // An access token for making authenticated requests.
   accessToken?: string;

--- a/test/types/types_test.js
+++ b/test/types/types_test.js
@@ -67,3 +67,24 @@ dropbox.usersGetCurrentAccount()
     var errorObject = error.error;
 });
 dropbox2.usersGetCurrentAccount();
+// Download routes expose the SDK-injected body for both supported environments.
+dropbox.filesDownload({ path: '/test.txt' })
+    .then(function (response) {
+    var _a = response.result, fileBinary = _a.fileBinary, fileBlob = _a.fileBlob;
+    if (fileBinary) {
+        fileBinary.toString('utf8');
+    }
+    if (fileBlob) {
+        fileBlob.arrayBuffer();
+    }
+});
+dropbox.sharingGetSharedLinkFile({ url: 'https://www.dropbox.com/example' })
+    .then(function (response) {
+    var _a = response.result, fileBinary = _a.fileBinary, fileBlob = _a.fileBlob;
+    if (fileBinary) {
+        fileBinary.toString('utf8');
+    }
+    if (fileBlob) {
+        fileBlob.text();
+    }
+});

--- a/test/types/types_test.ts
+++ b/test/types/types_test.ts
@@ -73,3 +73,34 @@ dropbox.usersGetCurrentAccount()
     const errorObject: Dropbox.users.GetAccountError = error.error;
   });
 dropbox2.usersGetCurrentAccount();
+
+// Download routes expose the SDK-injected body for both supported environments.
+dropbox.filesDownload({ path: '/test.txt' })
+  .then((response) => {
+    const {
+      fileBinary,
+      fileBlob,
+    } = response.result;
+
+    if (fileBinary) {
+      fileBinary.toString('utf8');
+    }
+    if (fileBlob) {
+      fileBlob.arrayBuffer();
+    }
+  });
+
+dropbox.sharingGetSharedLinkFile({ url: 'https://www.dropbox.com/example' })
+  .then((response) => {
+    const {
+      fileBinary,
+      fileBlob,
+    } = response.result;
+
+    if (fileBinary) {
+      fileBinary.toString('utf8');
+    }
+    if (fileBlob) {
+      fileBlob.text();
+    }
+  });

--- a/test/unit/response.js
+++ b/test/unit/response.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { httpHeaderSafeJson } from '../../src/utils';
+import sinon from 'sinon';
+import * as utils from '../../src/utils';
 import {
   DropboxResponse,
   parseResponse,
@@ -57,7 +58,7 @@ describe('DropboxResponse', () => {
       const init = {
         status: 200,
         headers: {
-          'dropbox-api-result': httpHeaderSafeJson({ fileBinary: 'test' }),
+          'dropbox-api-result': utils.httpHeaderSafeJson({ fileBinary: 'test' }),
         },
       };
       const response = new Response(undefined, init);
@@ -68,7 +69,7 @@ describe('DropboxResponse', () => {
       const init = {
         status: 200,
         headers: {
-          'dropbox-api-result': httpHeaderSafeJson({ name: 'test.bin' }),
+          'dropbox-api-result': utils.httpHeaderSafeJson({ name: 'test.bin' }),
         },
       };
       const response = new global.Response(Buffer.from([0, 1, 255]), init);
@@ -79,12 +80,31 @@ describe('DropboxResponse', () => {
       });
     });
 
+    it('parses a browser response as a Blob', () => {
+      const isWindowOrWorker = sinon.stub(utils, 'isWindowOrWorker').returns(true);
+      const init = {
+        status: 200,
+        headers: {
+          'dropbox-api-result': utils.httpHeaderSafeJson({ name: 'test.bin' }),
+        },
+      };
+      const response = new global.Response(Buffer.from([0, 1, 255]), init);
+
+      return parseDownloadResponse(response)
+        .then((parsedResponse) => {
+          chai.assert.instanceOf(parsedResponse.result.fileBlob, Blob);
+          chai.assert.equal(parsedResponse.result.fileBlob.size, 3);
+          chai.assert.isUndefined(parsedResponse.result.fileBinary);
+        })
+        .finally(() => isWindowOrWorker.restore());
+    });
+
     it('propagates errors while reading the download body', () => {
       const response = {
         ok: true,
         status: 200,
         headers: {
-          get: () => httpHeaderSafeJson({ name: 'test.bin' }),
+          get: () => utils.httpHeaderSafeJson({ name: 'test.bin' }),
         },
         arrayBuffer: () => Promise.reject(new Error('body read failed')),
       };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,27 @@
 import { account, async, auth, check, common, contacts, file_properties, file_requests, files, openid, paper, secondary_emails, seen_state, sharing, team, team_common, team_log, team_policies, users, users_common } from './dropbox_types';
 export * from './dropbox_types';
 
+/** Binary download content returned by the SDK in Node.js environments. */
+export interface DropboxFileBinary extends Uint8Array {
+  toString(encoding?: string, start?: number, end?: number): string;
+}
+
+/** Blob download content returned by the SDK in browser and Worker environments. */
+export interface DropboxFileBlob {
+  readonly size: number;
+  readonly type: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  slice(start?: number, end?: number, contentType?: string): DropboxFileBlob;
+  stream(): any;
+  text(): Promise<string>;
+}
+
+/** API result augmented with the downloaded file content for the current environment. */
+export type DropboxDownloadResult<T> = T & (
+  | { fileBinary: DropboxFileBinary; fileBlob?: never }
+  | { fileBinary?: never; fileBlob: DropboxFileBlob }
+);
+
 export interface DropboxAuthOptions {
   // An access token for making authenticated requests.
   accessToken?: string;
@@ -936,7 +957,7 @@ export class Dropbox {
      * DropboxResponseError<files.DownloadError>.
      * @param arg The request parameters.
      */
-    public filesDownload(arg: files.DownloadArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesDownload(arg: files.DownloadArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Download a folder from the user's Dropbox, as a zip file. The folder must
@@ -952,7 +973,7 @@ export class Dropbox {
      * DropboxResponseError<files.DownloadZipError>.
      * @param arg The request parameters.
      */
-    public filesDownloadZip(arg: files.DownloadZipArg): Promise<DropboxResponse<files.DownloadZipResult>>;
+    public filesDownloadZip(arg: files.DownloadZipArg): Promise<DropboxResponse<DropboxDownloadResult<files.DownloadZipResult>>>;
 
     /**
      * Export a file from a user's Dropbox. This route only supports exporting
@@ -966,7 +987,7 @@ export class Dropbox {
      * DropboxResponseError<files.ExportError>.
      * @param arg The request parameters.
      */
-    public filesExport(arg: files.ExportArg): Promise<DropboxResponse<files.ExportResult>>;
+    public filesExport(arg: files.ExportArg): Promise<DropboxResponse<DropboxDownloadResult<files.ExportResult>>>;
 
     /**
      * Return the lock metadata for the given list of paths.
@@ -1008,7 +1029,7 @@ export class Dropbox {
      * DropboxResponseError<files.PreviewError>.
      * @param arg The request parameters.
      */
-    public filesGetPreview(arg: files.PreviewArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesGetPreview(arg: files.PreviewArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Get a temporary link to stream content of a file. This link will expire
@@ -1078,7 +1099,7 @@ export class Dropbox {
      * DropboxResponseError<files.ThumbnailError>.
      * @param arg The request parameters.
      */
-    public filesGetThumbnail(arg: files.ThumbnailArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesGetThumbnail(arg: files.ThumbnailArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Get a thumbnail for an image. This method currently supports files with
@@ -1093,7 +1114,7 @@ export class Dropbox {
      * DropboxResponseError<files.ThumbnailV2Error>.
      * @param arg The request parameters.
      */
-    public filesGetThumbnailV2(arg: files.ThumbnailV2Arg): Promise<DropboxResponse<files.PreviewResult>>;
+    public filesGetThumbnailV2(arg: files.ThumbnailV2Arg): Promise<DropboxResponse<DropboxDownloadResult<files.PreviewResult>>>;
 
     /**
      * Get thumbnails for a list of images. We allow up to 25 thumbnails in a
@@ -1832,7 +1853,7 @@ export class Dropbox {
      * @deprecated
      * @param arg The request parameters.
      */
-    public paperDocsDownload(arg: paper.PaperDocExport): Promise<DropboxResponse<paper.PaperDocExportResult>>;
+    public paperDocsDownload(arg: paper.PaperDocExport): Promise<DropboxResponse<DropboxDownloadResult<paper.PaperDocExportResult>>>;
 
     /**
      * Lists the users who are explicitly invited to the Paper folder in which
@@ -2277,7 +2298,7 @@ export class Dropbox {
      * DropboxResponseError<sharing.GetSharedLinkFileError>.
      * @param arg The request parameters.
      */
-    public sharingGetSharedLinkFile(arg: sharing.GetSharedLinkFileArg): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
+    public sharingGetSharedLinkFile(arg: sharing.GetSharedLinkFileArg): Promise<DropboxResponse<DropboxDownloadResult<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>>;
 
     /**
      * Get the shared link's metadata.


### PR DESCRIPTION
Fixes #809.
Fixes #1136.

## What changed

- Add SDK-specific `DropboxDownloadResult<T>`, `DropboxFileBinary`, and `DropboxFileBlob` declarations.
- Generate augmented results automatically for every Stone route with `style = "download"`.
- Cover all eight current download-style endpoints instead of modifying `FileMetadata` globally.
- Update the TypeScript download example to use `fileBinary` without an `any` cast.
- Add compile-time coverage for Node and browser download bodies.
- Add runtime coverage for the browser `Blob` response path.

## Why

The Dropbox API specification describes the metadata returned in the response header, while the JavaScript SDK separately injects the downloaded body into `result.fileBinary` in Node.js or `result.fileBlob` in browsers and Workers. The generated TypeScript declarations modeled only the API metadata, so valid runtime properties failed to compile.

The SDK-specific Stone backend now augments download routes during generation, keeping the fix stable across future spec updates without adding download-only properties to metadata returned by unrelated endpoints.

## Validation

- Regenerated all routes and declarations twice from the current Stone/spec pins
- `npm run test:typescript`
- TypeScript examples build
- `npm run lint`
- 225 unit tests
- Full ES, CommonJS, UMD, and minified UMD build
- 8 browser, packed-consumer, CommonJS, and ES-module build compatibility tests
- 15 live Dropbox user/team integration tests
- Real headless Chrome download using the built UMD SDK: native `Blob`, 1,102,331 bytes, and no `fileBinary`
- Browser TypeScript check using `URL.createObjectURL(result.fileBlob)`
- `git diff --check`
