### PR TITLE
Preserve upload request arguments

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -133,15 +133,16 @@ export default class Dropbox {
   uploadRequest(path, args, auth, host) {
     return this.auth.checkAndRefreshAccessToken()
       .then(() => {
-        const { contents } = args;
-        delete args.contents;
+        const requestArgs = Object.assign({}, args); // eslint-disable-line prefer-object-spread
+        const { contents } = requestArgs;
+        delete requestArgs.contents;
 
         const fetchOptions = {
           body: contents,
           method: 'POST',
           headers: {
             'Content-Type': 'application/octet-stream',
-            'Dropbox-API-Arg': httpHeaderSafeJson(args),
+            'Dropbox-API-Arg': httpHeaderSafeJson(requestArgs),
           },
         };
 

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -150,6 +150,50 @@ describe('Dropbox', () => {
         chai.assert.equal(fetchOptions.duplex, 'half');
       });
     });
+
+    it('can reuse upload arguments after a successful request', () => {
+      const fetchStub = sinon.stub().callsFake(
+        () => Promise.resolve(new Response('{}', { status: 200 })),
+      );
+      const auth = new DropboxAuth({ accessToken: 'token', fetch: fetchStub });
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+      const contents = Buffer.from('reusable contents');
+      const args = { path: '/test.txt', contents };
+
+      return dbx.filesUpload(args)
+        .then(() => dbx.filesUpload(args))
+        .then(() => {
+          chai.assert.strictEqual(args.contents, contents);
+          chai.assert.strictEqual(fetchStub.firstCall.args[1].body, contents);
+          chai.assert.strictEqual(fetchStub.secondCall.args[1].body, contents);
+          chai.assert.deepEqual(
+            JSON.parse(fetchStub.firstCall.args[1].headers['Dropbox-API-Arg']),
+            { path: '/test.txt' },
+          );
+        });
+    });
+
+    it('can reuse upload arguments after a rejected request', () => {
+      const fetchStub = sinon.stub();
+      fetchStub.onFirstCall().resolves(new Response('{}', { status: 429 }));
+      fetchStub.onSecondCall().resolves(new Response('{}', { status: 200 }));
+      const auth = new DropboxAuth({ accessToken: 'token', fetch: fetchStub });
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+      const contents = Buffer.from('reusable contents');
+      const args = { path: '/test.txt', contents };
+
+      return chai.assert.isRejected(dbx.filesUpload(args))
+        .then(() => dbx.filesUpload(args))
+        .then(() => {
+          chai.assert.strictEqual(args.contents, contents);
+          chai.assert.strictEqual(fetchStub.firstCall.args[1].body, contents);
+          chai.assert.strictEqual(fetchStub.secondCall.args[1].body, contents);
+          chai.assert.deepEqual(
+            JSON.parse(fetchStub.secondCall.args[1].headers['Dropbox-API-Arg']),
+            { path: '/test.txt' },
+          );
+        });
+    });
   });
 
   describe('Download Requests', () => {


### PR DESCRIPTION
## Summary

- preserve caller-provided upload arguments instead of deleting `contents`
- continue sending `contents` as the request body while excluding it from `Dropbox-API-Arg`
- cover reuse after a successful upload and after an HTTP 429 rejection

Closes #969.

## Root cause

`uploadRequest` removed `contents` directly from the object supplied by the caller. Retrying with the same object therefore sent an empty request body. The request now uses a shallow copy for header serialization and leaves the caller's object unchanged.

## Validation

- reproduced both regressions before the fix: 0 passing, 2 failing
- Node.js 22 unit tests: 227 passing
- Node.js 24 unit tests: 227 passing
- TypeScript compilation
- ESLint
- full SDK build
- `git diff --check`
