### PR TITLE
Use OIDC for npm publishing

### DIFF
--- a/.github/workflows/npm_upload.yml
+++ b/.github/workflows/npm_upload.yml
@@ -1,12 +1,13 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-
 name: Publish to NPM
 
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   npm:
@@ -15,12 +16,14 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
-      - name: Build Package
-        run: |
-          npm install
-          npm run build
-      - name: NPM Publish
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Build package
+        run: npm run build
+      - name: Publish package
+        run: npm publish


### PR DESCRIPTION
## Summary

Switch npm publishing to GitHub Actions OIDC trusted publishing. The release workflow now runs tests and builds before publishing, and triggers when a GitHub Release is published.

## Validation

- `npm test`
- `npm run build`
- `actionlint .github/workflows/npm_upload.yml`
