### PR TITLE
Prepare 10.36.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dropbox",
-  "version": "10.34.0",
+  "version": "10.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dropbox",
-    "version": "10.34.0",
+    "version": "10.36.0",
     "registry": "npm",
     "description": "The Dropbox JavaScript SDK is a lightweight, promise based interface to the Dropbox v2 API that works in both nodejs and browser environments.",
     "main": "cjs/index.js",


### PR DESCRIPTION
## Summary

Bump the package version to `10.36.0` for the next npm release.

## Validation

- `npm test`
- `npm run build`
- `npm pack --dry-run`
