### PR TITLE
Fix automated npm releases

### DIFF
--- a/.github/workflows/npm_upload.yml
+++ b/.github/workflows/npm_upload.yml
@@ -1,9 +1,11 @@
 name: Publish to NPM
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
   workflow_dispatch:
-  release:
-    types: [published]
 
 permissions:
   contents: read
@@ -25,5 +27,16 @@ jobs:
         run: npm test
       - name: Build package
         run: npm run build
+      - name: Check package version
+        id: package
+        run: |
+          PACKAGE_NAME="$(node -p 'require("./package.json").name')"
+          PACKAGE_VERSION="$(node -p 'require("./package.json").version')"
+          if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version > /dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Publish package
-        run: npm publish
+        if: steps.package.outputs.publish == 'true'
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary

Publish new package versions automatically after they are merged to `main`, and explicitly enable npm provenance for trusted publishing.

## Validation

- `actionlint .github/workflows/npm_upload.yml`
