### PR TITLE
Handle incomplete browser globals

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -47,7 +47,7 @@ export default class DropboxAuth {
   constructor(options) {
     options = options || {};
 
-    if (isBrowserEnv()) {
+    if (isBrowserEnv() && typeof window.fetch === 'function') {
       fetch = window.fetch.bind(window);
       crypto = window.crypto || window.msCrypto; // for IE11
     } else if (isWorkerEnv()) {

--- a/test/unit/auth.js
+++ b/test/unit/auth.js
@@ -588,12 +588,33 @@ describe('DropboxAuth', () => {
       chai.assert(spyOnFetch.calledOnce);
       chai.assert(spyOnDigest.calledOnce);
     });
+    it('uses native fetch when window exists without fetch', () => {
+      Object.defineProperty(global, 'window', {
+        writable: true,
+        value: {},
+      });
+      Object.defineProperty(global, 'fetch', {
+        writable: true,
+        value: spyOnFetch,
+      });
+      spyOnIsBrowserEnv.returns(true);
+      spyOnIsWorkerEnv.returns(false);
+
+      const dbxAuth = new DropboxAuth();
+      dbxAuth.fetch();
+
+      chai.assert(spyOnFetch.calledOnce);
+    });
     it('uses an injected fetch when native fetch is unavailable', () => {
+      Object.defineProperty(global, 'window', {
+        writable: true,
+        value: {},
+      });
       Object.defineProperty(global, 'fetch', {
         writable: true,
         value: undefined,
       });
-      spyOnIsBrowserEnv.returns(false);
+      spyOnIsBrowserEnv.returns(true);
       spyOnIsWorkerEnv.returns(false);
 
       const dbxAuth = new DropboxAuth({ fetch: spyOnFetch });


### PR DESCRIPTION
## Summary

- require `window.fetch` to be callable before using the browser-specific binding
- fall back to native fetch when a Node.js application exposes an incomplete `window` global
- preserve an injected `options.fetch` in the same environment

## Root cause

`isBrowserEnv()` treats any defined `window` global as a browser. In Node.js applications where another dependency creates an incomplete `global.window`, the SDK attempted to bind a missing `window.fetch` before it could use native or injected fetch.

## Validation

- reproduced the failure on Node.js 24 before the fix for both native and injected fetch
- repeated both reproduction cases successfully after the fix
- `npm run lint`
- `npm test` (`229 passing` plus TypeScript tests)
- `npm run build`
- `npm run test:build` (`12 passing`)
- real-browser validation of UMD and minified UMD bundles with injected fetch and unavailable `window.fetch`

Fixes #1134
