### PR TITLE
Add Dropbox content hash utility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 24]
+        node: [22, 24, 26]
     steps:
       - uses: actions/checkout@v7
       - name: Setup Node.js environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 24, 26]
+        node: [22, 24]
     steps:
       - uses: actions/checkout@v7
       - name: Setup Node.js environment

--- a/src/content-hasher.js
+++ b/src/content-hasher.js
@@ -1,0 +1,129 @@
+import crypto from 'crypto';
+
+const BLOCK_SIZE = 4 * 1024 * 1024;
+
+/**
+ * Computes hashes using the same block-based algorithm as Dropbox's
+ * content_hash metadata field.
+ */
+class DropboxContentHasher {
+  constructor() {
+    this.overallHasher = crypto.createHash('sha256');
+    this.blockHasher = crypto.createHash('sha256');
+    this.blockPosition = 0;
+    this.finished = false;
+  }
+
+  /**
+   * Adds binary data to the hash.
+   *
+   * @param {Buffer|Uint8Array|ArrayBuffer} data Binary data to hash.
+   * @returns {DropboxContentHasher} This hasher instance.
+   */
+  update(data) {
+    this.assertNotFinished();
+
+    const bytes = DropboxContentHasher.toBuffer(data);
+
+    let position = 0;
+
+    while (position < bytes.length) {
+      if (this.blockPosition === BLOCK_SIZE) {
+        this.finishBlock();
+      }
+
+      const remainingBlockSpace = BLOCK_SIZE - this.blockPosition;
+      const remainingData = bytes.length - position;
+      const length = Math.min(remainingBlockSpace, remainingData);
+
+      this.blockHasher.update(
+        bytes.subarray(position, position + length),
+      );
+
+      this.blockPosition += length;
+      position += length;
+    }
+
+    return this;
+  }
+
+  /**
+   * Returns the final Dropbox content hash.
+   *
+   * @param {'hex'|undefined} encoding Optional output encoding.
+   * @returns {Buffer|string} Binary digest, or a hexadecimal string.
+   */
+  digest(encoding) {
+    this.assertNotFinished();
+
+    if (this.blockPosition > 0) {
+      this.finishBlock();
+    }
+
+    this.finished = true;
+
+    if (encoding === undefined) {
+      return this.overallHasher.digest();
+    }
+
+    if (encoding !== 'hex') {
+      throw new TypeError('DropboxContentHasher only supports hex encoding');
+    }
+
+    return this.overallHasher.digest('hex');
+  }
+
+  finishBlock() {
+    this.overallHasher.update(this.blockHasher.digest());
+    this.blockHasher = crypto.createHash('sha256');
+    this.blockPosition = 0;
+  }
+
+  assertNotFinished() {
+    if (this.finished) {
+      throw new Error(
+        'DropboxContentHasher cannot be used after digest() has been called',
+      );
+    }
+  }
+
+  static toBuffer(data) {
+    if (Buffer.isBuffer(data)) {
+      return data;
+    }
+
+    if (data instanceof ArrayBuffer) {
+      return Buffer.from(data);
+    }
+
+    if (ArrayBuffer.isView(data)) {
+      return Buffer.from(
+        data.buffer,
+        data.byteOffset,
+        data.byteLength,
+      );
+    }
+
+    throw new TypeError(
+      'DropboxContentHasher.update() expects a Buffer, Uint8Array, or ArrayBuffer',
+    );
+  }
+}
+
+/**
+ * Computes the Dropbox content hash for a complete binary payload.
+ *
+ * @param {Buffer|Uint8Array|ArrayBuffer} data Binary data to hash.
+ * @returns {string} Lowercase hexadecimal Dropbox content hash.
+ */
+function contentHash(data) {
+  return new DropboxContentHasher()
+    .update(data)
+    .digest('hex');
+}
+
+export {
+  BLOCK_SIZE,
+  DropboxContentHasher,
+  contentHash,
+};

--- a/test/unit/content-hasher.js
+++ b/test/unit/content-hasher.js
@@ -1,0 +1,143 @@
+import { expect } from 'chai';
+import crypto from 'crypto';
+
+import {
+  BLOCK_SIZE,
+  DropboxContentHasher,
+  contentHash,
+} from '../../src/content-hasher.js';
+
+function referenceContentHash(data) {
+  const blockHashes = [];
+
+  for (let offset = 0; offset < data.length; offset += BLOCK_SIZE) {
+    const block = data.subarray(
+      offset,
+      Math.min(offset + BLOCK_SIZE, data.length),
+    );
+
+    blockHashes.push(
+      crypto.createHash('sha256').update(block).digest(),
+    );
+  }
+
+  return crypto
+    .createHash('sha256')
+    .update(Buffer.concat(blockHashes))
+    .digest('hex');
+}
+
+describe('DropboxContentHasher', () => {
+  it('hashes empty content', () => {
+    expect(contentHash(Buffer.alloc(0))).to.equal(
+      crypto.createHash('sha256').update(Buffer.alloc(0)).digest('hex'),
+    );
+  });
+
+  it('hashes content smaller than one block', () => {
+    const data = Buffer.from('hello world');
+
+    expect(contentHash(data)).to.equal(referenceContentHash(data));
+  });
+
+  it('hashes exactly one block', () => {
+    const data = Buffer.alloc(BLOCK_SIZE, 0x61);
+
+    expect(contentHash(data)).to.equal(referenceContentHash(data));
+  });
+
+  it('hashes multiple blocks', () => {
+    const data = Buffer.alloc(BLOCK_SIZE + 123, 0x62);
+
+    expect(contentHash(data)).to.equal(referenceContentHash(data));
+  });
+
+  it('supports multiple update calls', () => {
+    const data = Buffer.alloc((BLOCK_SIZE * 2) + 500, 0x63);
+    const hasher = new DropboxContentHasher();
+
+    for (let offset = 0; offset < data.length; offset += 1000) {
+      hasher.update(data.subarray(offset, offset + 1000));
+    }
+
+    expect(hasher.digest('hex')).to.equal(referenceContentHash(data));
+  });
+
+  it('returns itself from update', () => {
+    const hasher = new DropboxContentHasher();
+
+    expect(hasher.update(Buffer.from('data'))).to.equal(hasher);
+  });
+
+  it('returns a Buffer from digest without encoding', () => {
+    const hasher = new DropboxContentHasher();
+
+    hasher.update(Buffer.from('data'));
+
+    const digest = hasher.digest();
+
+    expect(Buffer.isBuffer(digest)).to.equal(true);
+    expect(digest.toString('hex')).to.equal(
+      contentHash(Buffer.from('data')),
+    );
+  });
+
+  it('supports Uint8Array input', () => {
+    const data = new Uint8Array([1, 2, 3, 4]);
+
+    expect(contentHash(data)).to.equal(
+      referenceContentHash(Buffer.from(data)),
+    );
+  });
+
+  it('supports ArrayBuffer input', () => {
+    const data = new Uint8Array([5, 6, 7, 8]).buffer;
+
+    expect(contentHash(data)).to.equal(
+      referenceContentHash(Buffer.from(data)),
+    );
+  });
+
+  it('supports views with a nonzero byte offset', () => {
+    const source = new Uint8Array([0, 1, 2, 3, 4, 5]);
+    const data = source.subarray(2, 5);
+
+    expect(contentHash(data)).to.equal(
+      referenceContentHash(Buffer.from([2, 3, 4])),
+    );
+  });
+
+  it('rejects unsupported input', () => {
+    expect(() => contentHash('data')).to.throw(TypeError);
+  });
+
+  it('rejects unsupported digest encodings', () => {
+    const hasher = new DropboxContentHasher();
+
+    hasher.update(Buffer.from('data'));
+
+    expect(() => hasher.digest('base64')).to.throw(TypeError);
+  });
+
+  it('cannot be updated after digest', () => {
+    const hasher = new DropboxContentHasher();
+
+    hasher.update(Buffer.from('data'));
+    hasher.digest('hex');
+
+    expect(() => hasher.update(Buffer.from('more'))).to.throw(
+      'cannot be used after digest() has been called',
+    );
+  });
+
+  it('cannot be digested twice', () => {
+    const hasher = new DropboxContentHasher();
+
+    hasher.update(Buffer.from('data'));
+    hasher.digest('hex');
+
+    expect(() => hasher.digest('hex')).to.throw(
+      'cannot be used after digest() has been called',
+    );
+  });
+});

--- a/types/content-hasher.d.ts
+++ b/types/content-hasher.d.ts
@@ -1,0 +1,11 @@
+export const BLOCK_SIZE: number;
+
+export class DropboxContentHasher {
+  update(data: Buffer | Uint8Array | ArrayBuffer): this;
+
+  digest(encoding?: 'hex'): Buffer | string;
+}
+
+export function contentHash(
+  data: Buffer | Uint8Array | ArrayBuffer,
+): string;


### PR DESCRIPTION
Adds a reusable DropboxContentHasher implementation and contentHash convenience function for computing Dropbox content_hash values.

Includes JavaScript and TypeScript exports, unit coverage for block boundaries and incremental updates, and basic usage documentation.