### PR TITLE
Use npm ci and fail CI on errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   CI:
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -18,7 +17,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
-        run: npm install
+        run: npm ci
       - name: Run Build
         run: npm run build
       - name: Run Examples Builds
@@ -58,7 +57,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install SDK
-        run: npm install
+        run: npm ci
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Summary

Improve CI reliability by making dependency installation reproducible and ensuring failures are reported correctly.

## Changes

- replace `npm install` with `npm ci` in CI jobs
- remove `continue-on-error` from the main CI job

## Why

Using `npm ci` ensures dependencies are installed exactly as defined in `package-lock.json`, producing reproducible builds and avoiding unintended dependency resolution changes.

Removing `continue-on-error` ensures build, lint, and test failures correctly fail the workflow instead of allowing the job to continue.

No production code changes.