### PR TITLE
Automatically add content hash to file uploads

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -12,6 +12,9 @@ import { routes } from '../lib/routes.js';
 import DropboxAuth from './auth.js';
 import { baseApiUrl, httpHeaderSafeJson } from './utils.js';
 import { parseDownloadResponse, parseResponse } from './response.js';
+import {
+  contentHash as getUploadContentHash,
+} from './upload-content-hash.js';
 
 const b64 = typeof btoa === 'undefined'
   ? (str) => Buffer.from(str).toString('base64')
@@ -65,6 +68,7 @@ export default class Dropbox {
     this.domain = options.domain || this.auth.domain;
     this.domainDelimiter = options.domainDelimiter || this.auth.domainDelimiter;
     this.customHeaders = options.customHeaders || this.auth.customHeaders;
+    this.autoContentHash = options.autoContentHash !== false;
 
     Object.assign(this, routes);
   }
@@ -132,10 +136,15 @@ export default class Dropbox {
 
   uploadRequest(path, args, auth, host) {
     return this.auth.checkAndRefreshAccessToken()
-      .then(() => {
+      .then(async () => {
         const requestArgs = Object.assign({}, args); // eslint-disable-line prefer-object-spread
         const { contents } = requestArgs;
         delete requestArgs.contents;
+        await this.maybeAddContentHash(
+          path,
+          requestArgs,
+          contents,
+        );
 
         const fetchOptions = {
           body: contents,
@@ -211,6 +220,22 @@ export default class Dropbox {
       headerKeys.forEach((header) => {
         options.headers[header] = this.customHeaders[header];
       });
+    }
+  }
+
+  async maybeAddContentHash(path, requestArgs, contents) {
+    if (
+      !this.autoContentHash
+      || path !== '/2/files/upload'
+      || requestArgs.content_hash !== undefined
+    ) {
+      return;
+    }
+
+    const hash = await getUploadContentHash(contents);
+
+    if (hash !== null) {
+      requestArgs.content_hash = hash;
     }
   }
 }

--- a/src/upload-content-hash.js
+++ b/src/upload-content-hash.js
@@ -1,0 +1,127 @@
+const BLOCK_SIZE = 4 * 1024 * 1024;
+
+async function sha256(data) {
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    data,
+  );
+
+  return new Uint8Array(digest);
+}
+
+function toHex(bytes) {
+  return Array.from(
+    bytes,
+    (byte) => byte.toString(16).padStart(2, '0'),
+  ).join('');
+}
+
+function isBlob(value) {
+  return typeof Blob !== 'undefined' && value instanceof Blob;
+}
+
+function toUint8Array(value) {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    );
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    );
+  }
+
+  return null;
+}
+
+async function finishHash(blockHashes) {
+  const combined = new Uint8Array(blockHashes.length * 32);
+
+  blockHashes.forEach((hash, index) => {
+    combined.set(hash, index * 32);
+  });
+
+  return toHex(await sha256(combined));
+}
+
+async function hashByteArray(bytes) {
+  const blockHashes = [];
+
+  /* eslint-disable no-await-in-loop */
+  for (let offset = 0; offset < bytes.byteLength; offset += BLOCK_SIZE) {
+    const block = bytes.subarray(
+      offset,
+      Math.min(offset + BLOCK_SIZE, bytes.byteLength),
+    );
+
+    blockHashes.push(await sha256(block));
+  }
+  /* eslint-enable no-await-in-loop */
+
+  return finishHash(blockHashes);
+}
+
+async function hashBlob(blob) {
+  const blockHashes = [];
+
+  /* eslint-disable no-await-in-loop */
+  for (let offset = 0; offset < blob.size; offset += BLOCK_SIZE) {
+    const block = await blob
+      .slice(offset, Math.min(offset + BLOCK_SIZE, blob.size))
+      .arrayBuffer();
+
+    blockHashes.push(await sha256(block));
+  }
+  /* eslint-enable no-await-in-loop */
+
+  return finishHash(blockHashes);
+}
+
+/**
+ * Computes a Dropbox content hash for supported upload payloads.
+ *
+ * Returns null if a content hash cannot be computed, such as for
+ * unsupported values or when Web Crypto is unavailable.
+ *
+ * @param {Buffer|Uint8Array|ArrayBuffer|Blob|File} contents Upload contents.
+ * @returns {Promise<string|null>} Lowercase hexadecimal content hash.
+ */
+async function contentHash(contents) {
+  if (
+    typeof globalThis.crypto === 'undefined'
+    || !globalThis.crypto.subtle
+  ) {
+    return null;
+  }
+
+  try {
+    if (isBlob(contents)) {
+      return await hashBlob(contents);
+    }
+
+    const bytes = toUint8Array(contents);
+
+    if (bytes === null) {
+      return null;
+    }
+
+    return await hashByteArray(bytes);
+  } catch {
+    return null;
+  }
+}
+
+export {
+  BLOCK_SIZE,
+  contentHash,
+};

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -2,8 +2,9 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { Readable } from 'stream';
-
 import { fail } from 'assert';
+import { contentHash as nodeContentHash } from '../../src/content-hasher.js';
+
 import {
   RPC,
   USER_AUTH,
@@ -121,6 +122,133 @@ describe('Dropbox', () => {
   });
 
   describe('Upload Requests', () => {
+    it('does not add content_hash for unsupported upload contents', () => {
+      const fetchStub = sinon.stub().resolves(
+        new Response('{}', { status: 200 }),
+      );
+
+      const auth = new DropboxAuth({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+
+      const contents = Readable.from([
+        Buffer.from('stream contents'),
+      ]);
+
+      return dbx.uploadRequest(
+        '/2/files/upload',
+        { path: '/test.txt', contents },
+        USER_AUTH,
+        'content',
+      ).then(() => {
+        const requestArgs = JSON.parse(
+          fetchStub.firstCall.args[1].headers['Dropbox-API-Arg'],
+        );
+        chai.assert.notProperty(requestArgs, 'content_hash');
+      });
+    });
+
+    it('preserves an explicit content_hash', () => {
+      const fetchStub = sinon.stub().resolves(
+        new Response('{}', { status: 200 }),
+      );
+
+      const auth = new DropboxAuth({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+
+      const contents = Buffer.from('hello world');
+
+      return dbx.uploadRequest(
+        '/2/files/upload',
+        {
+          path: '/test.txt',
+          contents,
+          content_hash: 'explicit-hash',
+        },
+        USER_AUTH,
+        'content',
+      ).then(() => {
+        const requestArgs = JSON.parse(
+          fetchStub.firstCall.args[1].headers['Dropbox-API-Arg'],
+        );
+
+        chai.assert.equal(
+          requestArgs.content_hash,
+          'explicit-hash',
+        );
+      });
+    });
+
+    it('does not add content_hash when autoContentHash is false', () => {
+      const fetchStub = sinon.stub().resolves(
+        new Response('{}', { status: 200 }),
+      );
+
+      const auth = new DropboxAuth({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      const dbx = new Dropbox({
+        auth,
+        fetch: fetchStub,
+        autoContentHash: false,
+      });
+
+      return dbx.uploadRequest(
+        '/2/files/upload',
+        {
+          path: '/test.txt',
+          contents: Buffer.from('hello world'),
+        },
+        USER_AUTH,
+        'content',
+      ).then(() => {
+        const requestArgs = JSON.parse(
+          fetchStub.firstCall.args[1].headers['Dropbox-API-Arg'],
+        );
+        chai.assert.notProperty(requestArgs, 'content_hash');
+      });
+    });
+
+    it('adds content_hash for supported upload contents', () => {
+      const fetchStub = sinon.stub().resolves(
+        new Response('{}', { status: 200 }),
+      );
+
+      const auth = new DropboxAuth({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      const dbx = new Dropbox({ auth, fetch: fetchStub });
+
+      const contents = Buffer.from('hello world');
+
+      return dbx.uploadRequest(
+        '/2/files/upload',
+        { path: '/test.txt', contents },
+        USER_AUTH,
+        'content',
+      ).then(() => {
+        const requestArgs = JSON.parse(
+          fetchStub.firstCall.args[1].headers['Dropbox-API-Arg'],
+        );
+
+        chai.assert.equal(
+          requestArgs.content_hash,
+          nodeContentHash(contents),
+        );
+      });
+    });
+
     it('request() calls the correct request method', () => {
       const dbx = new Dropbox();
       const uploadSpy = sinon.spy(dbx, 'uploadRequest');

--- a/test/unit/upload-content-hash.js
+++ b/test/unit/upload-content-hash.js
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+
+import { contentHash as nodeContentHash } from '../../src/content-hasher.js';
+import {
+  contentHash,
+} from '../../src/upload-content-hash.js';
+
+describe('upload content hash', () => {
+  it('hashes a Buffer', async () => {
+    const contents = Buffer.from('hello world');
+
+    expect(await contentHash(contents)).to.equal(
+      nodeContentHash(contents),
+    );
+  });
+
+  it('hashes a Uint8Array', async () => {
+    const contents = new Uint8Array(
+      Buffer.from('hello world'),
+    );
+
+    expect(await contentHash(contents)).to.equal(
+      nodeContentHash(Buffer.from(contents)),
+    );
+  });
+
+  it('hashes an ArrayBuffer', async () => {
+    const bytes = new Uint8Array(
+      Buffer.from('hello world'),
+    );
+    const contents = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    );
+
+    expect(await contentHash(contents)).to.equal(
+      nodeContentHash(Buffer.from(bytes)),
+    );
+  });
+
+  it('hashes multiple blocks', async () => {
+    const contents = Buffer.alloc(
+      (4 * 1024 * 1024) + 1,
+      1,
+    );
+
+    expect(await contentHash(contents)).to.equal(
+      nodeContentHash(contents),
+    );
+  });
+
+  it('returns null for unsupported contents', async () => {
+    expect(await contentHash({ pipe() {} })).to.equal(null);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -204,6 +204,7 @@ export interface DropboxOptions {
   domainDelimiter?: string;
   // An object (in the form of header: value) designed to set custom headers to use during a request.
   customHeaders?: object;
+  autoContentHash?: boolean;
 }
 
 export class DropboxResponseError<T> {


### PR DESCRIPTION
### Summary

Automatically computes and adds content_hash for supported /2/files/upload requests.

The implementation is backward compatible:
* preserves explicitly provided content_hash
* skips unsupported upload types (such as streams)
* skips hashing when Web Crypto is unavailable
* can be disabled with autoContentHash: false

### Tests

Added unit tests for supported and unsupported upload payloads, automatic hash injection, and the opt-out behavior.