### PR TITLE
Enable automerge for automated spec update PRs

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -140,8 +140,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      # - name: Enable Pull Request Automerge
-      #   if: steps.create-pr.outputs.pull-request-number
-      #   run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Enable Pull Request Automerge
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Uncomments the Enable Pull Request Automerge step in the spec_update workflow so automated spec-update PRs merge automatically once required checks pass.