### PR TITLE
Fix spec-update automerge: use --squash instead of --merge

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -142,6 +142,6 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The Enable Pull Request Automerge step runs `gh pr merge --merge --auto`, but main requires linear history so merge commits are rejected, causing the step to fail and auto-merge never to be armed on generated spec-update PRs. Switches to `--squash`.