### PR TITLE
Fix spec-update codegen: install stone deps via pip (Python 3.12 setuptools)

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -91,9 +91,9 @@ jobs:
           cd ../..
       - name: Generate New Routes
         run: |
-          cd generator/stone
-          python setup.py install
-          cd ..
+          python -m pip install --upgrade pip
+          pip install -r generator/stone/requirements.txt
+          cd generator
           python generate_routes.py
           cd ..
 


### PR DESCRIPTION
The `Generate New Routes` step runs `python setup.py install` in the vendored `generator/stone` submodule, which fails on Python 3.12 (`ModuleNotFoundError: No module named 'setuptools'`) because 3.12 no longer bundles setuptools and the workflow never installs it.

`generate_routes.py` invokes stone via `python3 -m stone.cli` with `cwd=generator/stone` — i.e. it runs stone from the submodule directory and never uses the installed package. So the `setup.py install` only served to pull in stone's runtime deps. This replaces it with `pip install -r generator/stone/requirements.txt`, matching how the obj-c/SwiftyDropbox workflows handle the same vendored stone submodule. Using the submodule's requirements file avoids dependency drift.