### PR TITLE
Support per-request transport options (AbortSignal)

### DIFF
--- a/generator/generate_routes.py
+++ b/generator/generate_routes.py
@@ -92,7 +92,7 @@ def main():
     o = subprocess.check_output(
         (['python3', '-m', 'stone.cli', 'js_client', dropbox_pkg_path] +
          specs + ['-a', 'host', '-a', 'style', '-a', 'auth', '-a', 'scope'] +
-         ['--', 'routes.js', '-c', 'Dropbox', '--wrap-response-in', 'DropboxResponse', '--wrap-error-in', 'DropboxResponseError', '-a', 'scope']),
+         ['--', 'routes.js', '-c', 'Dropbox', '--wrap-response-in', 'DropboxResponse', '--wrap-error-in', 'DropboxResponseError', '--request-options', '-a', 'scope']),
         cwd=stone_path)
     if verbose:
         print(o)

--- a/generator/typescript/dropbox_tsd_client.stoneg.py
+++ b/generator/typescript/dropbox_tsd_client.stoneg.py
@@ -39,6 +39,9 @@ class DropboxTSDClientBackend(tsd_client.TSDClientBackend):
 
         if route.arg_data_type.__class__ != Void:
             self.emit(' * @param arg The request parameters.')
+        self.emit(
+            ' * @param options Optional transport settings for this request.'
+        )
         self.emit(' */')
 
         result_type = fmt_type(route.result_data_type)
@@ -53,8 +56,16 @@ class DropboxTSDClientBackend(tsd_client.TSDClientBackend):
         else:
             return_type = 'Promise<{}>;'.format(result_type)
 
-        arg = ''
-        if route.arg_data_type.__class__ != Void:
-            arg = 'arg: {}'.format(fmt_type(route.arg_data_type))
+        params = []
 
-        self.emit('public {}({}): {}'.format(function_name, arg, return_type))
+        if route.arg_data_type.__class__ != Void:
+            params.append('arg: {}'.format(fmt_type(route.arg_data_type)))
+
+        params.append('options?: DropboxRequestOptions')
+        self.emit(
+            'public {}({}): {}'.format(
+                function_name,
+                ', '.join(params),
+                return_type,
+            )
+        )

--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -3,6 +3,14 @@
 /*IMPORT*/
 export * from './dropbox_types';
 
+/**
+ * Optional transport settings for a single Dropbox API request.
+ */
+export interface DropboxRequestOptions {
+  /** An AbortSignal used to cancel the request. */
+  signal?: AbortSignal;
+}
+
 /** Binary download content returned by the SDK in Node.js environments. */
 export interface DropboxFileBinary extends Uint8Array {
   toString(encoding?: string, start?: number, end?: number): string;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -2018,6 +2018,10 @@ routes.paperFoldersCreate = function (arg, options) {
 
 /**
  * Asynchronous document-to-markdown conversion for supported file formats.
+ * Supported formats: .binder, .docx, .html, .paper, .papert, .pptx, .xlsx,
+ * .gsheet, .ods, .pdf. Unsupported formats return an
+ * `unsupported_format_error`. Size limit: the source file must be at most 50
+ * MB. Larger files are rejected.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMarkdownAsync
@@ -2043,7 +2047,17 @@ routes.rivieraGetMarkdownAsyncCheck = function (arg, options) {
 };
 
 /**
- * Asynchronous file metadata extraction for supported file formats.
+ * Asynchronous file metadata extraction for supported file formats. The kind of
+ * metadata returned depends on the file type: - Image (EXIF) formats: .3fr,
+ * .arw, .avif, .bmp, .cr2, .cr3, .crw, .dcr, .dcs, .dng, .erf, .gif, .heic,
+ * .j2c, .j2k, .jp2, .jpc, .jpeg, .jpf, .jpg, .jpg2, .jpm, .jpx, .kdc, .mef,
+ * .mos, .mrw, .nef, .nrw, .orf, .pef, .png, .ppm, .r3d, .raf, .rw2, .rwl, .sr2,
+ * .tga, .tif, .tiff, .wbmp, .web, .webp, .x3f. - Audio/video (media) formats:
+ * .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg, .wav, .wma, .3gp,
+ * .3gpp, .3gpp2, .asf, .avi, .dv, .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4,
+ * .mpeg, .mpg, .mts, .mxf, .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. - PDF
+ * format: .pdf. - MS Office formats: .docx, .pptx, .xlsx. Unsupported formats
+ * return an `unsupported_format_error`.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMetadataAsync
@@ -2069,7 +2083,46 @@ routes.rivieraGetMetadataAsyncCheck = function (arg, options) {
 };
 
 /**
- * Asynchronous transcript generation for audio and video files.
+ * Asynchronous plain-text extraction from documents. Supported formats include:
+ * - Word processing: .doc, .docx, .docm, .rtf. - Presentations: .ppt, .pptx,
+ * .pptm. - Spreadsheets: .xls, .xlsx, .xlsm. - PDF: .pdf. - Dropbox document
+ * types: .paper, .papert, .binder, .gdoc, .gsheet, .gslides. - Plain text /
+ * subtitles: .txt, .vtt. Unsupported formats return an
+ * `unsupported_format_error`. For the `url` variant only Dropbox shared links
+ * are supported; external URLs return `unsupported_format_error`.
+ * Route attributes:
+ *   scope: files.content.read
+ * @function Dropbox#rivieraGetTextAsync
+ * @arg {RivieraGetTextArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
+ * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<void>>}
+ */
+routes.rivieraGetTextAsync = function (arg, options) {
+  return this.request('riviera/get_text_async', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
+};
+
+/**
+ * Returns the status or result of specified get_text_async task.
+ * Route attributes:
+ *   scope: files.content.read
+ * @function Dropbox#rivieraGetTextAsyncCheck
+ * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
+ * @returns {Promise.<DropboxResponse<RivieraGetTextAsyncCheckResult>, DropboxResponseError.<AsyncPollError>>}
+ */
+routes.rivieraGetTextAsyncCheck = function (arg, options) {
+  return this.request('riviera/get_text_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
+};
+
+/**
+ * Asynchronous transcript generation for audio and video files. Supported audio
+ * formats: .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg, .wav, .wma.
+ * Supported video formats: .3gp, .3gpp, .3gpp2, .asf, .avi, .dv, .flv, .m2t,
+ * .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf, .oggtheora, .ogv,
+ * .rm, .ts, .vob, .webm, .wmv. Unsupported formats return an
+ * `unsupported_format_error`. Size limits: the source file must be at most 10
+ * GB and its audio track at most 1 hour in duration. Files exceeding these
+ * limits are rejected.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetTranscriptAsync
@@ -3343,6 +3396,32 @@ routes.teamMembersAddJobStatusGet = function (arg, options) {
  */
 routes.teamMembersAddJobStatusGetV2 = function (arg, options) {
   return this.request('team/members/add/job_status/get_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
+};
+
+/**
+ * Launch a bulk suspend job. The server enforces a maximum of 500 members.
+ * Route attributes:
+ *   scope: members.write
+ * @function Dropbox#teamMembersBulkSuspend
+ * @arg {TeamBulkSuspendArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
+ * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<TeamBulkSuspendError>>}
+ */
+routes.teamMembersBulkSuspend = function (arg, options) {
+  return this.request('team/members/bulk_suspend', arg, 'team', 'api', 'rpc', 'members.write', options);
+};
+
+/**
+ * Poll a previously launched bulk suspend job.
+ * Route attributes:
+ *   scope: members.write
+ * @function Dropbox#teamMembersBulkSuspendJobStatusCheck
+ * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
+ * @returns {Promise.<DropboxResponse<TeamBulkSuspendJobStatus>, DropboxResponseError.<AsyncPollError>>}
+ */
+routes.teamMembersBulkSuspendJobStatusCheck = function (arg, options) {
+  return this.request('team/members/bulk_suspend/job_status/check', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -7,10 +7,11 @@ var routes = {};
  *   scope: account_info.write
  * @function Dropbox#accountDeleteProfilePhoto
  * @arg {AccountDeleteProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AccountDeleteProfilePhotoResult>, DropboxResponseError.<AccountDeleteProfilePhotoError>>}
  */
-routes.accountDeleteProfilePhoto = function (arg) {
-  return this.request('account/delete_profile_photo', arg, 'user', 'api', 'rpc', 'account_info.write');
+routes.accountDeleteProfilePhoto = function (arg, options) {
+  return this.request('account/delete_profile_photo', arg, 'user', 'api', 'rpc', 'account_info.write', options);
 };
 
 /**
@@ -19,10 +20,11 @@ routes.accountDeleteProfilePhoto = function (arg) {
  *   scope: account_info.read
  * @function Dropbox#accountGetPhoto
  * @arg {AccountAccountPhotoGetArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AccountAccountPhotoGetResult>, DropboxResponseError.<AccountAccountPhotoGetError>>}
  */
-routes.accountGetPhoto = function (arg) {
-  return this.request('account/get_photo', arg, 'user', 'content', 'download', 'account_info.read');
+routes.accountGetPhoto = function (arg, options) {
+  return this.request('account/get_photo', arg, 'user', 'content', 'download', 'account_info.read', options);
 };
 
 /**
@@ -31,10 +33,11 @@ routes.accountGetPhoto = function (arg) {
  *   scope: account_info.write
  * @function Dropbox#accountSetProfilePhoto
  * @arg {AccountSetProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AccountSetProfilePhotoResult>, DropboxResponseError.<AccountSetProfilePhotoError>>}
  */
-routes.accountSetProfilePhoto = function (arg) {
-  return this.request('account/set_profile_photo', arg, 'user', 'api', 'rpc', 'account_info.write');
+routes.accountSetProfilePhoto = function (arg, options) {
+  return this.request('account/set_profile_photo', arg, 'user', 'api', 'rpc', 'account_info.write', options);
 };
 
 /**
@@ -42,10 +45,11 @@ routes.accountSetProfilePhoto = function (arg) {
  * @function Dropbox#authTokenFromOauth1
  * @deprecated
  * @arg {AuthTokenFromOAuth1Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AuthTokenFromOAuth1Result>, DropboxResponseError.<AuthTokenFromOAuth1Error>>}
  */
-routes.authTokenFromOauth1 = function (arg) {
-  return this.request('auth/token/from_oauth1', arg, 'app', 'api', 'rpc', null);
+routes.authTokenFromOauth1 = function (arg, options) {
+  return this.request('auth/token/from_oauth1', arg, 'app', 'api', 'rpc', null, options);
 };
 
 /**
@@ -53,10 +57,11 @@ routes.authTokenFromOauth1 = function (arg) {
  * corresponding refresh token for the access token, this disables that refresh
  * token, as well as any other access tokens for that refresh token.
  * @function Dropbox#authTokenRevoke
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<void>>}
  */
-routes.authTokenRevoke = function () {
-  return this.request('auth/token/revoke', null, 'user', 'api', 'rpc', null);
+routes.authTokenRevoke = function (options) {
+  return this.request('auth/token/revoke', null, 'user', 'api', 'rpc', null, options);
 };
 
 /**
@@ -67,10 +72,11 @@ routes.authTokenRevoke = function () {
  * Dropbox API infrastructure is working and that the app key and secret valid.
  * @function Dropbox#checkApp
  * @arg {CheckEchoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<CheckEchoResult>, DropboxResponseError.<CheckEchoError>>}
  */
-routes.checkApp = function (arg) {
-  return this.request('check/app', arg, 'app', 'api', 'rpc', null);
+routes.checkApp = function (arg, options) {
+  return this.request('check/app', arg, 'app', 'api', 'rpc', null, options);
 };
 
 /**
@@ -83,10 +89,11 @@ routes.checkApp = function (arg) {
  *   scope: account_info.read
  * @function Dropbox#checkUser
  * @arg {CheckEchoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<CheckEchoResult>, DropboxResponseError.<CheckEchoError>>}
  */
-routes.checkUser = function (arg) {
-  return this.request('check/user', arg, 'user', 'api', 'rpc', 'account_info.read');
+routes.checkUser = function (arg, options) {
+  return this.request('check/user', arg, 'user', 'api', 'rpc', 'account_info.read', options);
 };
 
 /**
@@ -95,10 +102,11 @@ routes.checkUser = function (arg) {
  * Route attributes:
  *   scope: contacts.write
  * @function Dropbox#contactsDeleteManualContacts
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<void>>}
  */
-routes.contactsDeleteManualContacts = function () {
-  return this.request('contacts/delete_manual_contacts', null, 'user', 'api', 'rpc', 'contacts.write');
+routes.contactsDeleteManualContacts = function (options) {
+  return this.request('contacts/delete_manual_contacts', null, 'user', 'api', 'rpc', 'contacts.write', options);
 };
 
 /**
@@ -107,10 +115,11 @@ routes.contactsDeleteManualContacts = function () {
  *   scope: contacts.write
  * @function Dropbox#contactsDeleteManualContactsBatch
  * @arg {ContactsDeleteManualContactsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<ContactsDeleteManualContactsError>>}
  */
-routes.contactsDeleteManualContactsBatch = function (arg) {
-  return this.request('contacts/delete_manual_contacts_batch', arg, 'user', 'api', 'rpc', 'contacts.write');
+routes.contactsDeleteManualContactsBatch = function (arg, options) {
+  return this.request('contacts/delete_manual_contacts_batch', arg, 'user', 'api', 'rpc', 'contacts.write', options);
 };
 
 /**
@@ -120,10 +129,11 @@ routes.contactsDeleteManualContactsBatch = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesPropertiesAdd
  * @arg {FilePropertiesAddPropertiesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesAddPropertiesError>>}
  */
-routes.filePropertiesPropertiesAdd = function (arg) {
-  return this.request('file_properties/properties/add', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesPropertiesAdd = function (arg, options) {
+  return this.request('file_properties/properties/add', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -136,10 +146,11 @@ routes.filePropertiesPropertiesAdd = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesPropertiesOverwrite
  * @arg {FilePropertiesOverwritePropertyGroupArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesInvalidPropertyGroupError>>}
  */
-routes.filePropertiesPropertiesOverwrite = function (arg) {
-  return this.request('file_properties/properties/overwrite', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesPropertiesOverwrite = function (arg, options) {
+  return this.request('file_properties/properties/overwrite', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -152,10 +163,11 @@ routes.filePropertiesPropertiesOverwrite = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesPropertiesRemove
  * @arg {FilePropertiesRemovePropertiesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesRemovePropertiesError>>}
  */
-routes.filePropertiesPropertiesRemove = function (arg) {
-  return this.request('file_properties/properties/remove', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesPropertiesRemove = function (arg, options) {
+  return this.request('file_properties/properties/remove', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -164,10 +176,11 @@ routes.filePropertiesPropertiesRemove = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filePropertiesPropertiesSearch
  * @arg {FilePropertiesPropertiesSearchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesPropertiesSearchResult>, DropboxResponseError.<FilePropertiesPropertiesSearchError>>}
  */
-routes.filePropertiesPropertiesSearch = function (arg) {
-  return this.request('file_properties/properties/search', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filePropertiesPropertiesSearch = function (arg, options) {
+  return this.request('file_properties/properties/search', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -177,10 +190,11 @@ routes.filePropertiesPropertiesSearch = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filePropertiesPropertiesSearchContinue
  * @arg {FilePropertiesPropertiesSearchContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesPropertiesSearchResult>, DropboxResponseError.<FilePropertiesPropertiesSearchContinueError>>}
  */
-routes.filePropertiesPropertiesSearchContinue = function (arg) {
-  return this.request('file_properties/properties/search/continue', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filePropertiesPropertiesSearchContinue = function (arg, options) {
+  return this.request('file_properties/properties/search/continue', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -194,10 +208,11 @@ routes.filePropertiesPropertiesSearchContinue = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesPropertiesUpdate
  * @arg {FilePropertiesUpdatePropertiesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesUpdatePropertiesError>>}
  */
-routes.filePropertiesPropertiesUpdate = function (arg) {
-  return this.request('file_properties/properties/update', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesPropertiesUpdate = function (arg, options) {
+  return this.request('file_properties/properties/update', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -207,10 +222,11 @@ routes.filePropertiesPropertiesUpdate = function (arg) {
  *   scope: files.team_metadata.write
  * @function Dropbox#filePropertiesTemplatesAddForTeam
  * @arg {FilePropertiesAddTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesAddTemplateResult>, DropboxResponseError.<FilePropertiesModifyTemplateError>>}
  */
-routes.filePropertiesTemplatesAddForTeam = function (arg) {
-  return this.request('file_properties/templates/add_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.filePropertiesTemplatesAddForTeam = function (arg, options) {
+  return this.request('file_properties/templates/add_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -220,10 +236,11 @@ routes.filePropertiesTemplatesAddForTeam = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesTemplatesAddForUser
  * @arg {FilePropertiesAddTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesAddTemplateResult>, DropboxResponseError.<FilePropertiesModifyTemplateError>>}
  */
-routes.filePropertiesTemplatesAddForUser = function (arg) {
-  return this.request('file_properties/templates/add_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesTemplatesAddForUser = function (arg, options) {
+  return this.request('file_properties/templates/add_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -232,10 +249,11 @@ routes.filePropertiesTemplatesAddForUser = function (arg) {
  *   scope: files.team_metadata.write
  * @function Dropbox#filePropertiesTemplatesGetForTeam
  * @arg {FilePropertiesGetTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesGetTemplateResult>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesGetForTeam = function (arg) {
-  return this.request('file_properties/templates/get_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.filePropertiesTemplatesGetForTeam = function (arg, options) {
+  return this.request('file_properties/templates/get_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -245,10 +263,11 @@ routes.filePropertiesTemplatesGetForTeam = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filePropertiesTemplatesGetForUser
  * @arg {FilePropertiesGetTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesGetTemplateResult>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesGetForUser = function (arg) {
-  return this.request('file_properties/templates/get_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filePropertiesTemplatesGetForUser = function (arg, options) {
+  return this.request('file_properties/templates/get_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -257,10 +276,11 @@ routes.filePropertiesTemplatesGetForUser = function (arg) {
  * Route attributes:
  *   scope: files.team_metadata.write
  * @function Dropbox#filePropertiesTemplatesListForTeam
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesListTemplateResult>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesListForTeam = function () {
-  return this.request('file_properties/templates/list_for_team', null, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.filePropertiesTemplatesListForTeam = function (options) {
+  return this.request('file_properties/templates/list_for_team', null, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -270,10 +290,11 @@ routes.filePropertiesTemplatesListForTeam = function () {
  * Route attributes:
  *   scope: files.metadata.read
  * @function Dropbox#filePropertiesTemplatesListForUser
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesListTemplateResult>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesListForUser = function () {
-  return this.request('file_properties/templates/list_for_user', null, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filePropertiesTemplatesListForUser = function (options) {
+  return this.request('file_properties/templates/list_for_user', null, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -284,10 +305,11 @@ routes.filePropertiesTemplatesListForUser = function () {
  *   scope: files.team_metadata.write
  * @function Dropbox#filePropertiesTemplatesRemoveForTeam
  * @arg {FilePropertiesRemoveTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesRemoveForTeam = function (arg) {
-  return this.request('file_properties/templates/remove_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.filePropertiesTemplatesRemoveForTeam = function (arg, options) {
+  return this.request('file_properties/templates/remove_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -298,10 +320,11 @@ routes.filePropertiesTemplatesRemoveForTeam = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesTemplatesRemoveForUser
  * @arg {FilePropertiesRemoveTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.filePropertiesTemplatesRemoveForUser = function (arg) {
-  return this.request('file_properties/templates/remove_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesTemplatesRemoveForUser = function (arg, options) {
+  return this.request('file_properties/templates/remove_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -311,10 +334,11 @@ routes.filePropertiesTemplatesRemoveForUser = function (arg) {
  *   scope: files.team_metadata.write
  * @function Dropbox#filePropertiesTemplatesUpdateForTeam
  * @arg {FilePropertiesUpdateTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesUpdateTemplateResult>, DropboxResponseError.<FilePropertiesModifyTemplateError>>}
  */
-routes.filePropertiesTemplatesUpdateForTeam = function (arg) {
-  return this.request('file_properties/templates/update_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.filePropertiesTemplatesUpdateForTeam = function (arg, options) {
+  return this.request('file_properties/templates/update_for_team', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -325,10 +349,11 @@ routes.filePropertiesTemplatesUpdateForTeam = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filePropertiesTemplatesUpdateForUser
  * @arg {FilePropertiesUpdateTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesUpdateTemplateResult>, DropboxResponseError.<FilePropertiesModifyTemplateError>>}
  */
-routes.filePropertiesTemplatesUpdateForUser = function (arg) {
-  return this.request('file_properties/templates/update_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filePropertiesTemplatesUpdateForUser = function (arg, options) {
+  return this.request('file_properties/templates/update_for_user', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -337,10 +362,11 @@ routes.filePropertiesTemplatesUpdateForUser = function (arg) {
  * Route attributes:
  *   scope: file_requests.read
  * @function Dropbox#fileRequestsCount
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsCountFileRequestsResult>, DropboxResponseError.<FileRequestsCountFileRequestsError>>}
  */
-routes.fileRequestsCount = function () {
-  return this.request('file_requests/count', null, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsCount = function (options) {
+  return this.request('file_requests/count', null, 'user', 'api', 'rpc', 'file_requests.read', options);
 };
 
 /**
@@ -349,10 +375,11 @@ routes.fileRequestsCount = function () {
  *   scope: file_requests.write
  * @function Dropbox#fileRequestsCreate
  * @arg {FileRequestsCreateFileRequestArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsFileRequest>, DropboxResponseError.<FileRequestsCreateFileRequestError>>}
  */
-routes.fileRequestsCreate = function (arg) {
-  return this.request('file_requests/create', arg, 'user', 'api', 'rpc', 'file_requests.write');
+routes.fileRequestsCreate = function (arg, options) {
+  return this.request('file_requests/create', arg, 'user', 'api', 'rpc', 'file_requests.write', options);
 };
 
 /**
@@ -361,10 +388,11 @@ routes.fileRequestsCreate = function (arg) {
  *   scope: file_requests.write
  * @function Dropbox#fileRequestsDelete
  * @arg {FileRequestsDeleteFileRequestArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsDeleteFileRequestsResult>, DropboxResponseError.<FileRequestsDeleteFileRequestError>>}
  */
-routes.fileRequestsDelete = function (arg) {
-  return this.request('file_requests/delete', arg, 'user', 'api', 'rpc', 'file_requests.write');
+routes.fileRequestsDelete = function (arg, options) {
+  return this.request('file_requests/delete', arg, 'user', 'api', 'rpc', 'file_requests.write', options);
 };
 
 /**
@@ -372,10 +400,11 @@ routes.fileRequestsDelete = function (arg) {
  * Route attributes:
  *   scope: file_requests.write
  * @function Dropbox#fileRequestsDeleteAllClosed
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsDeleteAllClosedFileRequestsResult>, DropboxResponseError.<FileRequestsDeleteAllClosedFileRequestsError>>}
  */
-routes.fileRequestsDeleteAllClosed = function () {
-  return this.request('file_requests/delete_all_closed', null, 'user', 'api', 'rpc', 'file_requests.write');
+routes.fileRequestsDeleteAllClosed = function (options) {
+  return this.request('file_requests/delete_all_closed', null, 'user', 'api', 'rpc', 'file_requests.write', options);
 };
 
 /**
@@ -384,10 +413,11 @@ routes.fileRequestsDeleteAllClosed = function () {
  *   scope: file_requests.read
  * @function Dropbox#fileRequestsGet
  * @arg {FileRequestsGetFileRequestArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsFileRequest>, DropboxResponseError.<FileRequestsGetFileRequestError>>}
  */
-routes.fileRequestsGet = function (arg) {
-  return this.request('file_requests/get', arg, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsGet = function (arg, options) {
+  return this.request('file_requests/get', arg, 'user', 'api', 'rpc', 'file_requests.read', options);
 };
 
 /**
@@ -397,10 +427,11 @@ routes.fileRequestsGet = function (arg) {
  * Route attributes:
  *   scope: file_requests.read
  * @function Dropbox#fileRequestsList
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsResult>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
  */
-routes.fileRequestsList = function () {
-  return this.request('file_requests/list', null, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsList = function (options) {
+  return this.request('file_requests/list', null, 'user', 'api', 'rpc', 'file_requests.read', options);
 };
 
 /**
@@ -411,10 +442,11 @@ routes.fileRequestsList = function () {
  *   scope: file_requests.read
  * @function Dropbox#fileRequestsListV2
  * @arg {FileRequestsListFileRequestsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsV2Result>, DropboxResponseError.<FileRequestsListFileRequestsError>>}
  */
-routes.fileRequestsListV2 = function (arg) {
-  return this.request('file_requests/list_v2', arg, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsListV2 = function (arg, options) {
+  return this.request('file_requests/list_v2', arg, 'user', 'api', 'rpc', 'file_requests.read', options);
 };
 
 /**
@@ -425,10 +457,11 @@ routes.fileRequestsListV2 = function (arg) {
  *   scope: file_requests.read
  * @function Dropbox#fileRequestsListContinue
  * @arg {FileRequestsListFileRequestsContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsListFileRequestsV2Result>, DropboxResponseError.<FileRequestsListFileRequestsContinueError>>}
  */
-routes.fileRequestsListContinue = function (arg) {
-  return this.request('file_requests/list/continue', arg, 'user', 'api', 'rpc', 'file_requests.read');
+routes.fileRequestsListContinue = function (arg, options) {
+  return this.request('file_requests/list/continue', arg, 'user', 'api', 'rpc', 'file_requests.read', options);
 };
 
 /**
@@ -437,10 +470,11 @@ routes.fileRequestsListContinue = function (arg) {
  *   scope: file_requests.write
  * @function Dropbox#fileRequestsUpdate
  * @arg {FileRequestsUpdateFileRequestArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FileRequestsFileRequest>, DropboxResponseError.<FileRequestsUpdateFileRequestError>>}
  */
-routes.fileRequestsUpdate = function (arg) {
-  return this.request('file_requests/update', arg, 'user', 'api', 'rpc', 'file_requests.write');
+routes.fileRequestsUpdate = function (arg, options) {
+  return this.request('file_requests/update', arg, 'user', 'api', 'rpc', 'file_requests.write', options);
 };
 
 /**
@@ -452,10 +486,11 @@ routes.fileRequestsUpdate = function (arg) {
  * @function Dropbox#filesAlphaGetMetadata
  * @deprecated
  * @arg {FilesAlphaGetMetadataArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesAlphaGetMetadataError>>}
  */
-routes.filesAlphaGetMetadata = function (arg) {
-  return this.request('files/alpha/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesAlphaGetMetadata = function (arg, options) {
+  return this.request('files/alpha/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -468,10 +503,11 @@ routes.filesAlphaGetMetadata = function (arg) {
  * @function Dropbox#filesAlphaUpload
  * @deprecated
  * @arg {FilesUploadArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesUploadError>>}
  */
-routes.filesAlphaUpload = function (arg) {
-  return this.request('files/alpha/upload', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesAlphaUpload = function (arg, options) {
+  return this.request('files/alpha/upload', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -482,10 +518,11 @@ routes.filesAlphaUpload = function (arg) {
  * @function Dropbox#filesCopy
  * @deprecated
  * @arg {FilesRelocationArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
  */
-routes.filesCopy = function (arg) {
-  return this.request('files/copy', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopy = function (arg, options) {
+  return this.request('files/copy', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -495,10 +532,11 @@ routes.filesCopy = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCopyV2
  * @arg {FilesRelocationArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationResult>, DropboxResponseError.<FilesRelocationError>>}
  */
-routes.filesCopyV2 = function (arg) {
-  return this.request('files/copy_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyV2 = function (arg, options) {
+  return this.request('files/copy_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -510,10 +548,11 @@ routes.filesCopyV2 = function (arg) {
  * @function Dropbox#filesCopyBatch
  * @deprecated
  * @arg {FilesRelocationBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesCopyBatch = function (arg) {
-  return this.request('files/copy_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatch = function (arg, options) {
+  return this.request('files/copy_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -527,10 +566,11 @@ routes.filesCopyBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCopyBatchV2
  * @arg {Object} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchV2Launch>, DropboxResponseError.<void>>}
  */
-routes.filesCopyBatchV2 = function (arg) {
-  return this.request('files/copy_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatchV2 = function (arg, options) {
+  return this.request('files/copy_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -541,10 +581,11 @@ routes.filesCopyBatchV2 = function (arg) {
  * @function Dropbox#filesCopyBatchCheck
  * @deprecated
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesCopyBatchCheck = function (arg) {
-  return this.request('files/copy_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatchCheck = function (arg, options) {
+  return this.request('files/copy_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -554,10 +595,11 @@ routes.filesCopyBatchCheck = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCopyBatchCheckV2
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchV2JobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesCopyBatchCheckV2 = function (arg) {
-  return this.request('files/copy_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyBatchCheckV2 = function (arg, options) {
+  return this.request('files/copy_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -568,10 +610,11 @@ routes.filesCopyBatchCheckV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCopyReferenceGet
  * @arg {FilesGetCopyReferenceArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesGetCopyReferenceResult>, DropboxResponseError.<FilesGetCopyReferenceError>>}
  */
-routes.filesCopyReferenceGet = function (arg) {
-  return this.request('files/copy_reference/get', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyReferenceGet = function (arg, options) {
+  return this.request('files/copy_reference/get', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -580,10 +623,11 @@ routes.filesCopyReferenceGet = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCopyReferenceSave
  * @arg {FilesSaveCopyReferenceArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSaveCopyReferenceResult>, DropboxResponseError.<FilesSaveCopyReferenceError>>}
  */
-routes.filesCopyReferenceSave = function (arg) {
-  return this.request('files/copy_reference/save', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCopyReferenceSave = function (arg, options) {
+  return this.request('files/copy_reference/save', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -593,10 +637,11 @@ routes.filesCopyReferenceSave = function (arg) {
  * @function Dropbox#filesCreateFolder
  * @deprecated
  * @arg {FilesCreateFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFolderMetadata>, DropboxResponseError.<FilesCreateFolderError>>}
  */
-routes.filesCreateFolder = function (arg) {
-  return this.request('files/create_folder', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCreateFolder = function (arg, options) {
+  return this.request('files/create_folder', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -605,10 +650,11 @@ routes.filesCreateFolder = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCreateFolderV2
  * @arg {FilesCreateFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesCreateFolderResult>, DropboxResponseError.<FilesCreateFolderError>>}
  */
-routes.filesCreateFolderV2 = function (arg) {
-  return this.request('files/create_folder_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCreateFolderV2 = function (arg, options) {
+  return this.request('files/create_folder_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -622,10 +668,11 @@ routes.filesCreateFolderV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCreateFolderBatch
  * @arg {FilesCreateFolderBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesCreateFolderBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesCreateFolderBatch = function (arg) {
-  return this.request('files/create_folder_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCreateFolderBatch = function (arg, options) {
+  return this.request('files/create_folder_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -635,10 +682,11 @@ routes.filesCreateFolderBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesCreateFolderBatchCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesCreateFolderBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesCreateFolderBatchCheck = function (arg) {
-  return this.request('files/create_folder_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesCreateFolderBatchCheck = function (arg, options) {
+  return this.request('files/create_folder_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -652,10 +700,11 @@ routes.filesCreateFolderBatchCheck = function (arg) {
  * @function Dropbox#filesDelete
  * @deprecated
  * @arg {FilesDeleteArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesDeleteError>>}
  */
-routes.filesDelete = function (arg) {
-  return this.request('files/delete', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDelete = function (arg, options) {
+  return this.request('files/delete', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -668,10 +717,11 @@ routes.filesDelete = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesDeleteV2
  * @arg {FilesDeleteArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesDeleteResult>, DropboxResponseError.<FilesDeleteError>>}
  */
-routes.filesDeleteV2 = function (arg) {
-  return this.request('files/delete_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDeleteV2 = function (arg, options) {
+  return this.request('files/delete_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -682,10 +732,11 @@ routes.filesDeleteV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesDeleteBatch
  * @arg {FilesDeleteBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesDeleteBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesDeleteBatch = function (arg) {
-  return this.request('files/delete_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDeleteBatch = function (arg, options) {
+  return this.request('files/delete_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -695,10 +746,11 @@ routes.filesDeleteBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesDeleteBatchCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesDeleteBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesDeleteBatchCheck = function (arg) {
-  return this.request('files/delete_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesDeleteBatchCheck = function (arg, options) {
+  return this.request('files/delete_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -707,10 +759,11 @@ routes.filesDeleteBatchCheck = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesDownload
  * @arg {FilesDownloadArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesDownloadError>>}
  */
-routes.filesDownload = function (arg) {
-  return this.request('files/download', arg, 'user', 'content', 'download', 'files.content.read');
+routes.filesDownload = function (arg, options) {
+  return this.request('files/download', arg, 'user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -723,10 +776,11 @@ routes.filesDownload = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesDownloadZip
  * @arg {FilesDownloadZipArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesDownloadZipResult>, DropboxResponseError.<FilesDownloadZipError>>}
  */
-routes.filesDownloadZip = function (arg) {
-  return this.request('files/download_zip', arg, 'user', 'content', 'download', 'files.content.read');
+routes.filesDownloadZip = function (arg, options) {
+  return this.request('files/download_zip', arg, 'user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -737,10 +791,11 @@ routes.filesDownloadZip = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesExport
  * @arg {FilesExportArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesExportResult>, DropboxResponseError.<FilesExportError>>}
  */
-routes.filesExport = function (arg) {
-  return this.request('files/export', arg, 'user', 'content', 'download', 'files.content.read');
+routes.filesExport = function (arg, options) {
+  return this.request('files/export', arg, 'user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -749,10 +804,11 @@ routes.filesExport = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetFileLockBatch
  * @arg {FilesLockFileBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesLockFileBatchResult>, DropboxResponseError.<FilesLockFileError>>}
  */
-routes.filesGetFileLockBatch = function (arg) {
-  return this.request('files/get_file_lock_batch', arg, 'user', 'api', 'rpc', 'files.content.read');
+routes.filesGetFileLockBatch = function (arg, options) {
+  return this.request('files/get_file_lock_batch', arg, 'user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -762,10 +818,11 @@ routes.filesGetFileLockBatch = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesGetMetadata
  * @arg {FilesGetMetadataArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesGetMetadataError>>}
  */
-routes.filesGetMetadata = function (arg) {
-  return this.request('files/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesGetMetadata = function (arg, options) {
+  return this.request('files/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -778,10 +835,11 @@ routes.filesGetMetadata = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetPreview
  * @arg {FilesPreviewArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesPreviewError>>}
  */
-routes.filesGetPreview = function (arg) {
-  return this.request('files/get_preview', arg, 'user', 'content', 'download', 'files.content.read');
+routes.filesGetPreview = function (arg, options) {
+  return this.request('files/get_preview', arg, 'user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -793,10 +851,11 @@ routes.filesGetPreview = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetTemporaryLink
  * @arg {FilesGetTemporaryLinkArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesGetTemporaryLinkResult>, DropboxResponseError.<FilesGetTemporaryLinkError>>}
  */
-routes.filesGetTemporaryLink = function (arg) {
-  return this.request('files/get_temporary_link', arg, 'user', 'api', 'rpc', 'files.content.read');
+routes.filesGetTemporaryLink = function (arg, options) {
+  return this.request('files/get_temporary_link', arg, 'user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -831,10 +890,11 @@ routes.filesGetTemporaryLink = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesGetTemporaryUploadLink
  * @arg {FilesGetTemporaryUploadLinkArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesGetTemporaryUploadLinkResult>, DropboxResponseError.<void>>}
  */
-routes.filesGetTemporaryUploadLink = function (arg) {
-  return this.request('files/get_temporary_upload_link', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesGetTemporaryUploadLink = function (arg, options) {
+  return this.request('files/get_temporary_upload_link', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -845,10 +905,11 @@ routes.filesGetTemporaryUploadLink = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetThumbnail
  * @arg {FilesThumbnailArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesThumbnailError>>}
  */
-routes.filesGetThumbnail = function (arg) {
-  return this.request('files/get_thumbnail', arg, 'user', 'content', 'download', 'files.content.read');
+routes.filesGetThumbnail = function (arg, options) {
+  return this.request('files/get_thumbnail', arg, 'user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -859,10 +920,11 @@ routes.filesGetThumbnail = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetThumbnailV2
  * @arg {FilesThumbnailV2Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesPreviewResult>, DropboxResponseError.<FilesThumbnailV2Error>>}
  */
-routes.filesGetThumbnailV2 = function (arg) {
-  return this.request('files/get_thumbnail_v2', arg, 'app, user', 'content', 'download', 'files.content.read');
+routes.filesGetThumbnailV2 = function (arg, options) {
+  return this.request('files/get_thumbnail_v2', arg, 'app, user', 'content', 'download', 'files.content.read', options);
 };
 
 /**
@@ -874,10 +936,11 @@ routes.filesGetThumbnailV2 = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#filesGetThumbnailBatch
  * @arg {FilesGetThumbnailBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesGetThumbnailBatchResult>, DropboxResponseError.<FilesGetThumbnailBatchError>>}
  */
-routes.filesGetThumbnailBatch = function (arg) {
-  return this.request('files/get_thumbnail_batch', arg, 'user', 'content', 'rpc', 'files.content.read');
+routes.filesGetThumbnailBatch = function (arg, options) {
+  return this.request('files/get_thumbnail_batch', arg, 'user', 'content', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -905,10 +968,11 @@ routes.filesGetThumbnailBatch = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesListFolder
  * @arg {FilesListFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesListFolderResult>, DropboxResponseError.<FilesListFolderError>>}
  */
-routes.filesListFolder = function (arg) {
-  return this.request('files/list_folder', arg, 'app, user', 'api', 'rpc', 'files.metadata.read');
+routes.filesListFolder = function (arg, options) {
+  return this.request('files/list_folder', arg, 'app, user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -919,10 +983,11 @@ routes.filesListFolder = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesListFolderContinue
  * @arg {FilesListFolderContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesListFolderResult>, DropboxResponseError.<FilesListFolderContinueError>>}
  */
-routes.filesListFolderContinue = function (arg) {
-  return this.request('files/list_folder/continue', arg, 'app, user', 'api', 'rpc', 'files.metadata.read');
+routes.filesListFolderContinue = function (arg, options) {
+  return this.request('files/list_folder/continue', arg, 'app, user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -934,10 +999,11 @@ routes.filesListFolderContinue = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesListFolderGetLatestCursor
  * @arg {FilesListFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesListFolderGetLatestCursorResult>, DropboxResponseError.<FilesListFolderError>>}
  */
-routes.filesListFolderGetLatestCursor = function (arg) {
-  return this.request('files/list_folder/get_latest_cursor', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesListFolderGetLatestCursor = function (arg, options) {
+  return this.request('files/list_folder/get_latest_cursor', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -950,10 +1016,11 @@ routes.filesListFolderGetLatestCursor = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesListFolderLongpoll
  * @arg {FilesListFolderLongpollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesListFolderLongpollResult>, DropboxResponseError.<FilesListFolderLongpollError>>}
  */
-routes.filesListFolderLongpoll = function (arg) {
-  return this.request('files/list_folder/longpoll', arg, 'noauth', 'notify', 'rpc', 'files.metadata.read');
+routes.filesListFolderLongpoll = function (arg, options) {
+  return this.request('files/list_folder/longpoll', arg, 'noauth', 'notify', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -969,10 +1036,11 @@ routes.filesListFolderLongpoll = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesListRevisions
  * @arg {FilesListRevisionsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesListRevisionsResult>, DropboxResponseError.<FilesListRevisionsError>>}
  */
-routes.filesListRevisions = function (arg) {
-  return this.request('files/list_revisions', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesListRevisions = function (arg, options) {
+  return this.request('files/list_revisions', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -984,10 +1052,11 @@ routes.filesListRevisions = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesLockFileBatch
  * @arg {FilesLockFileBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesLockFileBatchResult>, DropboxResponseError.<FilesLockFileError>>}
  */
-routes.filesLockFileBatch = function (arg) {
-  return this.request('files/lock_file_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesLockFileBatch = function (arg, options) {
+  return this.request('files/lock_file_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -998,10 +1067,11 @@ routes.filesLockFileBatch = function (arg) {
  * @function Dropbox#filesMove
  * @deprecated
  * @arg {FilesRelocationArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(FilesFileMetadata|FilesFolderMetadata|FilesDeletedMetadata)>, DropboxResponseError.<FilesRelocationError>>}
  */
-routes.filesMove = function (arg) {
-  return this.request('files/move', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMove = function (arg, options) {
+  return this.request('files/move', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1012,10 +1082,11 @@ routes.filesMove = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesMoveV2
  * @arg {FilesRelocationArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationResult>, DropboxResponseError.<FilesRelocationError>>}
  */
-routes.filesMoveV2 = function (arg) {
-  return this.request('files/move_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveV2 = function (arg, options) {
+  return this.request('files/move_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1027,10 +1098,11 @@ routes.filesMoveV2 = function (arg) {
  * @function Dropbox#filesMoveBatch
  * @deprecated
  * @arg {FilesRelocationBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesMoveBatch = function (arg) {
-  return this.request('files/move_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatch = function (arg, options) {
+  return this.request('files/move_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1045,10 +1117,11 @@ routes.filesMoveBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesMoveBatchV2
  * @arg {FilesMoveBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchV2Launch>, DropboxResponseError.<void>>}
  */
-routes.filesMoveBatchV2 = function (arg) {
-  return this.request('files/move_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatchV2 = function (arg, options) {
+  return this.request('files/move_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1059,10 +1132,11 @@ routes.filesMoveBatchV2 = function (arg) {
  * @function Dropbox#filesMoveBatchCheck
  * @deprecated
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesMoveBatchCheck = function (arg) {
-  return this.request('files/move_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatchCheck = function (arg, options) {
+  return this.request('files/move_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1072,10 +1146,11 @@ routes.filesMoveBatchCheck = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesMoveBatchCheckV2
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesRelocationBatchV2JobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesMoveBatchCheckV2 = function (arg) {
-  return this.request('files/move_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesMoveBatchCheckV2 = function (arg, options) {
+  return this.request('files/move_batch/check_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1084,10 +1159,11 @@ routes.filesMoveBatchCheckV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesPaperCreate
  * @arg {FilesPaperCreateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesPaperCreateResult>, DropboxResponseError.<FilesPaperCreateError>>}
  */
-routes.filesPaperCreate = function (arg) {
-  return this.request('files/paper/create', arg, 'user', 'api', 'upload', 'files.content.write');
+routes.filesPaperCreate = function (arg, options) {
+  return this.request('files/paper/create', arg, 'user', 'api', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1096,10 +1172,11 @@ routes.filesPaperCreate = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesPaperUpdate
  * @arg {FilesPaperUpdateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesPaperUpdateResult>, DropboxResponseError.<FilesPaperUpdateError>>}
  */
-routes.filesPaperUpdate = function (arg) {
-  return this.request('files/paper/update', arg, 'user', 'api', 'upload', 'files.content.write');
+routes.filesPaperUpdate = function (arg, options) {
+  return this.request('files/paper/update', arg, 'user', 'api', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1112,10 +1189,11 @@ routes.filesPaperUpdate = function (arg) {
  *   scope: files.permanent_delete
  * @function Dropbox#filesPermanentlyDelete
  * @arg {FilesDeleteArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesDeleteError>>}
  */
-routes.filesPermanentlyDelete = function (arg) {
-  return this.request('files/permanently_delete', arg, 'user', 'api', 'rpc', 'files.permanent_delete');
+routes.filesPermanentlyDelete = function (arg, options) {
+  return this.request('files/permanently_delete', arg, 'user', 'api', 'rpc', 'files.permanent_delete', options);
 };
 
 /**
@@ -1126,10 +1204,11 @@ routes.filesPermanentlyDelete = function (arg) {
  * @function Dropbox#filesPropertiesAdd
  * @deprecated
  * @arg {FilePropertiesAddPropertiesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesAddPropertiesError>>}
  */
-routes.filesPropertiesAdd = function (arg) {
-  return this.request('files/properties/add', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filesPropertiesAdd = function (arg, options) {
+  return this.request('files/properties/add', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -1141,10 +1220,11 @@ routes.filesPropertiesAdd = function (arg) {
  * @function Dropbox#filesPropertiesOverwrite
  * @deprecated
  * @arg {FilePropertiesOverwritePropertyGroupArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesInvalidPropertyGroupError>>}
  */
-routes.filesPropertiesOverwrite = function (arg) {
-  return this.request('files/properties/overwrite', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filesPropertiesOverwrite = function (arg, options) {
+  return this.request('files/properties/overwrite', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -1157,10 +1237,11 @@ routes.filesPropertiesOverwrite = function (arg) {
  * @function Dropbox#filesPropertiesUpdate
  * @deprecated
  * @arg {FilePropertiesUpdatePropertiesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilePropertiesUpdatePropertiesError>>}
  */
-routes.filesPropertiesUpdate = function (arg) {
-  return this.request('files/properties/update', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filesPropertiesUpdate = function (arg, options) {
+  return this.request('files/properties/update', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -1169,10 +1250,11 @@ routes.filesPropertiesUpdate = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesRestore
  * @arg {FilesRestoreArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesRestoreError>>}
  */
-routes.filesRestore = function (arg) {
-  return this.request('files/restore', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesRestore = function (arg, options) {
+  return this.request('files/restore', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1183,10 +1265,11 @@ routes.filesRestore = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesSaveUrl
  * @arg {FilesSaveUrlArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSaveUrlResult>, DropboxResponseError.<FilesSaveUrlError>>}
  */
-routes.filesSaveUrl = function (arg) {
-  return this.request('files/save_url', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesSaveUrl = function (arg, options) {
+  return this.request('files/save_url', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1195,10 +1278,11 @@ routes.filesSaveUrl = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesSaveUrlCheckJobStatus
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSaveUrlJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesSaveUrlCheckJobStatus = function (arg) {
-  return this.request('files/save_url/check_job_status', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesSaveUrlCheckJobStatus = function (arg, options) {
+  return this.request('files/save_url/check_job_status', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1210,10 +1294,11 @@ routes.filesSaveUrlCheckJobStatus = function (arg) {
  * @function Dropbox#filesSearch
  * @deprecated
  * @arg {FilesSearchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSearchResult>, DropboxResponseError.<FilesSearchError>>}
  */
-routes.filesSearch = function (arg) {
-  return this.request('files/search', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesSearch = function (arg, options) {
+  return this.request('files/search', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1226,10 +1311,11 @@ routes.filesSearch = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesSearchV2
  * @arg {FilesSearchV2Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSearchV2Result>, DropboxResponseError.<FilesSearchError>>}
  */
-routes.filesSearchV2 = function (arg) {
-  return this.request('files/search_v2', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesSearchV2 = function (arg, options) {
+  return this.request('files/search_v2', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1242,10 +1328,11 @@ routes.filesSearchV2 = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesSearchContinueV2
  * @arg {FilesSearchV2ContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesSearchV2Result>, DropboxResponseError.<FilesSearchError>>}
  */
-routes.filesSearchContinueV2 = function (arg) {
-  return this.request('files/search/continue_v2', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesSearchContinueV2 = function (arg, options) {
+  return this.request('files/search/continue_v2', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1256,10 +1343,11 @@ routes.filesSearchContinueV2 = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filesTagsAdd
  * @arg {FilesAddTagArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesAddTagError>>}
  */
-routes.filesTagsAdd = function (arg) {
-  return this.request('files/tags/add', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filesTagsAdd = function (arg, options) {
+  return this.request('files/tags/add', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -1268,10 +1356,11 @@ routes.filesTagsAdd = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#filesTagsGet
  * @arg {FilesGetTagsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesGetTagsResult>, DropboxResponseError.<FilesBaseTagError>>}
  */
-routes.filesTagsGet = function (arg) {
-  return this.request('files/tags/get', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.filesTagsGet = function (arg, options) {
+  return this.request('files/tags/get', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1280,10 +1369,11 @@ routes.filesTagsGet = function (arg) {
  *   scope: files.metadata.write
  * @function Dropbox#filesTagsRemove
  * @arg {FilesRemoveTagArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesRemoveTagError>>}
  */
-routes.filesTagsRemove = function (arg) {
-  return this.request('files/tags/remove', arg, 'user', 'api', 'rpc', 'files.metadata.write');
+routes.filesTagsRemove = function (arg, options) {
+  return this.request('files/tags/remove', arg, 'user', 'api', 'rpc', 'files.metadata.write', options);
 };
 
 /**
@@ -1295,10 +1385,11 @@ routes.filesTagsRemove = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUnlockFileBatch
  * @arg {FilesUnlockFileBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesLockFileBatchResult>, DropboxResponseError.<FilesLockFileError>>}
  */
-routes.filesUnlockFileBatch = function (arg) {
-  return this.request('files/unlock_file_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesUnlockFileBatch = function (arg, options) {
+  return this.request('files/unlock_file_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1313,10 +1404,11 @@ routes.filesUnlockFileBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUpload
  * @arg {FilesUploadArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesUploadError>>}
  */
-routes.filesUpload = function (arg) {
-  return this.request('files/upload', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUpload = function (arg, options) {
+  return this.request('files/upload', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1332,10 +1424,11 @@ routes.filesUpload = function (arg) {
  * @function Dropbox#filesUploadSessionAppend
  * @deprecated
  * @arg {FilesUploadSessionCursor} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesUploadSessionAppendError>>}
  */
-routes.filesUploadSessionAppend = function (arg) {
-  return this.request('files/upload_session/append', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUploadSessionAppend = function (arg, options) {
+  return this.request('files/upload_session/append', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1351,10 +1444,11 @@ routes.filesUploadSessionAppend = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionAppendV2
  * @arg {FilesUploadSessionAppendArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<FilesUploadSessionAppendError>>}
  */
-routes.filesUploadSessionAppendV2 = function (arg) {
-  return this.request('files/upload_session/append_v2', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUploadSessionAppendV2 = function (arg, options) {
+  return this.request('files/upload_session/append_v2', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1372,10 +1466,11 @@ routes.filesUploadSessionAppendV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionAppendBatch
  * @arg {FilesUploadSessionAppendBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionAppendBatchResult>, DropboxResponseError.<FilesUploadSessionAppendBatchError>>}
  */
-routes.filesUploadSessionAppendBatch = function (arg) {
-  return this.request('files/upload_session/append_batch', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUploadSessionAppendBatch = function (arg, options) {
+  return this.request('files/upload_session/append_batch', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1390,10 +1485,11 @@ routes.filesUploadSessionAppendBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionFinish
  * @arg {FilesUploadSessionFinishArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesFileMetadata>, DropboxResponseError.<FilesUploadSessionFinishError>>}
  */
-routes.filesUploadSessionFinish = function (arg) {
-  return this.request('files/upload_session/finish', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUploadSessionFinish = function (arg, options) {
+  return this.request('files/upload_session/finish', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1419,10 +1515,11 @@ routes.filesUploadSessionFinish = function (arg) {
  * @function Dropbox#filesUploadSessionFinishBatch
  * @deprecated
  * @arg {FilesUploadSessionFinishBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionFinishBatchLaunch>, DropboxResponseError.<void>>}
  */
-routes.filesUploadSessionFinishBatch = function (arg) {
-  return this.request('files/upload_session/finish_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesUploadSessionFinishBatch = function (arg, options) {
+  return this.request('files/upload_session/finish_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1444,10 +1541,11 @@ routes.filesUploadSessionFinishBatch = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionFinishBatchV2
  * @arg {FilesUploadSessionFinishBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionFinishBatchResult>, DropboxResponseError.<void>>}
  */
-routes.filesUploadSessionFinishBatchV2 = function (arg) {
-  return this.request('files/upload_session/finish_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesUploadSessionFinishBatchV2 = function (arg, options) {
+  return this.request('files/upload_session/finish_batch_v2', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1457,10 +1555,11 @@ routes.filesUploadSessionFinishBatchV2 = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionFinishBatchCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionFinishBatchJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.filesUploadSessionFinishBatchCheck = function (arg) {
-  return this.request('files/upload_session/finish_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesUploadSessionFinishBatchCheck = function (arg, options) {
+  return this.request('files/upload_session/finish_batch/check', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1498,10 +1597,11 @@ routes.filesUploadSessionFinishBatchCheck = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionStart
  * @arg {FilesUploadSessionStartArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionStartResult>, DropboxResponseError.<FilesUploadSessionStartError>>}
  */
-routes.filesUploadSessionStart = function (arg) {
-  return this.request('files/upload_session/start', arg, 'user', 'content', 'upload', 'files.content.write');
+routes.filesUploadSessionStart = function (arg, options) {
+  return this.request('files/upload_session/start', arg, 'user', 'content', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1514,10 +1614,11 @@ routes.filesUploadSessionStart = function (arg) {
  *   scope: files.content.write
  * @function Dropbox#filesUploadSessionStartBatch
  * @arg {FilesUploadSessionStartBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilesUploadSessionStartBatchResult>, DropboxResponseError.<void>>}
  */
-routes.filesUploadSessionStartBatch = function (arg) {
-  return this.request('files/upload_session/start_batch', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.filesUploadSessionStartBatch = function (arg, options) {
+  return this.request('files/upload_session/start_batch', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1528,10 +1629,11 @@ routes.filesUploadSessionStartBatch = function (arg) {
  *   scope: openid
  * @function Dropbox#openidUserinfo
  * @arg {OpenidUserInfoArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<OpenidUserInfoResult>, DropboxResponseError.<OpenidUserInfoError>>}
  */
-routes.openidUserinfo = function (arg) {
-  return this.request('openid/userinfo', arg, 'user', 'api', 'rpc', 'openid');
+routes.openidUserinfo = function (arg, options) {
+  return this.request('openid/userinfo', arg, 'user', 'api', 'rpc', 'openid', options);
 };
 
 /**
@@ -1549,10 +1651,11 @@ routes.openidUserinfo = function (arg) {
  * @function Dropbox#paperDocsArchive
  * @deprecated
  * @arg {PaperRefPaperDoc} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsArchive = function (arg) {
-  return this.request('paper/docs/archive', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.paperDocsArchive = function (arg, options) {
+  return this.request('paper/docs/archive', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
@@ -1569,10 +1672,11 @@ routes.paperDocsArchive = function (arg) {
  * @function Dropbox#paperDocsCreate
  * @deprecated
  * @arg {PaperPaperDocCreateArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperPaperDocCreateUpdateResult>, DropboxResponseError.<PaperPaperDocCreateError>>}
  */
-routes.paperDocsCreate = function (arg) {
-  return this.request('paper/docs/create', arg, 'user', 'api', 'upload', 'files.content.write');
+routes.paperDocsCreate = function (arg, options) {
+  return this.request('paper/docs/create', arg, 'user', 'api', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1588,10 +1692,11 @@ routes.paperDocsCreate = function (arg) {
  * @function Dropbox#paperDocsDownload
  * @deprecated
  * @arg {PaperPaperDocExport} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperPaperDocExportResult>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsDownload = function (arg) {
-  return this.request('paper/docs/download', arg, 'user', 'api', 'download', 'files.content.read');
+routes.paperDocsDownload = function (arg, options) {
+  return this.request('paper/docs/download', arg, 'user', 'api', 'download', 'files.content.read', options);
 };
 
 /**
@@ -1610,10 +1715,11 @@ routes.paperDocsDownload = function (arg) {
  * @function Dropbox#paperDocsFolderUsersList
  * @deprecated
  * @arg {PaperListUsersOnFolderArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListUsersOnFolderResponse>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsFolderUsersList = function (arg) {
-  return this.request('paper/docs/folder_users/list', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsFolderUsersList = function (arg, options) {
+  return this.request('paper/docs/folder_users/list', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1630,10 +1736,11 @@ routes.paperDocsFolderUsersList = function (arg) {
  * @function Dropbox#paperDocsFolderUsersListContinue
  * @deprecated
  * @arg {PaperListUsersOnFolderContinueArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListUsersOnFolderResponse>, DropboxResponseError.<PaperListUsersCursorError>>}
  */
-routes.paperDocsFolderUsersListContinue = function (arg) {
-  return this.request('paper/docs/folder_users/list/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsFolderUsersListContinue = function (arg, options) {
+  return this.request('paper/docs/folder_users/list/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1653,10 +1760,11 @@ routes.paperDocsFolderUsersListContinue = function (arg) {
  * @function Dropbox#paperDocsGetFolderInfo
  * @deprecated
  * @arg {PaperRefPaperDoc} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperFoldersContainingPaperDoc>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsGetFolderInfo = function (arg) {
-  return this.request('paper/docs/get_folder_info', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsGetFolderInfo = function (arg, options) {
+  return this.request('paper/docs/get_folder_info', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1665,10 +1773,11 @@ routes.paperDocsGetFolderInfo = function (arg) {
  *   scope: files.metadata.read
  * @function Dropbox#paperDocsGetMetadata
  * @arg {PaperGetDocMetadataArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperPaperDocGetMetadataResult>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsGetMetadata = function (arg) {
-  return this.request('paper/docs/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.paperDocsGetMetadata = function (arg, options) {
+  return this.request('paper/docs/get_metadata', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1686,10 +1795,11 @@ routes.paperDocsGetMetadata = function (arg) {
  * @function Dropbox#paperDocsList
  * @deprecated
  * @arg {PaperListPaperDocsArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListPaperDocsResponse>, DropboxResponseError.<void>>}
  */
-routes.paperDocsList = function (arg) {
-  return this.request('paper/docs/list', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.paperDocsList = function (arg, options) {
+  return this.request('paper/docs/list', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1706,10 +1816,11 @@ routes.paperDocsList = function (arg) {
  * @function Dropbox#paperDocsListContinue
  * @deprecated
  * @arg {PaperListPaperDocsContinueArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListPaperDocsResponse>, DropboxResponseError.<PaperListDocsCursorError>>}
  */
-routes.paperDocsListContinue = function (arg) {
-  return this.request('paper/docs/list/continue', arg, 'user', 'api', 'rpc', 'files.metadata.read');
+routes.paperDocsListContinue = function (arg, options) {
+  return this.request('paper/docs/list/continue', arg, 'user', 'api', 'rpc', 'files.metadata.read', options);
 };
 
 /**
@@ -1726,10 +1837,11 @@ routes.paperDocsListContinue = function (arg) {
  * @function Dropbox#paperDocsPermanentlyDelete
  * @deprecated
  * @arg {PaperRefPaperDoc} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsPermanentlyDelete = function (arg) {
-  return this.request('paper/docs/permanently_delete', arg, 'user', 'api', 'rpc', 'files.permanent_delete');
+routes.paperDocsPermanentlyDelete = function (arg, options) {
+  return this.request('paper/docs/permanently_delete', arg, 'user', 'api', 'rpc', 'files.permanent_delete', options);
 };
 
 /**
@@ -1745,10 +1857,11 @@ routes.paperDocsPermanentlyDelete = function (arg) {
  * @function Dropbox#paperDocsSharingPolicyGet
  * @deprecated
  * @arg {PaperRefPaperDoc} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperSharingPolicy>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsSharingPolicyGet = function (arg) {
-  return this.request('paper/docs/sharing_policy/get', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsSharingPolicyGet = function (arg, options) {
+  return this.request('paper/docs/sharing_policy/get', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1768,10 +1881,11 @@ routes.paperDocsSharingPolicyGet = function (arg) {
  * @function Dropbox#paperDocsSharingPolicySet
  * @deprecated
  * @arg {PaperPaperDocSharingPolicy} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsSharingPolicySet = function (arg) {
-  return this.request('paper/docs/sharing_policy/set', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.paperDocsSharingPolicySet = function (arg, options) {
+  return this.request('paper/docs/sharing_policy/set', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -1788,10 +1902,11 @@ routes.paperDocsSharingPolicySet = function (arg) {
  * @function Dropbox#paperDocsUpdate
  * @deprecated
  * @arg {PaperPaperDocUpdateArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperPaperDocCreateUpdateResult>, DropboxResponseError.<PaperPaperDocUpdateError>>}
  */
-routes.paperDocsUpdate = function (arg) {
-  return this.request('paper/docs/update', arg, 'user', 'api', 'upload', 'files.content.write');
+routes.paperDocsUpdate = function (arg, options) {
+  return this.request('paper/docs/update', arg, 'user', 'api', 'upload', 'files.content.write', options);
 };
 
 /**
@@ -1809,10 +1924,11 @@ routes.paperDocsUpdate = function (arg) {
  * @function Dropbox#paperDocsUsersAdd
  * @deprecated
  * @arg {PaperAddPaperDocUser} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<PaperAddPaperDocUserMemberResult>>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsUsersAdd = function (arg) {
-  return this.request('paper/docs/users/add', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.paperDocsUsersAdd = function (arg, options) {
+  return this.request('paper/docs/users/add', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -1831,10 +1947,11 @@ routes.paperDocsUsersAdd = function (arg) {
  * @function Dropbox#paperDocsUsersList
  * @deprecated
  * @arg {PaperListUsersOnPaperDocArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListUsersOnPaperDocResponse>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsUsersList = function (arg) {
-  return this.request('paper/docs/users/list', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsUsersList = function (arg, options) {
+  return this.request('paper/docs/users/list', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1851,10 +1968,11 @@ routes.paperDocsUsersList = function (arg) {
  * @function Dropbox#paperDocsUsersListContinue
  * @deprecated
  * @arg {PaperListUsersOnPaperDocContinueArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperListUsersOnPaperDocResponse>, DropboxResponseError.<PaperListUsersCursorError>>}
  */
-routes.paperDocsUsersListContinue = function (arg) {
-  return this.request('paper/docs/users/list/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.paperDocsUsersListContinue = function (arg, options) {
+  return this.request('paper/docs/users/list/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -1871,10 +1989,11 @@ routes.paperDocsUsersListContinue = function (arg) {
  * @function Dropbox#paperDocsUsersRemove
  * @deprecated
  * @arg {PaperRemovePaperDocUser} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<PaperDocLookupError>>}
  */
-routes.paperDocsUsersRemove = function (arg) {
-  return this.request('paper/docs/users/remove', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.paperDocsUsersRemove = function (arg, options) {
+  return this.request('paper/docs/users/remove', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -1890,26 +2009,24 @@ routes.paperDocsUsersRemove = function (arg) {
  * @function Dropbox#paperFoldersCreate
  * @deprecated
  * @arg {PaperPaperFolderCreateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<PaperPaperFolderCreateResult>, DropboxResponseError.<PaperPaperFolderCreateError>>}
  */
-routes.paperFoldersCreate = function (arg) {
-  return this.request('paper/folders/create', arg, 'user', 'api', 'rpc', 'files.content.write');
+routes.paperFoldersCreate = function (arg, options) {
+  return this.request('paper/folders/create', arg, 'user', 'api', 'rpc', 'files.content.write', options);
 };
 
 /**
  * Asynchronous document-to-markdown conversion for supported file formats.
- * Supported formats: .binder, .docx, .html, .paper, .papert, .pptx, .xlsx,
- * .gsheet, .ods, .pdf. Unsupported formats return an
- * `unsupported_format_error`. Size limit: the source file must be at most 50
- * MB. Larger files are rejected.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMarkdownAsync
  * @arg {RivieraGetMarkdownArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<void>>}
  */
-routes.rivieraGetMarkdownAsync = function (arg) {
-  return this.request('riviera/get_markdown_async', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetMarkdownAsync = function (arg, options) {
+  return this.request('riviera/get_markdown_async', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -1918,32 +2035,24 @@ routes.rivieraGetMarkdownAsync = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMarkdownAsyncCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<RivieraGetMarkdownAsyncCheckResult>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.rivieraGetMarkdownAsyncCheck = function (arg) {
-  return this.request('riviera/get_markdown_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetMarkdownAsyncCheck = function (arg, options) {
+  return this.request('riviera/get_markdown_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
- * Asynchronous file metadata extraction for supported file formats. The kind of
- * metadata returned depends on the file type: - Image (EXIF) formats: .3fr,
- * .arw, .avif, .bmp, .cr2, .cr3, .crw, .dcr, .dcs, .dng, .erf, .gif, .heic,
- * .j2c, .j2k, .jp2, .jpc, .jpeg, .jpf, .jpg, .jpg2, .jpm, .jpx, .kdc, .mef,
- * .mos, .mrw, .nef, .nrw, .orf, .pef, .png, .ppm, .r3d, .raf, .rw2, .rwl, .sr2,
- * .tga, .tif, .tiff, .wbmp, .web, .webp, .x3f. - Audio/video (media) formats:
- * .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg, .wav, .wma, .3gp,
- * .3gpp, .3gpp2, .asf, .avi, .dv, .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4,
- * .mpeg, .mpg, .mts, .mxf, .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. - PDF
- * format: .pdf. - MS Office formats: .docx, .pptx, .xlsx. Unsupported formats
- * return an `unsupported_format_error`.
+ * Asynchronous file metadata extraction for supported file formats.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMetadataAsync
  * @arg {RivieraGetMetadataArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<void>>}
  */
-routes.rivieraGetMetadataAsync = function (arg) {
-  return this.request('riviera/get_metadata_async', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetMetadataAsync = function (arg, options) {
+  return this.request('riviera/get_metadata_async', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -1952,59 +2061,24 @@ routes.rivieraGetMetadataAsync = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#rivieraGetMetadataAsyncCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<RivieraGetMetadataAsyncCheckResult>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.rivieraGetMetadataAsyncCheck = function (arg) {
-  return this.request('riviera/get_metadata_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetMetadataAsyncCheck = function (arg, options) {
+  return this.request('riviera/get_metadata_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
- * Asynchronous plain-text extraction from documents. Supported formats include:
- * - Word processing: .doc, .docx, .docm, .rtf. - Presentations: .ppt, .pptx,
- * .pptm. - Spreadsheets: .xls, .xlsx, .xlsm. - PDF: .pdf. - Dropbox document
- * types: .paper, .papert, .binder, .gdoc, .gsheet, .gslides. - Plain text /
- * subtitles: .txt, .vtt. Unsupported formats return an
- * `unsupported_format_error`. For the `url` variant only Dropbox shared links
- * are supported; external URLs return `unsupported_format_error`.
- * Route attributes:
- *   scope: files.content.read
- * @function Dropbox#rivieraGetTextAsync
- * @arg {RivieraGetTextArgs} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<void>>}
- */
-routes.rivieraGetTextAsync = function (arg) {
-  return this.request('riviera/get_text_async', arg, 'app, user', 'api', 'rpc', 'files.content.read');
-};
-
-/**
- * Returns the status or result of specified get_text_async task.
- * Route attributes:
- *   scope: files.content.read
- * @function Dropbox#rivieraGetTextAsyncCheck
- * @arg {AsyncPollArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<RivieraGetTextAsyncCheckResult>, DropboxResponseError.<AsyncPollError>>}
- */
-routes.rivieraGetTextAsyncCheck = function (arg) {
-  return this.request('riviera/get_text_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read');
-};
-
-/**
- * Asynchronous transcript generation for audio and video files. Supported audio
- * formats: .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg, .wav, .wma.
- * Supported video formats: .3gp, .3gpp, .3gpp2, .asf, .avi, .dv, .flv, .m2t,
- * .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf, .oggtheora, .ogv,
- * .rm, .ts, .vob, .webm, .wmv. Unsupported formats return an
- * `unsupported_format_error`. Size limits: the source file must be at most 10
- * GB and its audio track at most 1 hour in duration. Files exceeding these
- * limits are rejected.
+ * Asynchronous transcript generation for audio and video files.
  * Route attributes:
  *   scope: files.content.read
  * @function Dropbox#rivieraGetTranscriptAsync
  * @arg {RivieraGetTranscriptArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<void>>}
  */
-routes.rivieraGetTranscriptAsync = function (arg) {
-  return this.request('riviera/get_transcript_async', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetTranscriptAsync = function (arg, options) {
+  return this.request('riviera/get_transcript_async', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -2013,10 +2087,11 @@ routes.rivieraGetTranscriptAsync = function (arg) {
  *   scope: files.content.read
  * @function Dropbox#rivieraGetTranscriptAsyncCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<RivieraGetTranscriptAsyncCheckResult>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.rivieraGetTranscriptAsyncCheck = function (arg) {
-  return this.request('riviera/get_transcript_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read');
+routes.rivieraGetTranscriptAsyncCheck = function (arg, options) {
+  return this.request('riviera/get_transcript_async/check', arg, 'app, user', 'api', 'rpc', 'files.content.read', options);
 };
 
 /**
@@ -2025,10 +2100,11 @@ routes.rivieraGetTranscriptAsyncCheck = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingAddFileMember
  * @arg {SharingAddFileMemberArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<SharingFileMemberActionResult>>, DropboxResponseError.<SharingAddFileMemberError>>}
  */
-routes.sharingAddFileMember = function (arg) {
-  return this.request('sharing/add_file_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingAddFileMember = function (arg, options) {
+  return this.request('sharing/add_file_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2040,10 +2116,11 @@ routes.sharingAddFileMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingAddFolderMember
  * @arg {SharingAddFolderMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingAddFolderMemberError>>}
  */
-routes.sharingAddFolderMember = function (arg) {
-  return this.request('sharing/add_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingAddFolderMember = function (arg, options) {
+  return this.request('sharing/add_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2052,10 +2129,11 @@ routes.sharingAddFolderMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingCheckJobStatus
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.sharingCheckJobStatus = function (arg) {
-  return this.request('sharing/check_job_status', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingCheckJobStatus = function (arg, options) {
+  return this.request('sharing/check_job_status', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2064,10 +2142,11 @@ routes.sharingCheckJobStatus = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingCheckRemoveMemberJobStatus
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingRemoveMemberJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.sharingCheckRemoveMemberJobStatus = function (arg) {
-  return this.request('sharing/check_remove_member_job_status', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingCheckRemoveMemberJobStatus = function (arg, options) {
+  return this.request('sharing/check_remove_member_job_status', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2076,10 +2155,11 @@ routes.sharingCheckRemoveMemberJobStatus = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingCheckShareJobStatus
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingShareFolderJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.sharingCheckShareJobStatus = function (arg) {
-  return this.request('sharing/check_share_job_status', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingCheckShareJobStatus = function (arg, options) {
+  return this.request('sharing/check_share_job_status', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2094,10 +2174,11 @@ routes.sharingCheckShareJobStatus = function (arg) {
  * @function Dropbox#sharingCreateSharedLink
  * @deprecated
  * @arg {SharingCreateSharedLinkArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingPathLinkMetadata>, DropboxResponseError.<SharingCreateSharedLinkError>>}
  */
-routes.sharingCreateSharedLink = function (arg) {
-  return this.request('sharing/create_shared_link', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingCreateSharedLink = function (arg, options) {
+  return this.request('sharing/create_shared_link', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2108,10 +2189,11 @@ routes.sharingCreateSharedLink = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingCreateSharedLinkWithSettings
  * @arg {SharingCreateSharedLinkWithSettingsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(SharingFileLinkMetadata|SharingFolderLinkMetadata|SharingSharedLinkMetadata)>, DropboxResponseError.<SharingCreateSharedLinkWithSettingsError>>}
  */
-routes.sharingCreateSharedLinkWithSettings = function (arg) {
-  return this.request('sharing/create_shared_link_with_settings', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingCreateSharedLinkWithSettings = function (arg, options) {
+  return this.request('sharing/create_shared_link_with_settings', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2120,10 +2202,11 @@ routes.sharingCreateSharedLinkWithSettings = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingGetFileMetadata
  * @arg {SharingGetFileMetadataArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFileMetadata>, DropboxResponseError.<SharingGetFileMetadataError>>}
  */
-routes.sharingGetFileMetadata = function (arg) {
-  return this.request('sharing/get_file_metadata', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingGetFileMetadata = function (arg, options) {
+  return this.request('sharing/get_file_metadata', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2132,10 +2215,11 @@ routes.sharingGetFileMetadata = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingGetFileMetadataBatch
  * @arg {SharingGetFileMetadataBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<SharingGetFileMetadataBatchResult>>, DropboxResponseError.<SharingSharingUserError>>}
  */
-routes.sharingGetFileMetadataBatch = function (arg) {
-  return this.request('sharing/get_file_metadata/batch', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingGetFileMetadataBatch = function (arg, options) {
+  return this.request('sharing/get_file_metadata/batch', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2144,10 +2228,11 @@ routes.sharingGetFileMetadataBatch = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingGetFolderMetadata
  * @arg {SharingGetMetadataArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFolderMetadata>, DropboxResponseError.<SharingSharedFolderAccessError>>}
  */
-routes.sharingGetFolderMetadata = function (arg) {
-  return this.request('sharing/get_folder_metadata', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingGetFolderMetadata = function (arg, options) {
+  return this.request('sharing/get_folder_metadata', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2157,10 +2242,11 @@ routes.sharingGetFolderMetadata = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingGetSharedLinkFile
  * @arg {Object} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(SharingFileLinkMetadata|SharingFolderLinkMetadata|SharingSharedLinkMetadata)>, DropboxResponseError.<SharingGetSharedLinkFileError>>}
  */
-routes.sharingGetSharedLinkFile = function (arg) {
-  return this.request('sharing/get_shared_link_file', arg, 'app, user', 'content', 'download', 'sharing.read');
+routes.sharingGetSharedLinkFile = function (arg, options) {
+  return this.request('sharing/get_shared_link_file', arg, 'app, user', 'content', 'download', 'sharing.read', options);
 };
 
 /**
@@ -2169,10 +2255,11 @@ routes.sharingGetSharedLinkFile = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingGetSharedLinkMetadata
  * @arg {SharingGetSharedLinkMetadataArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(SharingFileLinkMetadata|SharingFolderLinkMetadata|SharingSharedLinkMetadata)>, DropboxResponseError.<SharingSharedLinkMetadataError>>}
  */
-routes.sharingGetSharedLinkMetadata = function (arg) {
-  return this.request('sharing/get_shared_link_metadata', arg, 'app, user', 'api', 'rpc', 'sharing.read');
+routes.sharingGetSharedLinkMetadata = function (arg, options) {
+  return this.request('sharing/get_shared_link_metadata', arg, 'app, user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2187,10 +2274,11 @@ routes.sharingGetSharedLinkMetadata = function (arg) {
  * @function Dropbox#sharingGetSharedLinks
  * @deprecated
  * @arg {SharingGetSharedLinksArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingGetSharedLinksResult>, DropboxResponseError.<SharingGetSharedLinksError>>}
  */
-routes.sharingGetSharedLinks = function (arg) {
-  return this.request('sharing/get_shared_links', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingGetSharedLinks = function (arg, options) {
+  return this.request('sharing/get_shared_links', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2200,10 +2288,11 @@ routes.sharingGetSharedLinks = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFileMembers
  * @arg {SharingListFileMembersArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFileMembers>, DropboxResponseError.<SharingListFileMembersError>>}
  */
-routes.sharingListFileMembers = function (arg) {
-  return this.request('sharing/list_file_members', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFileMembers = function (arg, options) {
+  return this.request('sharing/list_file_members', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2216,10 +2305,11 @@ routes.sharingListFileMembers = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFileMembersBatch
  * @arg {SharingListFileMembersBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<SharingListFileMembersBatchResult>>, DropboxResponseError.<SharingSharingUserError>>}
  */
-routes.sharingListFileMembersBatch = function (arg) {
-  return this.request('sharing/list_file_members/batch', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFileMembersBatch = function (arg, options) {
+  return this.request('sharing/list_file_members/batch', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2230,10 +2320,11 @@ routes.sharingListFileMembersBatch = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFileMembersContinue
  * @arg {SharingListFileMembersContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFileMembers>, DropboxResponseError.<SharingListFileMembersContinueError>>}
  */
-routes.sharingListFileMembersContinue = function (arg) {
-  return this.request('sharing/list_file_members/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFileMembersContinue = function (arg, options) {
+  return this.request('sharing/list_file_members/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2242,10 +2333,11 @@ routes.sharingListFileMembersContinue = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFolderMembers
  * @arg {SharingListFolderMembersArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFolderMembers>, DropboxResponseError.<SharingSharedFolderAccessError>>}
  */
-routes.sharingListFolderMembers = function (arg) {
-  return this.request('sharing/list_folder_members', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFolderMembers = function (arg, options) {
+  return this.request('sharing/list_folder_members', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2255,10 +2347,11 @@ routes.sharingListFolderMembers = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFolderMembersContinue
  * @arg {SharingListFolderMembersContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFolderMembers>, DropboxResponseError.<SharingListFolderMembersContinueError>>}
  */
-routes.sharingListFolderMembersContinue = function (arg) {
-  return this.request('sharing/list_folder_members/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFolderMembersContinue = function (arg, options) {
+  return this.request('sharing/list_folder_members/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2267,10 +2360,11 @@ routes.sharingListFolderMembersContinue = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFolders
  * @arg {SharingListFoldersArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFoldersResult>, DropboxResponseError.<void>>}
  */
-routes.sharingListFolders = function (arg) {
-  return this.request('sharing/list_folders', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFolders = function (arg, options) {
+  return this.request('sharing/list_folders', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2281,10 +2375,11 @@ routes.sharingListFolders = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListFoldersContinue
  * @arg {SharingListFoldersContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFoldersResult>, DropboxResponseError.<SharingListFoldersContinueError>>}
  */
-routes.sharingListFoldersContinue = function (arg) {
-  return this.request('sharing/list_folders/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListFoldersContinue = function (arg, options) {
+  return this.request('sharing/list_folders/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2293,10 +2388,11 @@ routes.sharingListFoldersContinue = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListMountableFolders
  * @arg {SharingListFoldersArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFoldersResult>, DropboxResponseError.<void>>}
  */
-routes.sharingListMountableFolders = function (arg) {
-  return this.request('sharing/list_mountable_folders', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListMountableFolders = function (arg, options) {
+  return this.request('sharing/list_mountable_folders', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2307,10 +2403,11 @@ routes.sharingListMountableFolders = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListMountableFoldersContinue
  * @arg {SharingListFoldersContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFoldersResult>, DropboxResponseError.<SharingListFoldersContinueError>>}
  */
-routes.sharingListMountableFoldersContinue = function (arg) {
-  return this.request('sharing/list_mountable_folders/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListMountableFoldersContinue = function (arg, options) {
+  return this.request('sharing/list_mountable_folders/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2319,10 +2416,11 @@ routes.sharingListMountableFoldersContinue = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListReceivedFiles
  * @arg {SharingListFilesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFilesResult>, DropboxResponseError.<SharingSharingUserError>>}
  */
-routes.sharingListReceivedFiles = function (arg) {
-  return this.request('sharing/list_received_files', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListReceivedFiles = function (arg, options) {
+  return this.request('sharing/list_received_files', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2331,10 +2429,11 @@ routes.sharingListReceivedFiles = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListReceivedFilesContinue
  * @arg {SharingListFilesContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListFilesResult>, DropboxResponseError.<SharingListFilesContinueError>>}
  */
-routes.sharingListReceivedFilesContinue = function (arg) {
-  return this.request('sharing/list_received_files/continue', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListReceivedFilesContinue = function (arg, options) {
+  return this.request('sharing/list_received_files/continue', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2350,10 +2449,11 @@ routes.sharingListReceivedFilesContinue = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#sharingListSharedLinks
  * @arg {SharingListSharedLinksArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingListSharedLinksResult>, DropboxResponseError.<SharingListSharedLinksError>>}
  */
-routes.sharingListSharedLinks = function (arg) {
-  return this.request('sharing/list_shared_links', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.sharingListSharedLinks = function (arg, options) {
+  return this.request('sharing/list_shared_links', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -2367,10 +2467,11 @@ routes.sharingListSharedLinks = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingModifySharedLinkSettings
  * @arg {SharingModifySharedLinkSettingsArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<(SharingFileLinkMetadata|SharingFolderLinkMetadata|SharingSharedLinkMetadata)>, DropboxResponseError.<SharingModifySharedLinkSettingsError>>}
  */
-routes.sharingModifySharedLinkSettings = function (arg) {
-  return this.request('sharing/modify_shared_link_settings', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingModifySharedLinkSettings = function (arg, options) {
+  return this.request('sharing/modify_shared_link_settings', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2381,10 +2482,11 @@ routes.sharingModifySharedLinkSettings = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingMountFolder
  * @arg {SharingMountFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFolderMetadata>, DropboxResponseError.<SharingMountFolderError>>}
  */
-routes.sharingMountFolder = function (arg) {
-  return this.request('sharing/mount_folder', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingMountFolder = function (arg, options) {
+  return this.request('sharing/mount_folder', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2395,10 +2497,11 @@ routes.sharingMountFolder = function (arg) {
  *   scope: private:sharing.write
  * @function Dropbox#sharingRelinquishAccess
  * @arg {SharingRelinquishAccessArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingRelinquishAccessResult>, DropboxResponseError.<SharingRelinquishAccessError>>}
  */
-routes.sharingRelinquishAccess = function (arg) {
-  return this.request('sharing/relinquish_access', arg, 'user', 'api', 'rpc', 'private:sharing.write');
+routes.sharingRelinquishAccess = function (arg, options) {
+  return this.request('sharing/relinquish_access', arg, 'user', 'api', 'rpc', 'private:sharing.write', options);
 };
 
 /**
@@ -2407,10 +2510,11 @@ routes.sharingRelinquishAccess = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingRelinquishFileMembership
  * @arg {SharingRelinquishFileMembershipArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingRelinquishFileMembershipError>>}
  */
-routes.sharingRelinquishFileMembership = function (arg) {
-  return this.request('sharing/relinquish_file_membership', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRelinquishFileMembership = function (arg, options) {
+  return this.request('sharing/relinquish_file_membership', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2422,10 +2526,11 @@ routes.sharingRelinquishFileMembership = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingRelinquishFolderMembership
  * @arg {SharingRelinquishFolderMembershipArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchEmptyResult>, DropboxResponseError.<SharingRelinquishFolderMembershipError>>}
  */
-routes.sharingRelinquishFolderMembership = function (arg) {
-  return this.request('sharing/relinquish_folder_membership', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRelinquishFolderMembership = function (arg, options) {
+  return this.request('sharing/relinquish_folder_membership', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2435,10 +2540,11 @@ routes.sharingRelinquishFolderMembership = function (arg) {
  * @function Dropbox#sharingRemoveFileMember
  * @deprecated
  * @arg {SharingRemoveFileMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingFileMemberActionIndividualResult>, DropboxResponseError.<SharingRemoveFileMemberError>>}
  */
-routes.sharingRemoveFileMember = function (arg) {
-  return this.request('sharing/remove_file_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRemoveFileMember = function (arg, options) {
+  return this.request('sharing/remove_file_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2447,10 +2553,11 @@ routes.sharingRemoveFileMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingRemoveFileMember2
  * @arg {SharingRemoveFileMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingFileMemberRemoveActionResult>, DropboxResponseError.<SharingRemoveFileMemberError>>}
  */
-routes.sharingRemoveFileMember2 = function (arg) {
-  return this.request('sharing/remove_file_member_2', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRemoveFileMember2 = function (arg, options) {
+  return this.request('sharing/remove_file_member_2', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2460,10 +2567,11 @@ routes.sharingRemoveFileMember2 = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingRemoveFolderMember
  * @arg {SharingRemoveFolderMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<SharingRemoveFolderMemberError>>}
  */
-routes.sharingRemoveFolderMember = function (arg) {
-  return this.request('sharing/remove_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRemoveFolderMember = function (arg, options) {
+  return this.request('sharing/remove_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2476,10 +2584,11 @@ routes.sharingRemoveFolderMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingRevokeSharedLink
  * @arg {SharingRevokeSharedLinkArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingRevokeSharedLinkError>>}
  */
-routes.sharingRevokeSharedLink = function (arg) {
-  return this.request('sharing/revoke_shared_link', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingRevokeSharedLink = function (arg, options) {
+  return this.request('sharing/revoke_shared_link', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2491,10 +2600,11 @@ routes.sharingRevokeSharedLink = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingSetAccessInheritance
  * @arg {SharingSetAccessInheritanceArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingShareFolderLaunch>, DropboxResponseError.<SharingSetAccessInheritanceError>>}
  */
-routes.sharingSetAccessInheritance = function (arg) {
-  return this.request('sharing/set_access_inheritance', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingSetAccessInheritance = function (arg, options) {
+  return this.request('sharing/set_access_inheritance', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2508,10 +2618,11 @@ routes.sharingSetAccessInheritance = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingShareFolder
  * @arg {SharingShareFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingShareFolderLaunch>, DropboxResponseError.<SharingShareFolderError>>}
  */
-routes.sharingShareFolder = function (arg) {
-  return this.request('sharing/share_folder', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingShareFolder = function (arg, options) {
+  return this.request('sharing/share_folder', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2522,10 +2633,11 @@ routes.sharingShareFolder = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingTransferFolder
  * @arg {SharingTransferFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingTransferFolderError>>}
  */
-routes.sharingTransferFolder = function (arg) {
-  return this.request('sharing/transfer_folder', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingTransferFolder = function (arg, options) {
+  return this.request('sharing/transfer_folder', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2535,10 +2647,11 @@ routes.sharingTransferFolder = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUnmountFolder
  * @arg {SharingUnmountFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingUnmountFolderError>>}
  */
-routes.sharingUnmountFolder = function (arg) {
-  return this.request('sharing/unmount_folder', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUnmountFolder = function (arg, options) {
+  return this.request('sharing/unmount_folder', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2547,10 +2660,11 @@ routes.sharingUnmountFolder = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUnshareFile
  * @arg {SharingUnshareFileArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<SharingUnshareFileError>>}
  */
-routes.sharingUnshareFile = function (arg) {
-  return this.request('sharing/unshare_file', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUnshareFile = function (arg, options) {
+  return this.request('sharing/unshare_file', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2562,10 +2676,11 @@ routes.sharingUnshareFile = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUnshareFolder
  * @arg {SharingUnshareFolderArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchEmptyResult>, DropboxResponseError.<SharingUnshareFolderError>>}
  */
-routes.sharingUnshareFolder = function (arg) {
-  return this.request('sharing/unshare_folder', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUnshareFolder = function (arg, options) {
+  return this.request('sharing/unshare_folder', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2574,10 +2689,11 @@ routes.sharingUnshareFolder = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUpdateFileMember
  * @arg {SharingUpdateFileMemberArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingMemberAccessLevelResult>, DropboxResponseError.<SharingFileMemberActionError>>}
  */
-routes.sharingUpdateFileMember = function (arg) {
-  return this.request('sharing/update_file_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUpdateFileMember = function (arg, options) {
+  return this.request('sharing/update_file_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2586,10 +2702,11 @@ routes.sharingUpdateFileMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUpdateFilePolicy
  * @arg {SharingUpdateFilePolicyArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFileMetadata>, DropboxResponseError.<SharingUpdateFilePolicyError>>}
  */
-routes.sharingUpdateFilePolicy = function (arg) {
-  return this.request('sharing/update_file_policy', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUpdateFilePolicy = function (arg, options) {
+  return this.request('sharing/update_file_policy', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2599,10 +2716,11 @@ routes.sharingUpdateFilePolicy = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUpdateFolderMember
  * @arg {SharingUpdateFolderMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingMemberAccessLevelResult>, DropboxResponseError.<SharingUpdateFolderMemberError>>}
  */
-routes.sharingUpdateFolderMember = function (arg) {
-  return this.request('sharing/update_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUpdateFolderMember = function (arg, options) {
+  return this.request('sharing/update_folder_member', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2612,10 +2730,11 @@ routes.sharingUpdateFolderMember = function (arg) {
  *   scope: sharing.write
  * @function Dropbox#sharingUpdateFolderPolicy
  * @arg {SharingUpdateFolderPolicyArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<SharingSharedFolderMetadata>, DropboxResponseError.<SharingUpdateFolderPolicyError>>}
  */
-routes.sharingUpdateFolderPolicy = function (arg) {
-  return this.request('sharing/update_folder_policy', arg, 'user', 'api', 'rpc', 'sharing.write');
+routes.sharingUpdateFolderPolicy = function (arg, options) {
+  return this.request('sharing/update_folder_policy', arg, 'user', 'api', 'rpc', 'sharing.write', options);
 };
 
 /**
@@ -2624,10 +2743,11 @@ routes.sharingUpdateFolderPolicy = function (arg) {
  *   scope: sessions.list
  * @function Dropbox#teamDevicesListMemberDevices
  * @arg {TeamListMemberDevicesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListMemberDevicesResult>, DropboxResponseError.<TeamListMemberDevicesError>>}
  */
-routes.teamDevicesListMemberDevices = function (arg) {
-  return this.request('team/devices/list_member_devices', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamDevicesListMemberDevices = function (arg, options) {
+  return this.request('team/devices/list_member_devices', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -2636,10 +2756,11 @@ routes.teamDevicesListMemberDevices = function (arg) {
  *   scope: sessions.list
  * @function Dropbox#teamDevicesListMembersDevices
  * @arg {TeamListMembersDevicesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListMembersDevicesResult>, DropboxResponseError.<TeamListMembersDevicesError>>}
  */
-routes.teamDevicesListMembersDevices = function (arg) {
-  return this.request('team/devices/list_members_devices', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamDevicesListMembersDevices = function (arg, options) {
+  return this.request('team/devices/list_members_devices', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -2649,10 +2770,11 @@ routes.teamDevicesListMembersDevices = function (arg) {
  * @function Dropbox#teamDevicesListTeamDevices
  * @deprecated
  * @arg {TeamListTeamDevicesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListTeamDevicesResult>, DropboxResponseError.<TeamListTeamDevicesError>>}
  */
-routes.teamDevicesListTeamDevices = function (arg) {
-  return this.request('team/devices/list_team_devices', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamDevicesListTeamDevices = function (arg, options) {
+  return this.request('team/devices/list_team_devices', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -2661,10 +2783,11 @@ routes.teamDevicesListTeamDevices = function (arg) {
  *   scope: sessions.modify
  * @function Dropbox#teamDevicesRevokeDeviceSession
  * @arg {TeamRevokeDeviceSessionArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamRevokeDeviceSessionError>>}
  */
-routes.teamDevicesRevokeDeviceSession = function (arg) {
-  return this.request('team/devices/revoke_device_session', arg, 'team', 'api', 'rpc', 'sessions.modify');
+routes.teamDevicesRevokeDeviceSession = function (arg, options) {
+  return this.request('team/devices/revoke_device_session', arg, 'team', 'api', 'rpc', 'sessions.modify', options);
 };
 
 /**
@@ -2673,10 +2796,11 @@ routes.teamDevicesRevokeDeviceSession = function (arg) {
  *   scope: sessions.modify
  * @function Dropbox#teamDevicesRevokeDeviceSessionBatch
  * @arg {TeamRevokeDeviceSessionBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamRevokeDeviceSessionBatchResult>, DropboxResponseError.<TeamRevokeDeviceSessionBatchError>>}
  */
-routes.teamDevicesRevokeDeviceSessionBatch = function (arg) {
-  return this.request('team/devices/revoke_device_session_batch', arg, 'team', 'api', 'rpc', 'sessions.modify');
+routes.teamDevicesRevokeDeviceSessionBatch = function (arg, options) {
+  return this.request('team/devices/revoke_device_session_batch', arg, 'team', 'api', 'rpc', 'sessions.modify', options);
 };
 
 /**
@@ -2687,10 +2811,11 @@ routes.teamDevicesRevokeDeviceSessionBatch = function (arg) {
  *   scope: team_info.read
  * @function Dropbox#teamFeaturesGetValues
  * @arg {TeamFeaturesGetValuesBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamFeaturesGetValuesBatchResult>, DropboxResponseError.<TeamFeaturesGetValuesBatchError>>}
  */
-routes.teamFeaturesGetValues = function (arg) {
-  return this.request('team/features/get_values', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamFeaturesGetValues = function (arg, options) {
+  return this.request('team/features/get_values', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -2698,10 +2823,11 @@ routes.teamFeaturesGetValues = function (arg) {
  * Route attributes:
  *   scope: team_info.read
  * @function Dropbox#teamGetInfo
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamGetInfoResult>, DropboxResponseError.<void>>}
  */
-routes.teamGetInfo = function () {
-  return this.request('team/get_info', null, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamGetInfo = function (options) {
+  return this.request('team/get_info', null, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -2711,10 +2837,11 @@ routes.teamGetInfo = function () {
  *   scope: groups.write
  * @function Dropbox#teamGroupsCreate
  * @arg {TeamGroupCreateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupFullInfo>, DropboxResponseError.<TeamGroupCreateError>>}
  */
-routes.teamGroupsCreate = function (arg) {
-  return this.request('team/groups/create', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsCreate = function (arg, options) {
+  return this.request('team/groups/create', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2726,10 +2853,11 @@ routes.teamGroupsCreate = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsDelete
  * @arg {TeamGroupSelector} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchEmptyResult>, DropboxResponseError.<TeamGroupDeleteError>>}
  */
-routes.teamGroupsDelete = function (arg) {
-  return this.request('team/groups/delete', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsDelete = function (arg, options) {
+  return this.request('team/groups/delete', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2740,10 +2868,11 @@ routes.teamGroupsDelete = function (arg) {
  *   scope: groups.read
  * @function Dropbox#teamGroupsGetInfo
  * @arg {TeamGroupsSelector} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamGroupsGetInfoError>>}
  */
-routes.teamGroupsGetInfo = function (arg) {
-  return this.request('team/groups/get_info', arg, 'team', 'api', 'rpc', 'groups.read');
+routes.teamGroupsGetInfo = function (arg, options) {
+  return this.request('team/groups/get_info', arg, 'team', 'api', 'rpc', 'groups.read', options);
 };
 
 /**
@@ -2755,10 +2884,11 @@ routes.teamGroupsGetInfo = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsJobStatusGet
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncPollEmptyResult>, DropboxResponseError.<TeamGroupsPollError>>}
  */
-routes.teamGroupsJobStatusGet = function (arg) {
-  return this.request('team/groups/job_status/get', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsJobStatusGet = function (arg, options) {
+  return this.request('team/groups/job_status/get', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2767,10 +2897,11 @@ routes.teamGroupsJobStatusGet = function (arg) {
  *   scope: groups.read
  * @function Dropbox#teamGroupsList
  * @arg {TeamGroupsListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupsListResult>, DropboxResponseError.<void>>}
  */
-routes.teamGroupsList = function (arg) {
-  return this.request('team/groups/list', arg, 'team', 'api', 'rpc', 'groups.read');
+routes.teamGroupsList = function (arg, options) {
+  return this.request('team/groups/list', arg, 'team', 'api', 'rpc', 'groups.read', options);
 };
 
 /**
@@ -2780,10 +2911,11 @@ routes.teamGroupsList = function (arg) {
  *   scope: groups.read
  * @function Dropbox#teamGroupsListContinue
  * @arg {TeamGroupsListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupsListResult>, DropboxResponseError.<TeamGroupsListContinueError>>}
  */
-routes.teamGroupsListContinue = function (arg) {
-  return this.request('team/groups/list/continue', arg, 'team', 'api', 'rpc', 'groups.read');
+routes.teamGroupsListContinue = function (arg, options) {
+  return this.request('team/groups/list/continue', arg, 'team', 'api', 'rpc', 'groups.read', options);
 };
 
 /**
@@ -2795,10 +2927,11 @@ routes.teamGroupsListContinue = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsMembersAdd
  * @arg {TeamGroupMembersAddArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupMembersChangeResult>, DropboxResponseError.<TeamGroupMembersAddError>>}
  */
-routes.teamGroupsMembersAdd = function (arg) {
-  return this.request('team/groups/members/add', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsMembersAdd = function (arg, options) {
+  return this.request('team/groups/members/add', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2807,10 +2940,11 @@ routes.teamGroupsMembersAdd = function (arg) {
  *   scope: groups.read
  * @function Dropbox#teamGroupsMembersList
  * @arg {TeamGroupsMembersListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupsMembersListResult>, DropboxResponseError.<TeamGroupSelectorError>>}
  */
-routes.teamGroupsMembersList = function (arg) {
-  return this.request('team/groups/members/list', arg, 'team', 'api', 'rpc', 'groups.read');
+routes.teamGroupsMembersList = function (arg, options) {
+  return this.request('team/groups/members/list', arg, 'team', 'api', 'rpc', 'groups.read', options);
 };
 
 /**
@@ -2820,10 +2954,11 @@ routes.teamGroupsMembersList = function (arg) {
  *   scope: groups.read
  * @function Dropbox#teamGroupsMembersListContinue
  * @arg {TeamGroupsMembersListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupsMembersListResult>, DropboxResponseError.<TeamGroupsMembersListContinueError>>}
  */
-routes.teamGroupsMembersListContinue = function (arg) {
-  return this.request('team/groups/members/list/continue', arg, 'team', 'api', 'rpc', 'groups.read');
+routes.teamGroupsMembersListContinue = function (arg, options) {
+  return this.request('team/groups/members/list/continue', arg, 'team', 'api', 'rpc', 'groups.read', options);
 };
 
 /**
@@ -2836,10 +2971,11 @@ routes.teamGroupsMembersListContinue = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsMembersRemove
  * @arg {TeamGroupMembersRemoveArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupMembersChangeResult>, DropboxResponseError.<TeamGroupMembersRemoveError>>}
  */
-routes.teamGroupsMembersRemove = function (arg) {
-  return this.request('team/groups/members/remove', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsMembersRemove = function (arg, options) {
+  return this.request('team/groups/members/remove', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2848,10 +2984,11 @@ routes.teamGroupsMembersRemove = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsMembersSetAccessType
  * @arg {TeamGroupMembersSetAccessTypeArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamGroupMemberSetAccessTypeError>>}
  */
-routes.teamGroupsMembersSetAccessType = function (arg) {
-  return this.request('team/groups/members/set_access_type', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsMembersSetAccessType = function (arg, options) {
+  return this.request('team/groups/members/set_access_type', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2861,10 +2998,11 @@ routes.teamGroupsMembersSetAccessType = function (arg) {
  *   scope: groups.write
  * @function Dropbox#teamGroupsUpdate
  * @arg {TeamGroupUpdateArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGroupFullInfo>, DropboxResponseError.<TeamGroupUpdateError>>}
  */
-routes.teamGroupsUpdate = function (arg) {
-  return this.request('team/groups/update', arg, 'team', 'api', 'rpc', 'groups.write');
+routes.teamGroupsUpdate = function (arg, options) {
+  return this.request('team/groups/update', arg, 'team', 'api', 'rpc', 'groups.write', options);
 };
 
 /**
@@ -2874,10 +3012,11 @@ routes.teamGroupsUpdate = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsCreatePolicy
  * @arg {TeamLegalHoldsPolicyCreateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsPolicyCreateError>>}
  */
-routes.teamLegalHoldsCreatePolicy = function (arg) {
-  return this.request('team/legal_holds/create_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsCreatePolicy = function (arg, options) {
+  return this.request('team/legal_holds/create_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2887,10 +3026,11 @@ routes.teamLegalHoldsCreatePolicy = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsGetPolicy
  * @arg {TeamLegalHoldsGetPolicyArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsGetPolicyError>>}
  */
-routes.teamLegalHoldsGetPolicy = function (arg) {
-  return this.request('team/legal_holds/get_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsGetPolicy = function (arg, options) {
+  return this.request('team/legal_holds/get_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2900,10 +3040,11 @@ routes.teamLegalHoldsGetPolicy = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListHeldRevisions
  * @arg {TeamLegalHoldsListHeldRevisionsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListHeldRevisionResult>, DropboxResponseError.<TeamLegalHoldsListHeldRevisionsError>>}
  */
-routes.teamLegalHoldsListHeldRevisions = function (arg) {
-  return this.request('team/legal_holds/list_held_revisions', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsListHeldRevisions = function (arg, options) {
+  return this.request('team/legal_holds/list_held_revisions', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2914,10 +3055,11 @@ routes.teamLegalHoldsListHeldRevisions = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListHeldRevisionsContinue
  * @arg {TeamLegalHoldsListHeldRevisionsContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListHeldRevisionResult>, DropboxResponseError.<TeamLegalHoldsListHeldRevisionsError>>}
  */
-routes.teamLegalHoldsListHeldRevisionsContinue = function (arg) {
-  return this.request('team/legal_holds/list_held_revisions_continue', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsListHeldRevisionsContinue = function (arg, options) {
+  return this.request('team/legal_holds/list_held_revisions_continue', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2927,10 +3069,11 @@ routes.teamLegalHoldsListHeldRevisionsContinue = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsListPolicies
  * @arg {TeamLegalHoldsListPoliciesArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamLegalHoldsListPoliciesResult>, DropboxResponseError.<TeamLegalHoldsListPoliciesError>>}
  */
-routes.teamLegalHoldsListPolicies = function (arg) {
-  return this.request('team/legal_holds/list_policies', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsListPolicies = function (arg, options) {
+  return this.request('team/legal_holds/list_policies', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2940,10 +3083,11 @@ routes.teamLegalHoldsListPolicies = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsReleasePolicy
  * @arg {TeamLegalHoldsPolicyReleaseArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamLegalHoldsPolicyReleaseError>>}
  */
-routes.teamLegalHoldsReleasePolicy = function (arg) {
-  return this.request('team/legal_holds/release_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsReleasePolicy = function (arg, options) {
+  return this.request('team/legal_holds/release_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2953,10 +3097,11 @@ routes.teamLegalHoldsReleasePolicy = function (arg) {
  *   scope: team_data.governance.write
  * @function Dropbox#teamLegalHoldsUpdatePolicy
  * @arg {TeamLegalHoldsPolicyUpdateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamLegalHoldsPolicyUpdateError>>}
  */
-routes.teamLegalHoldsUpdatePolicy = function (arg) {
-  return this.request('team/legal_holds/update_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write');
+routes.teamLegalHoldsUpdatePolicy = function (arg, options) {
+  return this.request('team/legal_holds/update_policy', arg, 'team', 'api', 'rpc', 'team_data.governance.write', options);
 };
 
 /**
@@ -2966,10 +3111,11 @@ routes.teamLegalHoldsUpdatePolicy = function (arg) {
  *   scope: sessions.list
  * @function Dropbox#teamLinkedAppsListMemberLinkedApps
  * @arg {TeamListMemberAppsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListMemberAppsResult>, DropboxResponseError.<TeamListMemberAppsError>>}
  */
-routes.teamLinkedAppsListMemberLinkedApps = function (arg) {
-  return this.request('team/linked_apps/list_member_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamLinkedAppsListMemberLinkedApps = function (arg, options) {
+  return this.request('team/linked_apps/list_member_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -2979,10 +3125,11 @@ routes.teamLinkedAppsListMemberLinkedApps = function (arg) {
  *   scope: sessions.list
  * @function Dropbox#teamLinkedAppsListMembersLinkedApps
  * @arg {TeamListMembersAppsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListMembersAppsResult>, DropboxResponseError.<TeamListMembersAppsError>>}
  */
-routes.teamLinkedAppsListMembersLinkedApps = function (arg) {
-  return this.request('team/linked_apps/list_members_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamLinkedAppsListMembersLinkedApps = function (arg, options) {
+  return this.request('team/linked_apps/list_members_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -2993,10 +3140,11 @@ routes.teamLinkedAppsListMembersLinkedApps = function (arg) {
  * @function Dropbox#teamLinkedAppsListTeamLinkedApps
  * @deprecated
  * @arg {TeamListTeamAppsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamListTeamAppsResult>, DropboxResponseError.<TeamListTeamAppsError>>}
  */
-routes.teamLinkedAppsListTeamLinkedApps = function (arg) {
-  return this.request('team/linked_apps/list_team_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list');
+routes.teamLinkedAppsListTeamLinkedApps = function (arg, options) {
+  return this.request('team/linked_apps/list_team_linked_apps', arg, 'team', 'api', 'rpc', 'sessions.list', options);
 };
 
 /**
@@ -3005,10 +3153,11 @@ routes.teamLinkedAppsListTeamLinkedApps = function (arg) {
  *   scope: sessions.modify
  * @function Dropbox#teamLinkedAppsRevokeLinkedApp
  * @arg {TeamRevokeLinkedApiAppArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamRevokeLinkedAppError>>}
  */
-routes.teamLinkedAppsRevokeLinkedApp = function (arg) {
-  return this.request('team/linked_apps/revoke_linked_app', arg, 'team', 'api', 'rpc', 'sessions.modify');
+routes.teamLinkedAppsRevokeLinkedApp = function (arg, options) {
+  return this.request('team/linked_apps/revoke_linked_app', arg, 'team', 'api', 'rpc', 'sessions.modify', options);
 };
 
 /**
@@ -3017,10 +3166,11 @@ routes.teamLinkedAppsRevokeLinkedApp = function (arg) {
  *   scope: sessions.modify
  * @function Dropbox#teamLinkedAppsRevokeLinkedAppBatch
  * @arg {TeamRevokeLinkedApiAppBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamRevokeLinkedAppBatchResult>, DropboxResponseError.<TeamRevokeLinkedAppBatchError>>}
  */
-routes.teamLinkedAppsRevokeLinkedAppBatch = function (arg) {
-  return this.request('team/linked_apps/revoke_linked_app_batch', arg, 'team', 'api', 'rpc', 'sessions.modify');
+routes.teamLinkedAppsRevokeLinkedAppBatch = function (arg, options) {
+  return this.request('team/linked_apps/revoke_linked_app_batch', arg, 'team', 'api', 'rpc', 'sessions.modify', options);
 };
 
 /**
@@ -3029,10 +3179,11 @@ routes.teamLinkedAppsRevokeLinkedAppBatch = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMemberSpaceLimitsExcludedUsersAdd
  * @arg {TeamExcludedUsersUpdateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamExcludedUsersUpdateResult>, DropboxResponseError.<TeamExcludedUsersUpdateError>>}
  */
-routes.teamMemberSpaceLimitsExcludedUsersAdd = function (arg) {
-  return this.request('team/member_space_limits/excluded_users/add', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMemberSpaceLimitsExcludedUsersAdd = function (arg, options) {
+  return this.request('team/member_space_limits/excluded_users/add', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3041,10 +3192,11 @@ routes.teamMemberSpaceLimitsExcludedUsersAdd = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMemberSpaceLimitsExcludedUsersList
  * @arg {TeamExcludedUsersListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamExcludedUsersListResult>, DropboxResponseError.<TeamExcludedUsersListError>>}
  */
-routes.teamMemberSpaceLimitsExcludedUsersList = function (arg) {
-  return this.request('team/member_space_limits/excluded_users/list', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMemberSpaceLimitsExcludedUsersList = function (arg, options) {
+  return this.request('team/member_space_limits/excluded_users/list', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3053,10 +3205,11 @@ routes.teamMemberSpaceLimitsExcludedUsersList = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMemberSpaceLimitsExcludedUsersListContinue
  * @arg {TeamExcludedUsersListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamExcludedUsersListResult>, DropboxResponseError.<TeamExcludedUsersListContinueError>>}
  */
-routes.teamMemberSpaceLimitsExcludedUsersListContinue = function (arg) {
-  return this.request('team/member_space_limits/excluded_users/list/continue', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMemberSpaceLimitsExcludedUsersListContinue = function (arg, options) {
+  return this.request('team/member_space_limits/excluded_users/list/continue', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3065,10 +3218,11 @@ routes.teamMemberSpaceLimitsExcludedUsersListContinue = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMemberSpaceLimitsExcludedUsersRemove
  * @arg {TeamExcludedUsersUpdateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamExcludedUsersUpdateResult>, DropboxResponseError.<TeamExcludedUsersUpdateError>>}
  */
-routes.teamMemberSpaceLimitsExcludedUsersRemove = function (arg) {
-  return this.request('team/member_space_limits/excluded_users/remove', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMemberSpaceLimitsExcludedUsersRemove = function (arg, options) {
+  return this.request('team/member_space_limits/excluded_users/remove', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3080,10 +3234,11 @@ routes.teamMemberSpaceLimitsExcludedUsersRemove = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMemberSpaceLimitsGetCustomQuota
  * @arg {TeamCustomQuotaUsersArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<TeamCustomQuotaResult>>, DropboxResponseError.<TeamCustomQuotaError>>}
  */
-routes.teamMemberSpaceLimitsGetCustomQuota = function (arg) {
-  return this.request('team/member_space_limits/get_custom_quota', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMemberSpaceLimitsGetCustomQuota = function (arg, options) {
+  return this.request('team/member_space_limits/get_custom_quota', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3095,10 +3250,11 @@ routes.teamMemberSpaceLimitsGetCustomQuota = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMemberSpaceLimitsRemoveCustomQuota
  * @arg {TeamCustomQuotaUsersArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<TeamRemoveCustomQuotaResult>>, DropboxResponseError.<TeamCustomQuotaError>>}
  */
-routes.teamMemberSpaceLimitsRemoveCustomQuota = function (arg) {
-  return this.request('team/member_space_limits/remove_custom_quota', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMemberSpaceLimitsRemoveCustomQuota = function (arg, options) {
+  return this.request('team/member_space_limits/remove_custom_quota', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3111,10 +3267,11 @@ routes.teamMemberSpaceLimitsRemoveCustomQuota = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMemberSpaceLimitsSetCustomQuota
  * @arg {TeamSetCustomQuotaArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<TeamCustomQuotaResult>>, DropboxResponseError.<TeamSetCustomQuotaError>>}
  */
-routes.teamMemberSpaceLimitsSetCustomQuota = function (arg) {
-  return this.request('team/member_space_limits/set_custom_quota', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMemberSpaceLimitsSetCustomQuota = function (arg, options) {
+  return this.request('team/member_space_limits/set_custom_quota', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3133,10 +3290,11 @@ routes.teamMemberSpaceLimitsSetCustomQuota = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersAdd
  * @arg {TeamMembersAddArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersAddLaunch>, DropboxResponseError.<void>>}
  */
-routes.teamMembersAdd = function (arg) {
-  return this.request('team/members/add', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAdd = function (arg, options) {
+  return this.request('team/members/add', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3152,10 +3310,11 @@ routes.teamMembersAdd = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersAddV2
  * @arg {TeamMembersAddV2Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersAddLaunchV2Result>, DropboxResponseError.<void>>}
  */
-routes.teamMembersAddV2 = function (arg) {
-  return this.request('team/members/add_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAddV2 = function (arg, options) {
+  return this.request('team/members/add_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3165,10 +3324,11 @@ routes.teamMembersAddV2 = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersAddJobStatusGet
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersAddJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamMembersAddJobStatusGet = function (arg) {
-  return this.request('team/members/add/job_status/get', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAddJobStatusGet = function (arg, options) {
+  return this.request('team/members/add/job_status/get', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3178,34 +3338,11 @@ routes.teamMembersAddJobStatusGet = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersAddJobStatusGetV2
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersAddJobStatusV2Result>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamMembersAddJobStatusGetV2 = function (arg) {
-  return this.request('team/members/add/job_status/get_v2', arg, 'team', 'api', 'rpc', 'members.write');
-};
-
-/**
- * Launch a bulk suspend job. The server enforces a maximum of 500 members.
- * Route attributes:
- *   scope: members.write
- * @function Dropbox#teamMembersBulkSuspend
- * @arg {TeamBulkSuspendArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<AsyncLaunchResultBase>, DropboxResponseError.<TeamBulkSuspendError>>}
- */
-routes.teamMembersBulkSuspend = function (arg) {
-  return this.request('team/members/bulk_suspend', arg, 'team', 'api', 'rpc', 'members.write');
-};
-
-/**
- * Poll a previously launched bulk suspend job.
- * Route attributes:
- *   scope: members.write
- * @function Dropbox#teamMembersBulkSuspendJobStatusCheck
- * @arg {AsyncPollArg} arg - The request parameters.
- * @returns {Promise.<DropboxResponse<TeamBulkSuspendJobStatus>, DropboxResponseError.<AsyncPollError>>}
- */
-routes.teamMembersBulkSuspendJobStatusCheck = function (arg) {
-  return this.request('team/members/bulk_suspend/job_status/check', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersAddJobStatusGetV2 = function (arg, options) {
+  return this.request('team/members/add/job_status/get_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3218,10 +3355,11 @@ routes.teamMembersBulkSuspendJobStatusCheck = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersDeleteFormerMemberFiles
  * @arg {TeamMembersFormerMemberArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamMembersDeleteFormerMemberFilesError>>}
  */
-routes.teamMembersDeleteFormerMemberFiles = function (arg) {
-  return this.request('team/members/delete_former_member_files', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersDeleteFormerMemberFiles = function (arg, options) {
+  return this.request('team/members/delete_former_member_files', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3230,10 +3368,11 @@ routes.teamMembersDeleteFormerMemberFiles = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersDeleteProfilePhoto
  * @arg {TeamMembersDeleteProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfo>, DropboxResponseError.<TeamMembersDeleteProfilePhotoError>>}
  */
-routes.teamMembersDeleteProfilePhoto = function (arg) {
-  return this.request('team/members/delete_profile_photo', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersDeleteProfilePhoto = function (arg, options) {
+  return this.request('team/members/delete_profile_photo', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3242,10 +3381,11 @@ routes.teamMembersDeleteProfilePhoto = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersDeleteProfilePhotoV2
  * @arg {TeamMembersDeleteProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersDeleteProfilePhotoError>>}
  */
-routes.teamMembersDeleteProfilePhotoV2 = function (arg) {
-  return this.request('team/members/delete_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersDeleteProfilePhotoV2 = function (arg, options) {
+  return this.request('team/members/delete_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3254,10 +3394,11 @@ routes.teamMembersDeleteProfilePhotoV2 = function (arg) {
  * Route attributes:
  *   scope: members.read
  * @function Dropbox#teamMembersGetAvailableTeamMemberRoles
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersGetAvailableTeamMemberRolesResult>, DropboxResponseError.<void>>}
  */
-routes.teamMembersGetAvailableTeamMemberRoles = function () {
-  return this.request('team/members/get_available_team_member_roles', null, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersGetAvailableTeamMemberRoles = function (options) {
+  return this.request('team/members/get_available_team_member_roles', null, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3268,10 +3409,11 @@ routes.teamMembersGetAvailableTeamMemberRoles = function () {
  *   scope: members.read
  * @function Dropbox#teamMembersGetInfo
  * @arg {TeamMembersGetInfoArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<TeamMembersGetInfoError>>}
  */
-routes.teamMembersGetInfo = function (arg) {
-  return this.request('team/members/get_info', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersGetInfo = function (arg, options) {
+  return this.request('team/members/get_info', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3282,10 +3424,11 @@ routes.teamMembersGetInfo = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMembersGetInfoV2
  * @arg {TeamMembersGetInfoV2Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersGetInfoV2Result>, DropboxResponseError.<TeamMembersGetInfoError>>}
  */
-routes.teamMembersGetInfoV2 = function (arg) {
-  return this.request('team/members/get_info_v2', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersGetInfoV2 = function (arg, options) {
+  return this.request('team/members/get_info_v2', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3294,10 +3437,11 @@ routes.teamMembersGetInfoV2 = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMembersList
  * @arg {TeamMembersListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersListResult>, DropboxResponseError.<TeamMembersListError>>}
  */
-routes.teamMembersList = function (arg) {
-  return this.request('team/members/list', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersList = function (arg, options) {
+  return this.request('team/members/list', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3306,10 +3450,11 @@ routes.teamMembersList = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMembersListV2
  * @arg {TeamMembersListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListError>>}
  */
-routes.teamMembersListV2 = function (arg) {
-  return this.request('team/members/list_v2', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersListV2 = function (arg, options) {
+  return this.request('team/members/list_v2', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3319,10 +3464,11 @@ routes.teamMembersListV2 = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMembersListContinue
  * @arg {TeamMembersListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersListResult>, DropboxResponseError.<TeamMembersListContinueError>>}
  */
-routes.teamMembersListContinue = function (arg) {
-  return this.request('team/members/list/continue', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersListContinue = function (arg, options) {
+  return this.request('team/members/list/continue', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3332,10 +3478,11 @@ routes.teamMembersListContinue = function (arg) {
  *   scope: members.read
  * @function Dropbox#teamMembersListContinueV2
  * @arg {TeamMembersListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersListV2Result>, DropboxResponseError.<TeamMembersListContinueError>>}
  */
-routes.teamMembersListContinueV2 = function (arg) {
-  return this.request('team/members/list/continue_v2', arg, 'team', 'api', 'rpc', 'members.read');
+routes.teamMembersListContinueV2 = function (arg, options) {
+  return this.request('team/members/list/continue_v2', arg, 'team', 'api', 'rpc', 'members.read', options);
 };
 
 /**
@@ -3347,10 +3494,11 @@ routes.teamMembersListContinueV2 = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersMoveFormerMemberFiles
  * @arg {TeamMembersDataTransferArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchEmptyResult>, DropboxResponseError.<TeamMembersTransferFormerMembersFilesError>>}
  */
-routes.teamMembersMoveFormerMemberFiles = function (arg) {
-  return this.request('team/members/move_former_member_files', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersMoveFormerMemberFiles = function (arg, options) {
+  return this.request('team/members/move_former_member_files', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3361,10 +3509,11 @@ routes.teamMembersMoveFormerMemberFiles = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersMoveFormerMemberFilesJobStatusCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncPollEmptyResult>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamMembersMoveFormerMemberFilesJobStatusCheck = function (arg) {
-  return this.request('team/members/move_former_member_files/job_status/check', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersMoveFormerMemberFilesJobStatusCheck = function (arg, options) {
+  return this.request('team/members/move_former_member_files/job_status/check', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3375,10 +3524,11 @@ routes.teamMembersMoveFormerMemberFilesJobStatusCheck = function (arg) {
  *   scope: members.delete
  * @function Dropbox#teamMembersRecover
  * @arg {TeamMembersRecoverArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamMembersRecoverError>>}
  */
-routes.teamMembersRecover = function (arg) {
-  return this.request('team/members/recover', arg, 'team', 'api', 'rpc', 'members.delete');
+routes.teamMembersRecover = function (arg, options) {
+  return this.request('team/members/recover', arg, 'team', 'api', 'rpc', 'members.delete', options);
 };
 
 /**
@@ -3399,10 +3549,11 @@ routes.teamMembersRecover = function (arg) {
  *   scope: members.delete
  * @function Dropbox#teamMembersRemove
  * @arg {TeamMembersRemoveArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncLaunchEmptyResult>, DropboxResponseError.<TeamMembersRemoveError>>}
  */
-routes.teamMembersRemove = function (arg) {
-  return this.request('team/members/remove', arg, 'team', 'api', 'rpc', 'members.delete');
+routes.teamMembersRemove = function (arg, options) {
+  return this.request('team/members/remove', arg, 'team', 'api', 'rpc', 'members.delete', options);
 };
 
 /**
@@ -3412,10 +3563,11 @@ routes.teamMembersRemove = function (arg) {
  *   scope: members.delete
  * @function Dropbox#teamMembersRemoveJobStatusGet
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<AsyncPollEmptyResult>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamMembersRemoveJobStatusGet = function (arg) {
-  return this.request('team/members/remove/job_status/get', arg, 'team', 'api', 'rpc', 'members.delete');
+routes.teamMembersRemoveJobStatusGet = function (arg, options) {
+  return this.request('team/members/remove/job_status/get', arg, 'team', 'api', 'rpc', 'members.delete', options);
 };
 
 /**
@@ -3426,10 +3578,11 @@ routes.teamMembersRemoveJobStatusGet = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSecondaryEmailsAdd
  * @arg {TeamAddSecondaryEmailsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamAddSecondaryEmailsResult>, DropboxResponseError.<TeamAddSecondaryEmailsError>>}
  */
-routes.teamMembersSecondaryEmailsAdd = function (arg) {
-  return this.request('team/members/secondary_emails/add', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSecondaryEmailsAdd = function (arg, options) {
+  return this.request('team/members/secondary_emails/add', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3440,10 +3593,11 @@ routes.teamMembersSecondaryEmailsAdd = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSecondaryEmailsDelete
  * @arg {TeamDeleteSecondaryEmailsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamDeleteSecondaryEmailsResult>, DropboxResponseError.<void>>}
  */
-routes.teamMembersSecondaryEmailsDelete = function (arg) {
-  return this.request('team/members/secondary_emails/delete', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSecondaryEmailsDelete = function (arg, options) {
+  return this.request('team/members/secondary_emails/delete', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3453,10 +3607,11 @@ routes.teamMembersSecondaryEmailsDelete = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSecondaryEmailsResendVerificationEmails
  * @arg {TeamResendVerificationEmailArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamResendVerificationEmailResult>, DropboxResponseError.<void>>}
  */
-routes.teamMembersSecondaryEmailsResendVerificationEmails = function (arg) {
-  return this.request('team/members/secondary_emails/resend_verification_emails', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSecondaryEmailsResendVerificationEmails = function (arg, options) {
+  return this.request('team/members/secondary_emails/resend_verification_emails', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3467,10 +3622,11 @@ routes.teamMembersSecondaryEmailsResendVerificationEmails = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSendWelcomeEmail
  * @arg {TeamUserSelectorArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamMembersSendWelcomeError>>}
  */
-routes.teamMembersSendWelcomeEmail = function (arg) {
-  return this.request('team/members/send_welcome_email', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSendWelcomeEmail = function (arg, options) {
+  return this.request('team/members/send_welcome_email', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3479,10 +3635,11 @@ routes.teamMembersSendWelcomeEmail = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetAdminPermissions
  * @arg {TeamMembersSetPermissionsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersSetPermissionsResult>, DropboxResponseError.<TeamMembersSetPermissionsError>>}
  */
-routes.teamMembersSetAdminPermissions = function (arg) {
-  return this.request('team/members/set_admin_permissions', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetAdminPermissions = function (arg, options) {
+  return this.request('team/members/set_admin_permissions', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3491,10 +3648,11 @@ routes.teamMembersSetAdminPermissions = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetAdminPermissionsV2
  * @arg {TeamMembersSetPermissions2Arg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamMembersSetPermissions2Result>, DropboxResponseError.<TeamMembersSetPermissions2Error>>}
  */
-routes.teamMembersSetAdminPermissionsV2 = function (arg) {
-  return this.request('team/members/set_admin_permissions_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetAdminPermissionsV2 = function (arg, options) {
+  return this.request('team/members/set_admin_permissions_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3503,10 +3661,11 @@ routes.teamMembersSetAdminPermissionsV2 = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetProfile
  * @arg {TeamMembersSetProfileArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfo>, DropboxResponseError.<TeamMembersSetProfileError>>}
  */
-routes.teamMembersSetProfile = function (arg) {
-  return this.request('team/members/set_profile', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetProfile = function (arg, options) {
+  return this.request('team/members/set_profile', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3515,10 +3674,11 @@ routes.teamMembersSetProfile = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetProfileV2
  * @arg {TeamMembersSetProfileArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfileError>>}
  */
-routes.teamMembersSetProfileV2 = function (arg) {
-  return this.request('team/members/set_profile_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetProfileV2 = function (arg, options) {
+  return this.request('team/members/set_profile_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3527,10 +3687,11 @@ routes.teamMembersSetProfileV2 = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetProfilePhoto
  * @arg {TeamMembersSetProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfo>, DropboxResponseError.<TeamMembersSetProfilePhotoError>>}
  */
-routes.teamMembersSetProfilePhoto = function (arg) {
-  return this.request('team/members/set_profile_photo', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetProfilePhoto = function (arg, options) {
+  return this.request('team/members/set_profile_photo', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3539,10 +3700,11 @@ routes.teamMembersSetProfilePhoto = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSetProfilePhotoV2
  * @arg {TeamMembersSetProfilePhotoArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamMemberInfoV2Result>, DropboxResponseError.<TeamMembersSetProfilePhotoError>>}
  */
-routes.teamMembersSetProfilePhotoV2 = function (arg) {
-  return this.request('team/members/set_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSetProfilePhotoV2 = function (arg, options) {
+  return this.request('team/members/set_profile_photo_v2', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3553,10 +3715,11 @@ routes.teamMembersSetProfilePhotoV2 = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersSuspend
  * @arg {TeamMembersDeactivateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamMembersSuspendError>>}
  */
-routes.teamMembersSuspend = function (arg) {
-  return this.request('team/members/suspend', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersSuspend = function (arg, options) {
+  return this.request('team/members/suspend', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3567,10 +3730,11 @@ routes.teamMembersSuspend = function (arg) {
  *   scope: members.write
  * @function Dropbox#teamMembersUnsuspend
  * @arg {TeamMembersUnsuspendArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamMembersUnsuspendError>>}
  */
-routes.teamMembersUnsuspend = function (arg) {
-  return this.request('team/members/unsuspend', arg, 'team', 'api', 'rpc', 'members.write');
+routes.teamMembersUnsuspend = function (arg, options) {
+  return this.request('team/members/unsuspend', arg, 'team', 'api', 'rpc', 'members.write', options);
 };
 
 /**
@@ -3583,10 +3747,11 @@ routes.teamMembersUnsuspend = function (arg) {
  *   scope: team_data.member
  * @function Dropbox#teamNamespacesList
  * @arg {TeamTeamNamespacesListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamNamespacesListResult>, DropboxResponseError.<TeamTeamNamespacesListError>>}
  */
-routes.teamNamespacesList = function (arg) {
-  return this.request('team/namespaces/list', arg, 'team', 'api', 'rpc', 'team_data.member');
+routes.teamNamespacesList = function (arg, options) {
+  return this.request('team/namespaces/list', arg, 'team', 'api', 'rpc', 'team_data.member', options);
 };
 
 /**
@@ -3596,10 +3761,11 @@ routes.teamNamespacesList = function (arg) {
  *   scope: team_data.member
  * @function Dropbox#teamNamespacesListContinue
  * @arg {TeamTeamNamespacesListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamNamespacesListResult>, DropboxResponseError.<TeamTeamNamespacesListContinueError>>}
  */
-routes.teamNamespacesListContinue = function (arg) {
-  return this.request('team/namespaces/list/continue', arg, 'team', 'api', 'rpc', 'team_data.member');
+routes.teamNamespacesListContinue = function (arg, options) {
+  return this.request('team/namespaces/list/continue', arg, 'team', 'api', 'rpc', 'team_data.member', options);
 };
 
 /**
@@ -3609,10 +3775,11 @@ routes.teamNamespacesListContinue = function (arg) {
  * @function Dropbox#teamPropertiesTemplateAdd
  * @deprecated
  * @arg {FilePropertiesAddTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesAddTemplateResult>, DropboxResponseError.<FilePropertiesModifyTemplateError>>}
  */
-routes.teamPropertiesTemplateAdd = function (arg) {
-  return this.request('team/properties/template/add', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.teamPropertiesTemplateAdd = function (arg, options) {
+  return this.request('team/properties/template/add', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -3623,10 +3790,11 @@ routes.teamPropertiesTemplateAdd = function (arg) {
  * @function Dropbox#teamPropertiesTemplateGet
  * @deprecated
  * @arg {FilePropertiesGetTemplateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<FilePropertiesGetTemplateResult>, DropboxResponseError.<FilePropertiesTemplateError>>}
  */
-routes.teamPropertiesTemplateGet = function (arg) {
-  return this.request('team/properties/template/get', arg, 'team', 'api', 'rpc', 'files.team_metadata.write');
+routes.teamPropertiesTemplateGet = function (arg, options) {
+  return this.request('team/properties/template/get', arg, 'team', 'api', 'rpc', 'files.team_metadata.write', options);
 };
 
 /**
@@ -3637,10 +3805,11 @@ routes.teamPropertiesTemplateGet = function (arg) {
  * @function Dropbox#teamReportsGetActivity
  * @deprecated
  * @arg {TeamDateRange} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGetActivityReport>, DropboxResponseError.<TeamDateRangeError>>}
  */
-routes.teamReportsGetActivity = function (arg) {
-  return this.request('team/reports/get_activity', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamReportsGetActivity = function (arg, options) {
+  return this.request('team/reports/get_activity', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3651,10 +3820,11 @@ routes.teamReportsGetActivity = function (arg) {
  * @function Dropbox#teamReportsGetDevices
  * @deprecated
  * @arg {TeamDateRange} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGetDevicesReport>, DropboxResponseError.<TeamDateRangeError>>}
  */
-routes.teamReportsGetDevices = function (arg) {
-  return this.request('team/reports/get_devices', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamReportsGetDevices = function (arg, options) {
+  return this.request('team/reports/get_devices', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3665,10 +3835,11 @@ routes.teamReportsGetDevices = function (arg) {
  * @function Dropbox#teamReportsGetMembership
  * @deprecated
  * @arg {TeamDateRange} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGetMembershipReport>, DropboxResponseError.<TeamDateRangeError>>}
  */
-routes.teamReportsGetMembership = function (arg) {
-  return this.request('team/reports/get_membership', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamReportsGetMembership = function (arg, options) {
+  return this.request('team/reports/get_membership', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3679,10 +3850,11 @@ routes.teamReportsGetMembership = function (arg) {
  * @function Dropbox#teamReportsGetStorage
  * @deprecated
  * @arg {TeamDateRange} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamGetStorageReport>, DropboxResponseError.<TeamDateRangeError>>}
  */
-routes.teamReportsGetStorage = function (arg) {
-  return this.request('team/reports/get_storage', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamReportsGetStorage = function (arg, options) {
+  return this.request('team/reports/get_storage', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3695,10 +3867,11 @@ routes.teamReportsGetStorage = function (arg) {
  *   scope: team_info.write
  * @function Dropbox#teamSharingAllowlistAdd
  * @arg {TeamSharingAllowlistAddArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamSharingAllowlistAddResponse>, DropboxResponseError.<TeamSharingAllowlistAddError>>}
  */
-routes.teamSharingAllowlistAdd = function (arg) {
-  return this.request('team/sharing_allowlist/add', arg, 'team', 'api', 'rpc', 'team_info.write');
+routes.teamSharingAllowlistAdd = function (arg, options) {
+  return this.request('team/sharing_allowlist/add', arg, 'team', 'api', 'rpc', 'team_info.write', options);
 };
 
 /**
@@ -3710,10 +3883,11 @@ routes.teamSharingAllowlistAdd = function (arg) {
  *   scope: team_info.read
  * @function Dropbox#teamSharingAllowlistList
  * @arg {TeamSharingAllowlistListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamSharingAllowlistListResponse>, DropboxResponseError.<TeamSharingAllowlistListError>>}
  */
-routes.teamSharingAllowlistList = function (arg) {
-  return this.request('team/sharing_allowlist/list', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamSharingAllowlistList = function (arg, options) {
+  return this.request('team/sharing_allowlist/list', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3723,10 +3897,11 @@ routes.teamSharingAllowlistList = function (arg) {
  *   scope: team_info.read
  * @function Dropbox#teamSharingAllowlistListContinue
  * @arg {TeamSharingAllowlistListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamSharingAllowlistListResponse>, DropboxResponseError.<TeamSharingAllowlistListContinueError>>}
  */
-routes.teamSharingAllowlistListContinue = function (arg) {
-  return this.request('team/sharing_allowlist/list/continue', arg, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamSharingAllowlistListContinue = function (arg, options) {
+  return this.request('team/sharing_allowlist/list/continue', arg, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3739,10 +3914,11 @@ routes.teamSharingAllowlistListContinue = function (arg) {
  *   scope: team_info.write
  * @function Dropbox#teamSharingAllowlistRemove
  * @arg {TeamSharingAllowlistRemoveArgs} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamSharingAllowlistRemoveResponse>, DropboxResponseError.<TeamSharingAllowlistRemoveError>>}
  */
-routes.teamSharingAllowlistRemove = function (arg) {
-  return this.request('team/sharing_allowlist/remove', arg, 'team', 'api', 'rpc', 'team_info.write');
+routes.teamSharingAllowlistRemove = function (arg, options) {
+  return this.request('team/sharing_allowlist/remove', arg, 'team', 'api', 'rpc', 'team_info.write', options);
 };
 
 /**
@@ -3752,10 +3928,11 @@ routes.teamSharingAllowlistRemove = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderActivate
  * @arg {TeamTeamFolderIdArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderActivateError>>}
  */
-routes.teamTeamFolderActivate = function (arg) {
-  return this.request('team/team_folder/activate', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderActivate = function (arg, options) {
+  return this.request('team/team_folder/activate', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3768,10 +3945,11 @@ routes.teamTeamFolderActivate = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderArchive
  * @arg {TeamTeamFolderArchiveArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderArchiveLaunch>, DropboxResponseError.<TeamTeamFolderArchiveError>>}
  */
-routes.teamTeamFolderArchive = function (arg) {
-  return this.request('team/team_folder/archive', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderArchive = function (arg, options) {
+  return this.request('team/team_folder/archive', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3785,10 +3963,11 @@ routes.teamTeamFolderArchive = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderArchiveCheck
  * @arg {AsyncPollArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderArchiveJobStatus>, DropboxResponseError.<AsyncPollError>>}
  */
-routes.teamTeamFolderArchiveCheck = function (arg) {
-  return this.request('team/team_folder/archive/check', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderArchiveCheck = function (arg, options) {
+  return this.request('team/team_folder/archive/check', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3799,10 +3978,11 @@ routes.teamTeamFolderArchiveCheck = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderCreate
  * @arg {TeamTeamFolderCreateArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderCreateError>>}
  */
-routes.teamTeamFolderCreate = function (arg) {
-  return this.request('team/team_folder/create', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderCreate = function (arg, options) {
+  return this.request('team/team_folder/create', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3811,10 +3991,11 @@ routes.teamTeamFolderCreate = function (arg) {
  *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderGetInfo
  * @arg {TeamTeamFolderIdListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Array.<TeamTeamFolderGetInfoItem>>, DropboxResponseError.<void>>}
  */
-routes.teamTeamFolderGetInfo = function (arg) {
-  return this.request('team/team_folder/get_info', arg, 'team', 'api', 'rpc', 'team_data.content.read');
+routes.teamTeamFolderGetInfo = function (arg, options) {
+  return this.request('team/team_folder/get_info', arg, 'team', 'api', 'rpc', 'team_data.content.read', options);
 };
 
 /**
@@ -3823,10 +4004,11 @@ routes.teamTeamFolderGetInfo = function (arg) {
  *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderList
  * @arg {TeamTeamFolderListArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderListResult>, DropboxResponseError.<TeamTeamFolderListError>>}
  */
-routes.teamTeamFolderList = function (arg) {
-  return this.request('team/team_folder/list', arg, 'team', 'api', 'rpc', 'team_data.content.read');
+routes.teamTeamFolderList = function (arg, options) {
+  return this.request('team/team_folder/list', arg, 'team', 'api', 'rpc', 'team_data.content.read', options);
 };
 
 /**
@@ -3836,10 +4018,11 @@ routes.teamTeamFolderList = function (arg) {
  *   scope: team_data.content.read
  * @function Dropbox#teamTeamFolderListContinue
  * @arg {TeamTeamFolderListContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderListResult>, DropboxResponseError.<TeamTeamFolderListContinueError>>}
  */
-routes.teamTeamFolderListContinue = function (arg) {
-  return this.request('team/team_folder/list/continue', arg, 'team', 'api', 'rpc', 'team_data.content.read');
+routes.teamTeamFolderListContinue = function (arg, options) {
+  return this.request('team/team_folder/list/continue', arg, 'team', 'api', 'rpc', 'team_data.content.read', options);
 };
 
 /**
@@ -3849,10 +4032,11 @@ routes.teamTeamFolderListContinue = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderPermanentlyDelete
  * @arg {TeamTeamFolderIdArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<void>, DropboxResponseError.<TeamTeamFolderPermanentlyDeleteError>>}
  */
-routes.teamTeamFolderPermanentlyDelete = function (arg) {
-  return this.request('team/team_folder/permanently_delete', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderPermanentlyDelete = function (arg, options) {
+  return this.request('team/team_folder/permanently_delete', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3861,10 +4045,11 @@ routes.teamTeamFolderPermanentlyDelete = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderRename
  * @arg {TeamTeamFolderRenameArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderRenameError>>}
  */
-routes.teamTeamFolderRename = function (arg) {
-  return this.request('team/team_folder/rename', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderRename = function (arg, options) {
+  return this.request('team/team_folder/rename', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3874,10 +4059,11 @@ routes.teamTeamFolderRename = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderRestore
  * @arg {TeamTeamFolderIdArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderRestoreError>>}
  */
-routes.teamTeamFolderRestore = function (arg) {
-  return this.request('team/team_folder/restore', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderRestore = function (arg, options) {
+  return this.request('team/team_folder/restore', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3887,10 +4073,11 @@ routes.teamTeamFolderRestore = function (arg) {
  *   scope: team_data.content.write
  * @function Dropbox#teamTeamFolderUpdateSyncSettings
  * @arg {TeamTeamFolderUpdateSyncSettingsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTeamFolderMetadata>, DropboxResponseError.<TeamTeamFolderUpdateSyncSettingsError>>}
  */
-routes.teamTeamFolderUpdateSyncSettings = function (arg) {
-  return this.request('team/team_folder/update_sync_settings', arg, 'team', 'api', 'rpc', 'team_data.content.write');
+routes.teamTeamFolderUpdateSyncSettings = function (arg, options) {
+  return this.request('team/team_folder/update_sync_settings', arg, 'team', 'api', 'rpc', 'team_data.content.write', options);
 };
 
 /**
@@ -3899,10 +4086,11 @@ routes.teamTeamFolderUpdateSyncSettings = function (arg) {
  * Route attributes:
  *   scope: team_info.read
  * @function Dropbox#teamTokenGetAuthenticatedAdmin
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamTokenGetAuthenticatedAdminResult>, DropboxResponseError.<TeamTokenGetAuthenticatedAdminError>>}
  */
-routes.teamTokenGetAuthenticatedAdmin = function () {
-  return this.request('team/token/get_authenticated_admin', null, 'team', 'api', 'rpc', 'team_info.read');
+routes.teamTokenGetAuthenticatedAdmin = function (options) {
+  return this.request('team/token/get_authenticated_admin', null, 'team', 'api', 'rpc', 'team_info.read', options);
 };
 
 /**
@@ -3920,10 +4108,11 @@ routes.teamTokenGetAuthenticatedAdmin = function () {
  *   scope: events.read
  * @function Dropbox#teamLogGetEvents
  * @arg {TeamLogGetTeamEventsArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamLogGetTeamEventsResult>, DropboxResponseError.<TeamLogGetTeamEventsError>>}
  */
-routes.teamLogGetEvents = function (arg) {
-  return this.request('team_log/get_events', arg, 'team', 'api', 'rpc', 'events.read');
+routes.teamLogGetEvents = function (arg, options) {
+  return this.request('team_log/get_events', arg, 'team', 'api', 'rpc', 'events.read', options);
 };
 
 /**
@@ -3933,10 +4122,11 @@ routes.teamLogGetEvents = function (arg) {
  *   scope: events.read
  * @function Dropbox#teamLogGetEventsContinue
  * @arg {TeamLogGetTeamEventsContinueArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<TeamLogGetTeamEventsResult>, DropboxResponseError.<TeamLogGetTeamEventsContinueError>>}
  */
-routes.teamLogGetEventsContinue = function (arg) {
-  return this.request('team_log/get_events/continue', arg, 'team', 'api', 'rpc', 'events.read');
+routes.teamLogGetEventsContinue = function (arg, options) {
+  return this.request('team_log/get_events/continue', arg, 'team', 'api', 'rpc', 'events.read', options);
 };
 
 /**
@@ -3945,10 +4135,11 @@ routes.teamLogGetEventsContinue = function (arg) {
  *   scope: account_info.read
  * @function Dropbox#usersFeaturesGetValues
  * @arg {UsersUserFeaturesGetValuesBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<UsersUserFeaturesGetValuesBatchResult>, DropboxResponseError.<UsersUserFeaturesGetValuesBatchError>>}
  */
-routes.usersFeaturesGetValues = function (arg) {
-  return this.request('users/features/get_values', arg, 'user', 'api', 'rpc', 'account_info.read');
+routes.usersFeaturesGetValues = function (arg, options) {
+  return this.request('users/features/get_values', arg, 'user', 'api', 'rpc', 'account_info.read', options);
 };
 
 /**
@@ -3957,10 +4148,11 @@ routes.usersFeaturesGetValues = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#usersGetAccount
  * @arg {UsersGetAccountArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<UsersBasicAccount>, DropboxResponseError.<UsersGetAccountError>>}
  */
-routes.usersGetAccount = function (arg) {
-  return this.request('users/get_account', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.usersGetAccount = function (arg, options) {
+  return this.request('users/get_account', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -3970,10 +4162,11 @@ routes.usersGetAccount = function (arg) {
  *   scope: sharing.read
  * @function Dropbox#usersGetAccountBatch
  * @arg {UsersGetAccountBatchArg} arg - The request parameters.
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<Object>, DropboxResponseError.<UsersGetAccountBatchError>>}
  */
-routes.usersGetAccountBatch = function (arg) {
-  return this.request('users/get_account_batch', arg, 'user', 'api', 'rpc', 'sharing.read');
+routes.usersGetAccountBatch = function (arg, options) {
+  return this.request('users/get_account_batch', arg, 'user', 'api', 'rpc', 'sharing.read', options);
 };
 
 /**
@@ -3981,10 +4174,11 @@ routes.usersGetAccountBatch = function (arg) {
  * Route attributes:
  *   scope: account_info.read
  * @function Dropbox#usersGetCurrentAccount
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<UsersFullAccount>, DropboxResponseError.<void>>}
  */
-routes.usersGetCurrentAccount = function () {
-  return this.request('users/get_current_account', null, 'user', 'api', 'rpc', 'account_info.read');
+routes.usersGetCurrentAccount = function (options) {
+  return this.request('users/get_current_account', null, 'user', 'api', 'rpc', 'account_info.read', options);
 };
 
 /**
@@ -3992,10 +4186,11 @@ routes.usersGetCurrentAccount = function () {
  * Route attributes:
  *   scope: account_info.read
  * @function Dropbox#usersGetSpaceUsage
+ * @arg {Object} [options] - The request options.
  * @returns {Promise.<DropboxResponse<UsersSpaceUsage>, DropboxResponseError.<void>>}
  */
-routes.usersGetSpaceUsage = function () {
-  return this.request('users/get_space_usage', null, 'user', 'api', 'rpc', 'account_info.read');
+routes.usersGetSpaceUsage = function (options) {
+  return this.request('users/get_space_usage', null, 'user', 'api', 'rpc', 'account_info.read', options);
 };
 
 export { routes };

--- a/lib/types.js
+++ b/lib/types.js
@@ -3293,40 +3293,24 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
- * Reason a transcript job failed. Returned in the `failed` variant of
- * `GetTranscriptAsyncCheckResult`. This is a semantic error union: the HTTP
- * status of the poll request itself is unaffected (a poll that surfaces a
- * failed job is still a normal successful poll response). Callers should branch
- * on the variant.
  * @typedef {Object} RivieraContentApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error. An
- * unexpected, typically transient, server-side failure. The string is a
- * human-readable message; retrying with backoff may succeed.
- * @property {string} [user_error] - Available if .tag is user_error. The
- * request could not be processed as supplied (a problem with the caller's
- * input). The string is a human-readable message; retrying the same request
- * will not help.
+ * @property {string} [server_error] - Available if .tag is server_error.
+ * @property {string} [user_error] - Available if .tag is user_error.
  * @property {RivieraMediaDurationError} [media_duration_error] - Available if
  * .tag is media_duration_error.
  * @property {('server_error'|'user_error'|'media_duration_error'|'no_audio_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
+ * @typedef {Object} RivieraErrorCode
+ * @property {('unknown_error'|'bad_request'|'api_error'|'access_error'|'ratelimit_error'|'unavailable'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
  * @typedef {Object} RivieraFileIdOrUrl
- * @property {string} [file_id] - Available if .tag is file_id. A Dropbox-issued
- * file id (format: "id:<id>") for a file the authenticated user has access to.
- * @property {string} [url] - Available if .tag is url. Either a Dropbox shared
- * link (www.dropbox.com) or an external HTTP or HTTPS URL pointing to a
- * supported file. - Dropbox shared links are resolved internally using the
- * caller's authenticated identity and the link's visibility / download
- * settings. They therefore require an authenticated user context (anonymous
- * `url` requests against Dropbox links are rejected with an `access_error`).
- * Links protected by a password are rejected with
- * `shared_link_password_protected`; links with downloads disabled are rejected
- * with `link_download_disabled_error`. - External URLs are fetched through the
- * backend's egress proxy and must point at a supported file extension.
- * @property {string} [path] - Available if .tag is path. An absolute Dropbox
- * path, e.g. "/folder/example.pdf".
+ * @property {string} [file_id] - Available if .tag is file_id.
+ * @property {string} [url] - Available if .tag is url.
+ * @property {string} [path] - Available if .tag is path.
  * @property {('file_id'|'url'|'path'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3336,10 +3320,20 @@ only present when needed to discriminate between multiple possible subtypes.
  * the document to convert to markdown.
  * @typedef {Object} RivieraGetMarkdownArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the document
- * to convert. Callers must set exactly one of the `FileIdOrUrl` variants. The
- * referenced file must be a document in a supported format (see the route
- * description for the list); requests against unsupported formats return
- * `unsupported_format_error`.
+ * to convert. Callers must set exactly one of the oneof variants: - file_id: a
+ * Dropbox-issued file id (format: "id:<id>") for a file the authenticated user
+ * has access to. - path: an absolute Dropbox path, e.g. "/folder/report.docx".
+ * - url: either a Dropbox shared link (www.dropbox.com) or an external HTTPS
+ * URL pointing to a supported document file. - Dropbox shared links are
+ * resolved internally using the caller's authenticated identity and the link's
+ * visibility / download settings. They therefore require an authenticated user
+ * context (anonymous `url` requests against Dropbox links are rejected with an
+ * `ACCESS_ERROR`). Links protected by a password are rejected with
+ * `shared_link_password_protected`; links with downloads disabled are rejected
+ * with `link_download_disabled_error`. - External URLs are fetched over HTTPS
+ * through the backend's egress proxy and must point at a supported document
+ * file extension. The referenced file must be a document in a supported format;
+ * requests against unsupported formats return `unsupported_format_error`.
  * @property {boolean} enable_ocr - Enable OCR for PDF documents. Processing is
  * slower when enabled.
  * @property {boolean} embed_images - When true, embed images as base64 data
@@ -3351,9 +3345,15 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetMarkdownAsyncCheckResult
  * @property {RivieraGetMarkdownResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraMarkdownConversionApiV2Error} [failed] - Available if .tag
- * is failed.
+ * @property {RivieraGetMarkdownAsyncError} [failed] - Available if .tag is
+ * failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * @typedef {Object} RivieraGetMarkdownAsyncError
+ * @property {RivieraErrorCode} error_code
+ * @property {RivieraMarkdownConversionApiV2Error} [error_details]
  */
 
 /**
@@ -3367,12 +3367,23 @@ only present when needed to discriminate between multiple possible subtypes.
  * the file whose metadata should be extracted.
  * @typedef {Object} RivieraGetMetadataArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the file to
- * extract metadata from. Callers must set exactly one of the `FileIdOrUrl`
- * variants. The kind of metadata returned is determined by the file type: image
- * files return EXIF metadata, audio/video files return media metadata, PDFs
- * return PDF metadata, and MS Office documents (docx, pptx, xlsx) return Office
- * metadata. See the route description for the supported formats. Requests
- * against unsupported formats return `unsupported_format_error`.
+ * extract metadata from. Callers must set exactly one of the oneof variants: -
+ * file_id: a Dropbox-issued file id (format: "id:<id>") for a file the
+ * authenticated user has access to. - path: an absolute Dropbox path, e.g.
+ * "/folder/photo.jpg". - url: either a Dropbox shared link (www.dropbox.com) or
+ * an external HTTPS URL pointing to a supported file. - Dropbox shared links
+ * are resolved internally using the caller's authenticated identity and the
+ * link's visibility / download settings. They therefore require an
+ * authenticated user context (anonymous `url` requests against Dropbox links
+ * are rejected with an `ACCESS_ERROR`). Links protected by a password are
+ * rejected with `shared_link_password_protected`; links with downloads disabled
+ * are rejected with `link_download_disabled_error`. - External URLs are fetched
+ * over HTTPS through the backend's egress proxy and must point at a supported
+ * file extension. The kind of metadata returned is determined by the file type:
+ * image files return EXIF metadata, audio/video files return media metadata,
+ * PDFs return PDF metadata, and MS Office documents (docx, pptx, xlsx) return
+ * Office metadata. Requests against unsupported formats return
+ * `unsupported_format_error`.
  */
 
 /**
@@ -3380,9 +3391,15 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetMetadataAsyncCheckResult
  * @property {RivieraGetMetadataResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraMetadataExtractionApiV2Error} [failed] - Available if .tag
- * is failed.
+ * @property {RivieraGetMetadataAsyncError} [failed] - Available if .tag is
+ * failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * @typedef {Object} RivieraGetMetadataAsyncError
+ * @property {RivieraErrorCode} error_code
+ * @property {RivieraMetadataExtractionApiV2Error} [error_details]
  */
 
 /**
@@ -3394,52 +3411,32 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
- * Arguments for the asynchronous `get_text_async` route. Exactly one of
- * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to identify
- * the document whose plain-text content should be extracted.
- * @typedef {Object} RivieraGetTextArgs
- * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the document
- * to extract text from. Callers must set exactly one of the `FileIdOrUrl`
- * variants. Text extraction is supported for common document formats (Word,
- * PowerPoint, Excel, PDF, RTF, and Dropbox document types); see the route
- * description for the supported formats. Requests against unsupported formats
- * return `unsupported_format_error`. NOTE: for the `url` variant, only Dropbox
- * shared links (www.dropbox.com) are supported. External (non-Dropbox) URLs are
- * not supported and return `unsupported_format_error`; import the file into
- * Dropbox and reference it by `file_id` or `path` instead.
- */
-
-/**
- * Result type for EventBus async check - must end in "CheckResult"
- * @typedef {Object} RivieraGetTextAsyncCheckResult
- * @property {RivieraGetTextResult} [complete] - Available if .tag is complete.
- * @property {RivieraTextExtractionApiV2Error} [failed] - Available if .tag is
- * failed.
- * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * @typedef {Object} RivieraGetTextResult
- * @property {string} text - The plain-text content extracted from the document.
- * For multi-page documents the text is concatenated in document order. May be
- * empty when no text is detected in the source.
- */
-
-/**
  * Arguments for the asynchronous `get_transcript_async` route. Exactly one of
  * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to identify
  * the audio or video asset to transcribe.
  * @typedef {Object} RivieraGetTranscriptArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the media
- * asset to transcribe. Callers must set exactly one of the `FileIdOrUrl`
- * variants. The referenced asset must be an audio or video file in a supported
- * format (see the route description for the list); requests against files with
- * no audio track return a `no_audio_error`.
+ * asset to transcribe. Callers must set exactly one of the oneof variants: -
+ * file_id: a Dropbox-issued file id (format: "id:<id>") for a file the
+ * authenticated user has access to. - path: an absolute Dropbox path, e.g.
+ * "/folder/recording.mp4". - url: either a Dropbox shared link
+ * (www.dropbox.com) or an external HTTPS URL pointing to a supported
+ * audio/video file. - Dropbox shared links are resolved internally using the
+ * caller's authenticated identity and the link's visibility / download
+ * settings. They therefore require an authenticated user context (anonymous
+ * `url` requests against Dropbox links are rejected with an `ACCESS_ERROR`).
+ * Links protected by a password are rejected with
+ * `shared_link_password_protected`; links with downloads disabled are rejected
+ * with `link_download_disabled_error`. - External URLs are fetched over HTTPS
+ * through the backend's egress proxy and must point at a supported audio/video
+ * file extension. The referenced asset must be an audio or video file in a
+ * supported format; requests against files with no audio track return a
+ * `no_audio_error`.
  * @property {RivieraTimestampLevel} timestamp_level - Granularity of the time
- * offsets returned for each transcript segment. Defaults to `SENTENCE` when the
- * field is omitted. - SENTENCE: one segment per spoken sentence (recommended).
- * - WORD: one segment per word, useful for fine-grained alignment such as
- * captioning or highlight-as-you-listen experiences.
+ * offsets returned for each transcript segment. Defaults to `SENTENCE. -
+ * SENTENCE: one segment per spoken sentence (recommended). - WORD: one segment
+ * per word, useful for fine-grained alignment such as captioning or
+ * highlight-as-you-listen experiences.
  * @property {string} included_special_words - Comma-delimited list of
  * non-lexical filler words to preserve in the transcript output, e.g. `"uh, ah,
  * uhm"`. By default these fillers are stripped. Unrecognized tokens are
@@ -3456,8 +3453,15 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetTranscriptAsyncCheckResult
  * @property {RivieraGetTranscriptResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraContentApiV2Error} [failed] - Available if .tag is failed.
+ * @property {RivieraGetTranscriptAsyncError} [failed] - Available if .tag is
+ * failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * @typedef {Object} RivieraGetTranscriptAsyncError
+ * @property {RivieraErrorCode} error_code
+ * @property {RivieraContentApiV2Error} [error_details]
  */
 
 /**
@@ -3469,19 +3473,9 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
- * Reason a markdown conversion job failed. Returned in the `failed` variant of
- * `GetMarkdownAsyncCheckResult`. This is a semantic error union: the HTTP
- * status of the poll request itself is unaffected (a poll that surfaces a
- * failed job is still a normal successful poll response). Callers should branch
- * on the variant.
  * @typedef {Object} RivieraMarkdownConversionApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error. An
- * unexpected, typically transient, server-side failure. The string is a
- * human-readable message; retrying with backoff may succeed.
- * @property {string} [user_error] - Available if .tag is user_error. The
- * request could not be processed as supplied (a problem with the caller's
- * input). The string is a human-readable message; retrying the same request
- * will not help.
+ * @property {string} [server_error] - Available if .tag is server_error.
+ * @property {string} [user_error] - Available if .tag is user_error.
  * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3491,19 +3485,9 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
- * Reason a metadata extraction job failed. Returned in the `failed` variant of
- * `GetMetadataAsyncCheckResult`. This is a semantic error union: the HTTP
- * status of the poll request itself is unaffected (a poll that surfaces a
- * failed job is still a normal successful poll response). Callers should branch
- * on the variant.
  * @typedef {Object} RivieraMetadataExtractionApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error. An
- * unexpected, typically transient, server-side failure. The string is a
- * human-readable message; retrying with backoff may succeed.
- * @property {string} [user_error] - Available if .tag is user_error. The
- * request could not be processed as supplied (a problem with the caller's
- * input). The string is a human-readable message; retrying the same request
- * will not help.
+ * @property {string} [server_error] - Available if .tag is server_error.
+ * @property {string} [user_error] - Available if .tag is user_error.
  * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3521,25 +3505,8 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
- * Reason a text extraction job failed. Returned in the `failed` variant of
- * `GetTextAsyncCheckResult`. This is a semantic error union: the HTTP status of
- * the poll request itself is unaffected (a poll that surfaces a failed job is
- * still a normal successful poll response). Callers should branch on the
- * variant.
- * @typedef {Object} RivieraTextExtractionApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error. An
- * unexpected, typically transient, server-side failure. The string is a
- * human-readable message; retrying with backoff may succeed.
- * @property {string} [user_error] - Available if .tag is user_error. The
- * request could not be processed as supplied (a problem with the caller's
- * input). The string is a human-readable message; retrying the same request
- * will not help.
- * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
  * @typedef {Object} RivieraTimestampLevel
- * @property {('sentence'|'word'|'other')} .tag - Tag identifying the union variant.
+ * @property {('unknown'|'sentence'|'word'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -5179,7 +5146,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * `link_access_level` field of `LinkPermissions`. This is used in conjunction
  * with team policies and shared folder policies to determine the final
  * effective audience type in the `effective_audience` field of
- * `LinkPermissions`.
+ * `LinkPermissions.
  * @property {SharingRequestedLinkAccessLevel} [access] - Requested access level
  * you want the audience to gain from this link. Note, modifying access level
  * for an existing link is not supported.
@@ -5540,73 +5507,6 @@ only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
  * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * Launches one action-specific bulk suspend job.
- * @typedef {Object} TeamBulkSuspendArg
- * @property {Array.<TeamBulkSuspendMemberTarget>} members - Must contain
- * between 1 and 500 targets. The launch handler also rejects duplicate client
- * item IDs and duplicate member selectors.
- */
-
-/**
- * @typedef {Object} TeamBulkSuspendComplete
- * @property {number} requested
- * @property {number} suspended
- * @property {number} failed
- * @property {number} unknown
- * @property {TeamBulkSuspendReportDeliveryStatus} report_delivery
- */
-
-/**
- * A typed launch rejection. Authorization failures continue to use the API v2
- * authentication/permission error surface.
- * @typedef {Object} TeamBulkSuspendError
- * @property {('invalid_request'|'too_many_members'|'duplicate_client_item_id'|'duplicate_team_member_id'|'acting_admin'|'last_admin'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * Coarse job state. Live row progress and report contents are intentionally
- * omitted; callers receive row details in the terminal email report.
- * @typedef {Object} TeamBulkSuspendJobStatus
- * @property {TeamBulkSuspendComplete} [complete] - Available if .tag is
- * complete.
- * @property {TeamBulkSuspendTaskFailure} [failed] - Available if .tag is
- * failed.
- * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * One member selected for suspension. The opaque client item ID correlates the
- * eventual report row with the caller's input without sending CSV data.
- * @typedef {Object} TeamBulkSuspendMemberTarget
- * @property {string} client_item_id
- * @property {TeamMembersDeactivateArg} suspend_arg
- */
-
-/**
- * @typedef {Object} TeamBulkSuspendReportDeliveryStatus
- * @property {('bulk_suspend_report_delivery_status_unspecified'|'bulk_suspend_report_delivery_status_pending'|'bulk_suspend_report_delivery_status_delivered'|'bulk_suspend_report_delivery_status_failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * Stable machine-readable reasons used by the terminal row report.
- * @typedef {Object} TeamBulkSuspendRowFailure
- * @property {('user_not_found'|'user_not_in_team'|'other'|'suspend_inactive_user'|'suspend_last_admin'|'team_license_limit'|'protected_acting_admin'|'permission_changed'|'suspend_failed')} .tag - Tag identifying the union variant.
- */
-
-/**
- * The terminal outcome for one requested member. Row outcomes are delivered in
- * the report rather than embedded in the status response.
- * @typedef {Object} TeamBulkSuspendRowOutcome
- * @property {TeamBulkSuspendRowFailure} [failed] - Available if .tag is failed.
- * @property {('suspended'|'failed'|'unknown'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * @typedef {Object} TeamBulkSuspendTaskFailure
- * @property {('unusable_result'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -7481,7 +7381,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * .tag is status_error.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
- * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other'|'folder_count_limit_exceeded')} .tag - Tag identifying the union variant.
+ * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -7648,7 +7548,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * .tag is status_error.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
- * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other'|'folder_count_limit_exceeded')} .tag - Tag identifying the union variant.
+ * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -10724,9 +10624,6 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMemberDeleteProfilePhotoDetails}
  * [member_delete_profile_photo_details] - Available if .tag is
  * member_delete_profile_photo_details.
- * @property {TeamLogMemberFolderContentsAccessedDetails}
- * [member_folder_contents_accessed_details] - Available if .tag is
- * member_folder_contents_accessed_details.
  * @property {TeamLogMemberPermanentlyDeleteAccountContentsDetails}
  * [member_permanently_delete_account_contents_details] - Available if .tag is
  * member_permanently_delete_account_contents_details.
@@ -10899,40 +10796,9 @@ is only present when needed to discriminate between multiple possible subtypes.
  * if .tag is password_reset_details.
  * @property {TeamLogPasswordResetAllDetails} [password_reset_all_details] -
  * Available if .tag is password_reset_all_details.
- * @property {TeamLogProtectActionAddCollaboratorDetails}
- * [protect_action_add_collaborator_details] - Available if .tag is
- * protect_action_add_collaborator_details.
- * @property {TeamLogProtectActionAddLinkDetails}
- * [protect_action_add_link_details] - Available if .tag is
- * protect_action_add_link_details.
- * @property {TeamLogProtectActionDeleteDetails} [protect_action_delete_details]
- * - Available if .tag is protect_action_delete_details.
- * @property {TeamLogProtectActionExportDetails} [protect_action_export_details]
- * - Available if .tag is protect_action_export_details.
- * @property {TeamLogProtectActionRemoveCollaboratorDetails}
- * [protect_action_remove_collaborator_details] - Available if .tag is
- * protect_action_remove_collaborator_details.
- * @property {TeamLogProtectActionRemoveLinkDetails}
- * [protect_action_remove_link_details] - Available if .tag is
- * protect_action_remove_link_details.
- * @property {TeamLogProtectActionStopSharingDetails}
- * [protect_action_stop_sharing_details] - Available if .tag is
- * protect_action_stop_sharing_details.
  * @property {TeamLogProtectInternalDomainsChangedDetails}
  * [protect_internal_domains_changed_details] - Available if .tag is
  * protect_internal_domains_changed_details.
- * @property {TeamLogProtectPolicyActivatedDetails}
- * [protect_policy_activated_details] - Available if .tag is
- * protect_policy_activated_details.
- * @property {TeamLogProtectPolicyDeactivatedDetails}
- * [protect_policy_deactivated_details] - Available if .tag is
- * protect_policy_deactivated_details.
- * @property {TeamLogProtectPolicyScheduledDetails}
- * [protect_policy_scheduled_details] - Available if .tag is
- * protect_policy_scheduled_details.
- * @property {TeamLogProtectPolicyUpdatedDetails}
- * [protect_policy_updated_details] - Available if .tag is
- * protect_policy_updated_details.
  * @property {TeamLogClassificationCreateReportDetails}
  * [classification_create_report_details] - Available if .tag is
  * classification_create_report_details.
@@ -11880,7 +11746,7 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMissingDetails} [missing_details] - Available if .tag is
  * missing_details. Hints that this event was returned with missing details due
  * to an internal error.
- * @property {('admin_alerting_alert_state_changed_details'|'admin_alerting_changed_alert_config_details'|'admin_alerting_triggered_alert_details'|'ransomware_restore_process_completed_details'|'ransomware_restore_process_started_details'|'app_blocked_by_permissions_details'|'app_link_team_details'|'app_link_user_details'|'app_unlink_team_details'|'app_unlink_user_details'|'integration_connected_details'|'integration_disconnected_details'|'file_add_comment_details'|'file_change_comment_subscription_details'|'file_delete_comment_details'|'file_edit_comment_details'|'file_like_comment_details'|'file_resolve_comment_details'|'file_unlike_comment_details'|'file_unresolve_comment_details'|'dash_added_comment_to_stack_details'|'dash_added_connector_details'|'dash_added_link_to_stack_details'|'dash_added_team_email_domain_allowlist_details'|'dash_admin_added_org_wide_connector_details'|'dash_admin_disabled_connector_details'|'dash_admin_enabled_connector_details'|'dash_admin_removed_org_wide_connector_details'|'dash_archived_stack_details'|'dash_changed_audience_of_shared_link_to_stack_details'|'dash_cloned_stack_details'|'dash_connector_tools_call_details'|'dash_created_stack_details'|'dash_deleted_comment_from_stack_details'|'dash_deleted_stack_details'|'dash_edited_comment_in_stack_details'|'dash_external_user_opened_stack_details'|'dash_first_launched_desktop_details'|'dash_first_launched_extension_details'|'dash_first_launched_web_start_page_details'|'dash_opened_shared_link_to_stack_details'|'dash_opened_stack_details'|'dash_preview_opt_out_status_changed_details'|'dash_removed_connector_details'|'dash_removed_link_from_stack_details'|'dash_removed_shared_link_to_stack_details'|'dash_removed_team_email_domain_allowlist_details'|'dash_renamed_stack_details'|'dash_shared_link_to_stack_details'|'dash_unarchived_stack_details'|'dash_viewed_company_stack_details'|'dash_viewed_external_ai_activity_report_details'|'governance_policy_add_folders_details'|'governance_policy_add_folder_failed_details'|'governance_policy_content_disposed_details'|'governance_policy_create_details'|'governance_policy_delete_details'|'governance_policy_edit_details_details'|'governance_policy_edit_duration_details'|'governance_policy_export_created_details'|'governance_policy_export_removed_details'|'governance_policy_remove_folders_details'|'governance_policy_report_created_details'|'governance_policy_zip_part_downloaded_details'|'legal_holds_activate_a_hold_details'|'legal_holds_add_members_details'|'legal_holds_change_hold_details_details'|'legal_holds_change_hold_name_details'|'legal_holds_export_a_hold_details'|'legal_holds_export_cancelled_details'|'legal_holds_export_downloaded_details'|'legal_holds_export_removed_details'|'legal_holds_release_a_hold_details'|'legal_holds_remove_members_details'|'legal_holds_report_a_hold_details'|'device_change_ip_desktop_details'|'device_change_ip_mobile_details'|'device_change_ip_web_details'|'device_delete_on_unlink_fail_details'|'device_delete_on_unlink_success_details'|'device_link_fail_details'|'device_link_success_details'|'device_management_disabled_details'|'device_management_enabled_details'|'device_sync_backup_status_changed_details'|'device_unlink_details'|'dropbox_passwords_exported_details'|'dropbox_passwords_new_device_enrolled_details'|'emm_refresh_auth_token_details'|'external_drive_backup_eligibility_status_checked_details'|'external_drive_backup_status_changed_details'|'account_capture_change_availability_details'|'account_capture_migrate_account_details'|'account_capture_notification_emails_sent_details'|'account_capture_relinquish_account_details'|'disabled_domain_invites_details'|'domain_invites_approve_request_to_join_team_details'|'domain_invites_decline_request_to_join_team_details'|'domain_invites_email_existing_users_details'|'domain_invites_request_to_join_team_details'|'domain_invites_set_invite_new_user_pref_to_no_details'|'domain_invites_set_invite_new_user_pref_to_yes_details'|'domain_verification_add_domain_fail_details'|'domain_verification_add_domain_success_details'|'domain_verification_remove_domain_details'|'enabled_domain_invites_details'|'encrypted_folder_cancel_team_key_rotation_details'|'encrypted_folder_enroll_backup_key_details'|'encrypted_folder_enroll_client_details'|'encrypted_folder_enroll_team_details'|'encrypted_folder_finish_team_unenrollment_details'|'encrypted_folder_init_team_key_rotation_details'|'encrypted_folder_init_team_unenrollment_details'|'encrypted_folder_remove_backup_key_details'|'encrypted_folder_rotate_team_key_details'|'encrypted_folder_unenroll_client_details'|'team_encryption_key_activate_key_details'|'team_encryption_key_cancel_key_deletion_details'|'team_encryption_key_create_key_details'|'team_encryption_key_deactivate_key_details'|'team_encryption_key_delete_key_details'|'team_encryption_key_disable_key_details'|'team_encryption_key_enable_key_details'|'team_encryption_key_rotate_key_details'|'team_encryption_key_schedule_key_deletion_details'|'apply_naming_convention_details'|'create_folder_details'|'file_add_details'|'file_add_from_automation_details'|'file_copy_details'|'file_delete_details'|'file_download_details'|'file_edit_details'|'file_get_copy_reference_details'|'file_locking_lock_status_changed_details'|'file_move_details'|'file_permanently_delete_details'|'file_preview_details'|'file_rename_details'|'file_restore_details'|'file_revert_details'|'file_rollback_changes_details'|'file_save_copy_reference_details'|'folder_overview_description_changed_details'|'folder_overview_item_pinned_details'|'folder_overview_item_unpinned_details'|'media_hub_file_downloaded_details'|'object_label_added_details'|'object_label_removed_details'|'object_label_updated_value_details'|'organize_folder_with_tidy_details'|'replay_file_delete_details'|'replay_file_downloaded_details'|'replay_team_project_created_details'|'rewind_folder_details'|'undo_naming_convention_details'|'undo_organize_folder_with_tidy_details'|'user_tags_added_details'|'user_tags_removed_details'|'email_ingest_receive_file_details'|'file_request_auto_close_details'|'file_request_change_details'|'file_request_close_details'|'file_request_create_details'|'file_request_delete_details'|'file_request_receive_file_details'|'group_add_external_id_details'|'group_add_member_details'|'group_change_external_id_details'|'group_change_management_type_details'|'group_change_member_role_details'|'group_create_details'|'group_delete_details'|'group_description_updated_details'|'group_external_sharing_setting_override_changed_details'|'group_join_policy_updated_details'|'group_moved_details'|'group_remove_external_id_details'|'group_remove_member_details'|'group_rename_details'|'account_lock_or_unlocked_details'|'emm_error_details'|'guest_admin_signed_in_via_trusted_teams_details'|'guest_admin_signed_out_via_trusted_teams_details'|'login_fail_details'|'login_success_details'|'logout_details'|'reseller_support_session_end_details'|'reseller_support_session_start_details'|'sign_in_as_session_end_details'|'sign_in_as_session_start_details'|'sso_error_details'|'addon_assigned_details'|'addon_removed_details'|'backup_admin_invitation_sent_details'|'backup_invitation_opened_details'|'create_team_invite_link_details'|'delete_team_invite_link_details'|'member_add_external_id_details'|'member_add_name_details'|'member_change_admin_role_details'|'member_change_email_details'|'member_change_external_id_details'|'member_change_membership_type_details'|'member_change_name_details'|'member_change_reseller_role_details'|'member_change_status_details'|'member_delete_manual_contacts_details'|'member_delete_profile_photo_details'|'member_folder_contents_accessed_details'|'member_permanently_delete_account_contents_details'|'member_remove_external_id_details'|'member_set_profile_photo_details'|'member_space_limits_add_custom_quota_details'|'member_space_limits_change_custom_quota_details'|'member_space_limits_change_status_details'|'member_space_limits_remove_custom_quota_details'|'member_suggest_details'|'member_transfer_account_contents_details'|'pending_secondary_email_added_details'|'product_assigned_to_member_details'|'product_removed_from_member_details'|'secondary_email_deleted_details'|'secondary_email_verified_details'|'secondary_mails_policy_changed_details'|'binder_add_page_details'|'binder_add_section_details'|'binder_remove_page_details'|'binder_remove_section_details'|'binder_rename_page_details'|'binder_rename_section_details'|'binder_reorder_page_details'|'binder_reorder_section_details'|'paper_content_add_member_details'|'paper_content_add_to_folder_details'|'paper_content_archive_details'|'paper_content_create_details'|'paper_content_permanently_delete_details'|'paper_content_remove_from_folder_details'|'paper_content_remove_member_details'|'paper_content_rename_details'|'paper_content_restore_details'|'paper_doc_add_comment_details'|'paper_doc_change_member_role_details'|'paper_doc_change_sharing_policy_details'|'paper_doc_change_subscription_details'|'paper_doc_deleted_details'|'paper_doc_delete_comment_details'|'paper_doc_download_details'|'paper_doc_edit_details'|'paper_doc_edit_comment_details'|'paper_doc_followed_details'|'paper_doc_mention_details'|'paper_doc_ownership_changed_details'|'paper_doc_request_access_details'|'paper_doc_resolve_comment_details'|'paper_doc_revert_details'|'paper_doc_slack_share_details'|'paper_doc_team_invite_details'|'paper_doc_trashed_details'|'paper_doc_unresolve_comment_details'|'paper_doc_untrashed_details'|'paper_doc_view_details'|'paper_external_view_allow_details'|'paper_external_view_default_team_details'|'paper_external_view_forbid_details'|'paper_folder_change_subscription_details'|'paper_folder_deleted_details'|'paper_folder_followed_details'|'paper_folder_team_invite_details'|'paper_published_link_change_permission_details'|'paper_published_link_create_details'|'paper_published_link_disabled_details'|'paper_published_link_view_details'|'password_change_details'|'password_reset_details'|'password_reset_all_details'|'protect_action_add_collaborator_details'|'protect_action_add_link_details'|'protect_action_delete_details'|'protect_action_export_details'|'protect_action_remove_collaborator_details'|'protect_action_remove_link_details'|'protect_action_stop_sharing_details'|'protect_internal_domains_changed_details'|'protect_policy_activated_details'|'protect_policy_deactivated_details'|'protect_policy_scheduled_details'|'protect_policy_updated_details'|'classification_create_report_details'|'classification_create_report_fail_details'|'emm_create_exceptions_report_details'|'emm_create_usage_report_details'|'export_members_report_details'|'export_members_report_fail_details'|'external_sharing_create_report_details'|'external_sharing_report_failed_details'|'member_access_details_create_report_details'|'member_access_details_create_report_failed_details'|'no_expiration_link_gen_create_report_details'|'no_expiration_link_gen_report_failed_details'|'no_password_link_gen_create_report_details'|'no_password_link_gen_report_failed_details'|'no_password_link_view_create_report_details'|'no_password_link_view_report_failed_details'|'outdated_link_view_create_report_details'|'outdated_link_view_report_failed_details'|'paper_admin_export_start_details'|'ransomware_alert_create_report_details'|'ransomware_alert_create_report_failed_details'|'shared_folders_create_report_details'|'shared_folders_create_report_failed_details'|'smart_sync_create_admin_privilege_report_details'|'team_activity_create_report_details'|'team_activity_create_report_fail_details'|'team_folders_create_report_details'|'team_folders_create_report_failed_details'|'team_storage_create_report_details'|'team_storage_create_report_failed_details'|'collection_share_details'|'file_transfers_file_add_details'|'file_transfers_transfer_delete_details'|'file_transfers_transfer_download_details'|'file_transfers_transfer_send_details'|'file_transfers_transfer_view_details'|'media_hub_project_team_add_details'|'media_hub_project_team_delete_details'|'media_hub_project_team_role_changed_details'|'media_hub_shared_link_audience_changed_details'|'media_hub_shared_link_created_details'|'media_hub_shared_link_download_setting_changed_details'|'media_hub_shared_link_revoked_details'|'note_acl_invite_only_details'|'note_acl_link_details'|'note_acl_team_link_details'|'note_shared_details'|'note_share_receive_details'|'open_note_shared_details'|'replay_file_shared_link_created_details'|'replay_file_shared_link_modified_details'|'replay_project_team_add_details'|'replay_project_team_delete_details'|'send_and_track_file_added_details'|'send_and_track_file_renamed_details'|'send_and_track_file_updated_details'|'send_and_track_link_created_details'|'send_and_track_link_deleted_details'|'send_and_track_link_updated_details'|'send_and_track_link_viewed_details'|'send_and_track_removed_file_and_associated_links_details'|'sf_add_group_details'|'sf_allow_non_members_to_view_shared_links_details'|'sf_external_invite_warn_details'|'sf_fb_invite_details'|'sf_fb_invite_change_role_details'|'sf_fb_uninvite_details'|'sf_invite_group_details'|'sf_team_grant_access_details'|'sf_team_invite_details'|'sf_team_invite_change_role_details'|'sf_team_join_details'|'sf_team_join_from_oob_link_details'|'sf_team_uninvite_details'|'shared_content_add_invitees_details'|'shared_content_add_link_expiry_details'|'shared_content_add_link_password_details'|'shared_content_add_member_details'|'shared_content_change_downloads_policy_details'|'shared_content_change_invitee_role_details'|'shared_content_change_link_audience_details'|'shared_content_change_link_expiry_details'|'shared_content_change_link_password_details'|'shared_content_change_member_role_details'|'shared_content_change_viewer_info_policy_details'|'shared_content_claim_invitation_details'|'shared_content_copy_details'|'shared_content_download_details'|'shared_content_relinquish_membership_details'|'shared_content_remove_invitees_details'|'shared_content_remove_link_expiry_details'|'shared_content_remove_link_password_details'|'shared_content_remove_member_details'|'shared_content_request_access_details'|'shared_content_restore_invitees_details'|'shared_content_restore_member_details'|'shared_content_unshare_details'|'shared_content_view_details'|'shared_folder_change_link_policy_details'|'shared_folder_change_members_inheritance_policy_details'|'shared_folder_change_members_management_policy_details'|'shared_folder_change_members_policy_details'|'shared_folder_create_details'|'shared_folder_decline_invitation_details'|'shared_folder_mount_details'|'shared_folder_nest_details'|'shared_folder_transfer_ownership_details'|'shared_folder_unmount_details'|'shared_link_add_expiry_details'|'shared_link_change_expiry_details'|'shared_link_change_visibility_details'|'shared_link_copy_details'|'shared_link_create_details'|'shared_link_disable_details'|'shared_link_download_details'|'shared_link_remove_expiry_details'|'shared_link_remove_visitor_details'|'shared_link_settings_add_expiration_details'|'shared_link_settings_add_password_details'|'shared_link_settings_allow_download_disabled_details'|'shared_link_settings_allow_download_enabled_details'|'shared_link_settings_change_audience_details'|'shared_link_settings_change_expiration_details'|'shared_link_settings_change_password_details'|'shared_link_settings_remove_expiration_details'|'shared_link_settings_remove_password_details'|'shared_link_share_details'|'shared_link_view_details'|'shared_note_opened_details'|'shmodel_disable_downloads_details'|'shmodel_enable_downloads_details'|'shmodel_group_share_details'|'showcase_access_granted_details'|'showcase_add_member_details'|'showcase_archived_details'|'showcase_created_details'|'showcase_delete_comment_details'|'showcase_edited_details'|'showcase_edit_comment_details'|'showcase_file_added_details'|'showcase_file_download_details'|'showcase_file_removed_details'|'showcase_file_view_details'|'showcase_permanently_deleted_details'|'showcase_post_comment_details'|'showcase_remove_member_details'|'showcase_renamed_details'|'showcase_request_access_details'|'showcase_resolve_comment_details'|'showcase_restored_details'|'showcase_trashed_details'|'showcase_trashed_deprecated_details'|'showcase_unresolve_comment_details'|'showcase_untrashed_details'|'showcase_untrashed_deprecated_details'|'showcase_view_details'|'sign_signature_request_canceled_details'|'sign_signature_request_completed_details'|'sign_signature_request_declined_details'|'sign_signature_request_opened_details'|'sign_signature_request_reminder_sent_details'|'sign_signature_request_sent_details'|'sign_template_created_details'|'sign_template_shared_details'|'risc_security_event_details'|'sso_add_cert_details'|'sso_add_login_url_details'|'sso_add_logout_url_details'|'sso_change_cert_details'|'sso_change_login_url_details'|'sso_change_logout_url_details'|'sso_change_saml_identity_mode_details'|'sso_remove_cert_details'|'sso_remove_login_url_details'|'sso_remove_logout_url_details'|'team_folder_change_status_details'|'team_folder_create_details'|'team_folder_downgrade_details'|'team_folder_permanently_delete_details'|'team_folder_rename_details'|'team_folder_space_limits_change_caps_type_details'|'team_folder_space_limits_change_limit_details'|'team_folder_space_limits_change_notification_target_details'|'team_selective_sync_settings_changed_details'|'account_capture_change_policy_details'|'admin_email_reminders_changed_details'|'ai_third_party_sharing_dropbox_base_policy_changed_details'|'allow_download_disabled_details'|'allow_download_enabled_details'|'apple_login_change_policy_details'|'app_permissions_changed_details'|'camera_uploads_policy_changed_details'|'capture_team_space_policy_changed_details'|'capture_transcript_policy_changed_details'|'classification_change_policy_details'|'computer_backup_policy_changed_details'|'content_administration_policy_changed_details'|'content_deletion_protection_change_policy_details'|'dash_external_sharing_policy_changed_details'|'data_placement_restriction_change_policy_details'|'data_placement_restriction_satisfy_policy_details'|'device_approvals_add_exception_details'|'device_approvals_change_desktop_policy_details'|'device_approvals_change_mobile_policy_details'|'device_approvals_change_overage_action_details'|'device_approvals_change_unlink_action_details'|'device_approvals_remove_exception_details'|'directory_restrictions_add_members_details'|'directory_restrictions_remove_members_details'|'dropbox_passwords_policy_changed_details'|'email_ingest_policy_changed_details'|'emm_add_exception_details'|'emm_change_policy_details'|'emm_remove_exception_details'|'extended_version_history_change_policy_details'|'external_drive_backup_policy_changed_details'|'file_comments_change_policy_details'|'file_locking_policy_changed_details'|'file_provider_migration_policy_changed_details'|'file_requests_change_policy_details'|'file_requests_emails_enabled_details'|'file_requests_emails_restricted_to_team_only_details'|'file_transfers_policy_changed_details'|'flexible_file_names_policy_changed_details'|'folder_link_restriction_policy_changed_details'|'google_sso_change_policy_details'|'group_user_management_change_policy_details'|'integration_policy_changed_details'|'invite_acceptance_email_policy_changed_details'|'media_hub_adding_people_policy_changed_details'|'media_hub_download_policy_changed_details'|'media_hub_link_sharing_policy_changed_details'|'member_requests_change_policy_details'|'member_send_invite_policy_changed_details'|'member_space_limits_add_exception_details'|'member_space_limits_change_caps_type_policy_details'|'member_space_limits_change_policy_details'|'member_space_limits_remove_exception_details'|'member_suggestions_change_policy_details'|'microsoft_login_change_policy_details'|'microsoft_office_addin_change_policy_details'|'multi_team_identity_policy_changed_details'|'network_control_change_policy_details'|'paper_change_deployment_policy_details'|'paper_change_member_link_policy_details'|'paper_change_member_policy_details'|'paper_change_policy_details'|'paper_default_folder_policy_changed_details'|'paper_desktop_policy_changed_details'|'paper_enabled_users_group_addition_details'|'paper_enabled_users_group_removal_details'|'passkey_login_policy_changed_details'|'password_strength_requirements_change_policy_details'|'permanent_delete_change_policy_details'|'previews_ai_policy_changed_details'|'replay_adding_people_policy_changed_details'|'replay_sharing_policy_changed_details'|'reseller_support_change_policy_details'|'rewind_policy_changed_details'|'send_and_track_policy_changed_details'|'send_external_sharing_policy_changed_details'|'send_for_signature_policy_changed_details'|'shared_link_default_permissions_policy_changed_details'|'sharing_change_folder_join_policy_details'|'sharing_change_link_allow_change_expiration_policy_details'|'sharing_change_link_default_expiration_policy_details'|'sharing_change_link_enforce_password_policy_details'|'sharing_change_link_policy_details'|'sharing_change_member_policy_details'|'showcase_change_download_policy_details'|'showcase_change_enabled_policy_details'|'showcase_change_external_sharing_policy_details'|'sign_external_sharing_policy_changed_details'|'sign_template_creation_permission_changed_details'|'smarter_smart_sync_policy_changed_details'|'smart_sync_change_policy_details'|'smart_sync_not_opt_out_details'|'smart_sync_opt_out_details'|'sso_change_policy_details'|'stack_cross_team_access_policy_changed_details'|'team_branding_policy_changed_details'|'team_extensions_policy_changed_details'|'team_member_storage_request_policy_changed_details'|'team_selective_sync_policy_changed_details'|'team_sharing_whitelist_subjects_changed_details'|'tfa_add_exception_details'|'tfa_change_policy_details'|'tfa_remove_exception_details'|'top_level_content_policy_changed_details'|'two_account_change_policy_details'|'viewer_info_policy_changed_details'|'watermarking_policy_changed_details'|'web_sessions_change_active_session_limit_details'|'web_sessions_change_fixed_length_policy_details'|'web_sessions_change_idle_length_policy_details'|'data_residency_migration_request_successful_details'|'data_residency_migration_request_unsuccessful_details'|'team_merge_from_details'|'team_merge_to_details'|'team_profile_add_background_details'|'team_profile_add_logo_details'|'team_profile_change_background_details'|'team_profile_change_default_language_details'|'team_profile_change_logo_details'|'team_profile_change_name_details'|'team_profile_remove_background_details'|'team_profile_remove_logo_details'|'passkey_add_details'|'passkey_remove_details'|'tfa_add_backup_phone_details'|'tfa_add_security_key_details'|'tfa_change_backup_phone_details'|'tfa_change_status_details'|'tfa_remove_backup_phone_details'|'tfa_remove_security_key_details'|'tfa_reset_details'|'changed_enterprise_admin_role_details'|'changed_enterprise_connected_team_status_details'|'ended_enterprise_admin_session_details'|'ended_enterprise_admin_session_deprecated_details'|'enterprise_settings_locking_details'|'guest_admin_change_status_details'|'started_enterprise_admin_session_details'|'team_merge_request_accepted_details'|'team_merge_request_accepted_shown_to_primary_team_details'|'team_merge_request_accepted_shown_to_secondary_team_details'|'team_merge_request_auto_canceled_details'|'team_merge_request_canceled_details'|'team_merge_request_canceled_shown_to_primary_team_details'|'team_merge_request_canceled_shown_to_secondary_team_details'|'team_merge_request_expired_details'|'team_merge_request_expired_shown_to_primary_team_details'|'team_merge_request_expired_shown_to_secondary_team_details'|'team_merge_request_rejected_shown_to_primary_team_details'|'team_merge_request_rejected_shown_to_secondary_team_details'|'team_merge_request_reminder_details'|'team_merge_request_reminder_shown_to_primary_team_details'|'team_merge_request_reminder_shown_to_secondary_team_details'|'team_merge_request_revoked_details'|'team_merge_request_sent_shown_to_primary_team_details'|'team_merge_request_sent_shown_to_secondary_team_details'|'missing_details'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed_details'|'admin_alerting_changed_alert_config_details'|'admin_alerting_triggered_alert_details'|'ransomware_restore_process_completed_details'|'ransomware_restore_process_started_details'|'app_blocked_by_permissions_details'|'app_link_team_details'|'app_link_user_details'|'app_unlink_team_details'|'app_unlink_user_details'|'integration_connected_details'|'integration_disconnected_details'|'file_add_comment_details'|'file_change_comment_subscription_details'|'file_delete_comment_details'|'file_edit_comment_details'|'file_like_comment_details'|'file_resolve_comment_details'|'file_unlike_comment_details'|'file_unresolve_comment_details'|'dash_added_comment_to_stack_details'|'dash_added_connector_details'|'dash_added_link_to_stack_details'|'dash_added_team_email_domain_allowlist_details'|'dash_admin_added_org_wide_connector_details'|'dash_admin_disabled_connector_details'|'dash_admin_enabled_connector_details'|'dash_admin_removed_org_wide_connector_details'|'dash_archived_stack_details'|'dash_changed_audience_of_shared_link_to_stack_details'|'dash_cloned_stack_details'|'dash_connector_tools_call_details'|'dash_created_stack_details'|'dash_deleted_comment_from_stack_details'|'dash_deleted_stack_details'|'dash_edited_comment_in_stack_details'|'dash_external_user_opened_stack_details'|'dash_first_launched_desktop_details'|'dash_first_launched_extension_details'|'dash_first_launched_web_start_page_details'|'dash_opened_shared_link_to_stack_details'|'dash_opened_stack_details'|'dash_preview_opt_out_status_changed_details'|'dash_removed_connector_details'|'dash_removed_link_from_stack_details'|'dash_removed_shared_link_to_stack_details'|'dash_removed_team_email_domain_allowlist_details'|'dash_renamed_stack_details'|'dash_shared_link_to_stack_details'|'dash_unarchived_stack_details'|'dash_viewed_company_stack_details'|'dash_viewed_external_ai_activity_report_details'|'governance_policy_add_folders_details'|'governance_policy_add_folder_failed_details'|'governance_policy_content_disposed_details'|'governance_policy_create_details'|'governance_policy_delete_details'|'governance_policy_edit_details_details'|'governance_policy_edit_duration_details'|'governance_policy_export_created_details'|'governance_policy_export_removed_details'|'governance_policy_remove_folders_details'|'governance_policy_report_created_details'|'governance_policy_zip_part_downloaded_details'|'legal_holds_activate_a_hold_details'|'legal_holds_add_members_details'|'legal_holds_change_hold_details_details'|'legal_holds_change_hold_name_details'|'legal_holds_export_a_hold_details'|'legal_holds_export_cancelled_details'|'legal_holds_export_downloaded_details'|'legal_holds_export_removed_details'|'legal_holds_release_a_hold_details'|'legal_holds_remove_members_details'|'legal_holds_report_a_hold_details'|'device_change_ip_desktop_details'|'device_change_ip_mobile_details'|'device_change_ip_web_details'|'device_delete_on_unlink_fail_details'|'device_delete_on_unlink_success_details'|'device_link_fail_details'|'device_link_success_details'|'device_management_disabled_details'|'device_management_enabled_details'|'device_sync_backup_status_changed_details'|'device_unlink_details'|'dropbox_passwords_exported_details'|'dropbox_passwords_new_device_enrolled_details'|'emm_refresh_auth_token_details'|'external_drive_backup_eligibility_status_checked_details'|'external_drive_backup_status_changed_details'|'account_capture_change_availability_details'|'account_capture_migrate_account_details'|'account_capture_notification_emails_sent_details'|'account_capture_relinquish_account_details'|'disabled_domain_invites_details'|'domain_invites_approve_request_to_join_team_details'|'domain_invites_decline_request_to_join_team_details'|'domain_invites_email_existing_users_details'|'domain_invites_request_to_join_team_details'|'domain_invites_set_invite_new_user_pref_to_no_details'|'domain_invites_set_invite_new_user_pref_to_yes_details'|'domain_verification_add_domain_fail_details'|'domain_verification_add_domain_success_details'|'domain_verification_remove_domain_details'|'enabled_domain_invites_details'|'encrypted_folder_cancel_team_key_rotation_details'|'encrypted_folder_enroll_backup_key_details'|'encrypted_folder_enroll_client_details'|'encrypted_folder_enroll_team_details'|'encrypted_folder_finish_team_unenrollment_details'|'encrypted_folder_init_team_key_rotation_details'|'encrypted_folder_init_team_unenrollment_details'|'encrypted_folder_remove_backup_key_details'|'encrypted_folder_rotate_team_key_details'|'encrypted_folder_unenroll_client_details'|'team_encryption_key_activate_key_details'|'team_encryption_key_cancel_key_deletion_details'|'team_encryption_key_create_key_details'|'team_encryption_key_deactivate_key_details'|'team_encryption_key_delete_key_details'|'team_encryption_key_disable_key_details'|'team_encryption_key_enable_key_details'|'team_encryption_key_rotate_key_details'|'team_encryption_key_schedule_key_deletion_details'|'apply_naming_convention_details'|'create_folder_details'|'file_add_details'|'file_add_from_automation_details'|'file_copy_details'|'file_delete_details'|'file_download_details'|'file_edit_details'|'file_get_copy_reference_details'|'file_locking_lock_status_changed_details'|'file_move_details'|'file_permanently_delete_details'|'file_preview_details'|'file_rename_details'|'file_restore_details'|'file_revert_details'|'file_rollback_changes_details'|'file_save_copy_reference_details'|'folder_overview_description_changed_details'|'folder_overview_item_pinned_details'|'folder_overview_item_unpinned_details'|'media_hub_file_downloaded_details'|'object_label_added_details'|'object_label_removed_details'|'object_label_updated_value_details'|'organize_folder_with_tidy_details'|'replay_file_delete_details'|'replay_file_downloaded_details'|'replay_team_project_created_details'|'rewind_folder_details'|'undo_naming_convention_details'|'undo_organize_folder_with_tidy_details'|'user_tags_added_details'|'user_tags_removed_details'|'email_ingest_receive_file_details'|'file_request_auto_close_details'|'file_request_change_details'|'file_request_close_details'|'file_request_create_details'|'file_request_delete_details'|'file_request_receive_file_details'|'group_add_external_id_details'|'group_add_member_details'|'group_change_external_id_details'|'group_change_management_type_details'|'group_change_member_role_details'|'group_create_details'|'group_delete_details'|'group_description_updated_details'|'group_external_sharing_setting_override_changed_details'|'group_join_policy_updated_details'|'group_moved_details'|'group_remove_external_id_details'|'group_remove_member_details'|'group_rename_details'|'account_lock_or_unlocked_details'|'emm_error_details'|'guest_admin_signed_in_via_trusted_teams_details'|'guest_admin_signed_out_via_trusted_teams_details'|'login_fail_details'|'login_success_details'|'logout_details'|'reseller_support_session_end_details'|'reseller_support_session_start_details'|'sign_in_as_session_end_details'|'sign_in_as_session_start_details'|'sso_error_details'|'addon_assigned_details'|'addon_removed_details'|'backup_admin_invitation_sent_details'|'backup_invitation_opened_details'|'create_team_invite_link_details'|'delete_team_invite_link_details'|'member_add_external_id_details'|'member_add_name_details'|'member_change_admin_role_details'|'member_change_email_details'|'member_change_external_id_details'|'member_change_membership_type_details'|'member_change_name_details'|'member_change_reseller_role_details'|'member_change_status_details'|'member_delete_manual_contacts_details'|'member_delete_profile_photo_details'|'member_permanently_delete_account_contents_details'|'member_remove_external_id_details'|'member_set_profile_photo_details'|'member_space_limits_add_custom_quota_details'|'member_space_limits_change_custom_quota_details'|'member_space_limits_change_status_details'|'member_space_limits_remove_custom_quota_details'|'member_suggest_details'|'member_transfer_account_contents_details'|'pending_secondary_email_added_details'|'product_assigned_to_member_details'|'product_removed_from_member_details'|'secondary_email_deleted_details'|'secondary_email_verified_details'|'secondary_mails_policy_changed_details'|'binder_add_page_details'|'binder_add_section_details'|'binder_remove_page_details'|'binder_remove_section_details'|'binder_rename_page_details'|'binder_rename_section_details'|'binder_reorder_page_details'|'binder_reorder_section_details'|'paper_content_add_member_details'|'paper_content_add_to_folder_details'|'paper_content_archive_details'|'paper_content_create_details'|'paper_content_permanently_delete_details'|'paper_content_remove_from_folder_details'|'paper_content_remove_member_details'|'paper_content_rename_details'|'paper_content_restore_details'|'paper_doc_add_comment_details'|'paper_doc_change_member_role_details'|'paper_doc_change_sharing_policy_details'|'paper_doc_change_subscription_details'|'paper_doc_deleted_details'|'paper_doc_delete_comment_details'|'paper_doc_download_details'|'paper_doc_edit_details'|'paper_doc_edit_comment_details'|'paper_doc_followed_details'|'paper_doc_mention_details'|'paper_doc_ownership_changed_details'|'paper_doc_request_access_details'|'paper_doc_resolve_comment_details'|'paper_doc_revert_details'|'paper_doc_slack_share_details'|'paper_doc_team_invite_details'|'paper_doc_trashed_details'|'paper_doc_unresolve_comment_details'|'paper_doc_untrashed_details'|'paper_doc_view_details'|'paper_external_view_allow_details'|'paper_external_view_default_team_details'|'paper_external_view_forbid_details'|'paper_folder_change_subscription_details'|'paper_folder_deleted_details'|'paper_folder_followed_details'|'paper_folder_team_invite_details'|'paper_published_link_change_permission_details'|'paper_published_link_create_details'|'paper_published_link_disabled_details'|'paper_published_link_view_details'|'password_change_details'|'password_reset_details'|'password_reset_all_details'|'protect_internal_domains_changed_details'|'classification_create_report_details'|'classification_create_report_fail_details'|'emm_create_exceptions_report_details'|'emm_create_usage_report_details'|'export_members_report_details'|'export_members_report_fail_details'|'external_sharing_create_report_details'|'external_sharing_report_failed_details'|'member_access_details_create_report_details'|'member_access_details_create_report_failed_details'|'no_expiration_link_gen_create_report_details'|'no_expiration_link_gen_report_failed_details'|'no_password_link_gen_create_report_details'|'no_password_link_gen_report_failed_details'|'no_password_link_view_create_report_details'|'no_password_link_view_report_failed_details'|'outdated_link_view_create_report_details'|'outdated_link_view_report_failed_details'|'paper_admin_export_start_details'|'ransomware_alert_create_report_details'|'ransomware_alert_create_report_failed_details'|'shared_folders_create_report_details'|'shared_folders_create_report_failed_details'|'smart_sync_create_admin_privilege_report_details'|'team_activity_create_report_details'|'team_activity_create_report_fail_details'|'team_folders_create_report_details'|'team_folders_create_report_failed_details'|'team_storage_create_report_details'|'team_storage_create_report_failed_details'|'collection_share_details'|'file_transfers_file_add_details'|'file_transfers_transfer_delete_details'|'file_transfers_transfer_download_details'|'file_transfers_transfer_send_details'|'file_transfers_transfer_view_details'|'media_hub_project_team_add_details'|'media_hub_project_team_delete_details'|'media_hub_project_team_role_changed_details'|'media_hub_shared_link_audience_changed_details'|'media_hub_shared_link_created_details'|'media_hub_shared_link_download_setting_changed_details'|'media_hub_shared_link_revoked_details'|'note_acl_invite_only_details'|'note_acl_link_details'|'note_acl_team_link_details'|'note_shared_details'|'note_share_receive_details'|'open_note_shared_details'|'replay_file_shared_link_created_details'|'replay_file_shared_link_modified_details'|'replay_project_team_add_details'|'replay_project_team_delete_details'|'send_and_track_file_added_details'|'send_and_track_file_renamed_details'|'send_and_track_file_updated_details'|'send_and_track_link_created_details'|'send_and_track_link_deleted_details'|'send_and_track_link_updated_details'|'send_and_track_link_viewed_details'|'send_and_track_removed_file_and_associated_links_details'|'sf_add_group_details'|'sf_allow_non_members_to_view_shared_links_details'|'sf_external_invite_warn_details'|'sf_fb_invite_details'|'sf_fb_invite_change_role_details'|'sf_fb_uninvite_details'|'sf_invite_group_details'|'sf_team_grant_access_details'|'sf_team_invite_details'|'sf_team_invite_change_role_details'|'sf_team_join_details'|'sf_team_join_from_oob_link_details'|'sf_team_uninvite_details'|'shared_content_add_invitees_details'|'shared_content_add_link_expiry_details'|'shared_content_add_link_password_details'|'shared_content_add_member_details'|'shared_content_change_downloads_policy_details'|'shared_content_change_invitee_role_details'|'shared_content_change_link_audience_details'|'shared_content_change_link_expiry_details'|'shared_content_change_link_password_details'|'shared_content_change_member_role_details'|'shared_content_change_viewer_info_policy_details'|'shared_content_claim_invitation_details'|'shared_content_copy_details'|'shared_content_download_details'|'shared_content_relinquish_membership_details'|'shared_content_remove_invitees_details'|'shared_content_remove_link_expiry_details'|'shared_content_remove_link_password_details'|'shared_content_remove_member_details'|'shared_content_request_access_details'|'shared_content_restore_invitees_details'|'shared_content_restore_member_details'|'shared_content_unshare_details'|'shared_content_view_details'|'shared_folder_change_link_policy_details'|'shared_folder_change_members_inheritance_policy_details'|'shared_folder_change_members_management_policy_details'|'shared_folder_change_members_policy_details'|'shared_folder_create_details'|'shared_folder_decline_invitation_details'|'shared_folder_mount_details'|'shared_folder_nest_details'|'shared_folder_transfer_ownership_details'|'shared_folder_unmount_details'|'shared_link_add_expiry_details'|'shared_link_change_expiry_details'|'shared_link_change_visibility_details'|'shared_link_copy_details'|'shared_link_create_details'|'shared_link_disable_details'|'shared_link_download_details'|'shared_link_remove_expiry_details'|'shared_link_remove_visitor_details'|'shared_link_settings_add_expiration_details'|'shared_link_settings_add_password_details'|'shared_link_settings_allow_download_disabled_details'|'shared_link_settings_allow_download_enabled_details'|'shared_link_settings_change_audience_details'|'shared_link_settings_change_expiration_details'|'shared_link_settings_change_password_details'|'shared_link_settings_remove_expiration_details'|'shared_link_settings_remove_password_details'|'shared_link_share_details'|'shared_link_view_details'|'shared_note_opened_details'|'shmodel_disable_downloads_details'|'shmodel_enable_downloads_details'|'shmodel_group_share_details'|'showcase_access_granted_details'|'showcase_add_member_details'|'showcase_archived_details'|'showcase_created_details'|'showcase_delete_comment_details'|'showcase_edited_details'|'showcase_edit_comment_details'|'showcase_file_added_details'|'showcase_file_download_details'|'showcase_file_removed_details'|'showcase_file_view_details'|'showcase_permanently_deleted_details'|'showcase_post_comment_details'|'showcase_remove_member_details'|'showcase_renamed_details'|'showcase_request_access_details'|'showcase_resolve_comment_details'|'showcase_restored_details'|'showcase_trashed_details'|'showcase_trashed_deprecated_details'|'showcase_unresolve_comment_details'|'showcase_untrashed_details'|'showcase_untrashed_deprecated_details'|'showcase_view_details'|'sign_signature_request_canceled_details'|'sign_signature_request_completed_details'|'sign_signature_request_declined_details'|'sign_signature_request_opened_details'|'sign_signature_request_reminder_sent_details'|'sign_signature_request_sent_details'|'sign_template_created_details'|'sign_template_shared_details'|'risc_security_event_details'|'sso_add_cert_details'|'sso_add_login_url_details'|'sso_add_logout_url_details'|'sso_change_cert_details'|'sso_change_login_url_details'|'sso_change_logout_url_details'|'sso_change_saml_identity_mode_details'|'sso_remove_cert_details'|'sso_remove_login_url_details'|'sso_remove_logout_url_details'|'team_folder_change_status_details'|'team_folder_create_details'|'team_folder_downgrade_details'|'team_folder_permanently_delete_details'|'team_folder_rename_details'|'team_folder_space_limits_change_caps_type_details'|'team_folder_space_limits_change_limit_details'|'team_folder_space_limits_change_notification_target_details'|'team_selective_sync_settings_changed_details'|'account_capture_change_policy_details'|'admin_email_reminders_changed_details'|'ai_third_party_sharing_dropbox_base_policy_changed_details'|'allow_download_disabled_details'|'allow_download_enabled_details'|'apple_login_change_policy_details'|'app_permissions_changed_details'|'camera_uploads_policy_changed_details'|'capture_team_space_policy_changed_details'|'capture_transcript_policy_changed_details'|'classification_change_policy_details'|'computer_backup_policy_changed_details'|'content_administration_policy_changed_details'|'content_deletion_protection_change_policy_details'|'dash_external_sharing_policy_changed_details'|'data_placement_restriction_change_policy_details'|'data_placement_restriction_satisfy_policy_details'|'device_approvals_add_exception_details'|'device_approvals_change_desktop_policy_details'|'device_approvals_change_mobile_policy_details'|'device_approvals_change_overage_action_details'|'device_approvals_change_unlink_action_details'|'device_approvals_remove_exception_details'|'directory_restrictions_add_members_details'|'directory_restrictions_remove_members_details'|'dropbox_passwords_policy_changed_details'|'email_ingest_policy_changed_details'|'emm_add_exception_details'|'emm_change_policy_details'|'emm_remove_exception_details'|'extended_version_history_change_policy_details'|'external_drive_backup_policy_changed_details'|'file_comments_change_policy_details'|'file_locking_policy_changed_details'|'file_provider_migration_policy_changed_details'|'file_requests_change_policy_details'|'file_requests_emails_enabled_details'|'file_requests_emails_restricted_to_team_only_details'|'file_transfers_policy_changed_details'|'flexible_file_names_policy_changed_details'|'folder_link_restriction_policy_changed_details'|'google_sso_change_policy_details'|'group_user_management_change_policy_details'|'integration_policy_changed_details'|'invite_acceptance_email_policy_changed_details'|'media_hub_adding_people_policy_changed_details'|'media_hub_download_policy_changed_details'|'media_hub_link_sharing_policy_changed_details'|'member_requests_change_policy_details'|'member_send_invite_policy_changed_details'|'member_space_limits_add_exception_details'|'member_space_limits_change_caps_type_policy_details'|'member_space_limits_change_policy_details'|'member_space_limits_remove_exception_details'|'member_suggestions_change_policy_details'|'microsoft_login_change_policy_details'|'microsoft_office_addin_change_policy_details'|'multi_team_identity_policy_changed_details'|'network_control_change_policy_details'|'paper_change_deployment_policy_details'|'paper_change_member_link_policy_details'|'paper_change_member_policy_details'|'paper_change_policy_details'|'paper_default_folder_policy_changed_details'|'paper_desktop_policy_changed_details'|'paper_enabled_users_group_addition_details'|'paper_enabled_users_group_removal_details'|'passkey_login_policy_changed_details'|'password_strength_requirements_change_policy_details'|'permanent_delete_change_policy_details'|'previews_ai_policy_changed_details'|'replay_adding_people_policy_changed_details'|'replay_sharing_policy_changed_details'|'reseller_support_change_policy_details'|'rewind_policy_changed_details'|'send_and_track_policy_changed_details'|'send_external_sharing_policy_changed_details'|'send_for_signature_policy_changed_details'|'shared_link_default_permissions_policy_changed_details'|'sharing_change_folder_join_policy_details'|'sharing_change_link_allow_change_expiration_policy_details'|'sharing_change_link_default_expiration_policy_details'|'sharing_change_link_enforce_password_policy_details'|'sharing_change_link_policy_details'|'sharing_change_member_policy_details'|'showcase_change_download_policy_details'|'showcase_change_enabled_policy_details'|'showcase_change_external_sharing_policy_details'|'sign_external_sharing_policy_changed_details'|'sign_template_creation_permission_changed_details'|'smarter_smart_sync_policy_changed_details'|'smart_sync_change_policy_details'|'smart_sync_not_opt_out_details'|'smart_sync_opt_out_details'|'sso_change_policy_details'|'stack_cross_team_access_policy_changed_details'|'team_branding_policy_changed_details'|'team_extensions_policy_changed_details'|'team_member_storage_request_policy_changed_details'|'team_selective_sync_policy_changed_details'|'team_sharing_whitelist_subjects_changed_details'|'tfa_add_exception_details'|'tfa_change_policy_details'|'tfa_remove_exception_details'|'top_level_content_policy_changed_details'|'two_account_change_policy_details'|'viewer_info_policy_changed_details'|'watermarking_policy_changed_details'|'web_sessions_change_active_session_limit_details'|'web_sessions_change_fixed_length_policy_details'|'web_sessions_change_idle_length_policy_details'|'data_residency_migration_request_successful_details'|'data_residency_migration_request_unsuccessful_details'|'team_merge_from_details'|'team_merge_to_details'|'team_profile_add_background_details'|'team_profile_add_logo_details'|'team_profile_change_background_details'|'team_profile_change_default_language_details'|'team_profile_change_logo_details'|'team_profile_change_name_details'|'team_profile_remove_background_details'|'team_profile_remove_logo_details'|'passkey_add_details'|'passkey_remove_details'|'tfa_add_backup_phone_details'|'tfa_add_security_key_details'|'tfa_change_backup_phone_details'|'tfa_change_status_details'|'tfa_remove_backup_phone_details'|'tfa_remove_security_key_details'|'tfa_reset_details'|'changed_enterprise_admin_role_details'|'changed_enterprise_connected_team_status_details'|'ended_enterprise_admin_session_details'|'ended_enterprise_admin_session_deprecated_details'|'enterprise_settings_locking_details'|'guest_admin_change_status_details'|'started_enterprise_admin_session_details'|'team_merge_request_accepted_details'|'team_merge_request_accepted_shown_to_primary_team_details'|'team_merge_request_accepted_shown_to_secondary_team_details'|'team_merge_request_auto_canceled_details'|'team_merge_request_canceled_details'|'team_merge_request_canceled_shown_to_primary_team_details'|'team_merge_request_canceled_shown_to_secondary_team_details'|'team_merge_request_expired_details'|'team_merge_request_expired_shown_to_primary_team_details'|'team_merge_request_expired_shown_to_secondary_team_details'|'team_merge_request_rejected_shown_to_primary_team_details'|'team_merge_request_rejected_shown_to_secondary_team_details'|'team_merge_request_reminder_details'|'team_merge_request_reminder_shown_to_primary_team_details'|'team_merge_request_reminder_shown_to_secondary_team_details'|'team_merge_request_revoked_details'|'team_merge_request_sent_shown_to_primary_team_details'|'team_merge_request_sent_shown_to_secondary_team_details'|'missing_details'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -12339,7 +12205,7 @@ is only present when needed to discriminate between multiple possible subtypes.
  * overview
  * @property {TeamLogMediaHubFileDownloadedType} [media_hub_file_downloaded] -
  * Available if .tag is media_hub_file_downloaded. (file_operations) Downloaded
- * files in Replay
+ * files in Media Hub
  * @property {TeamLogObjectLabelAddedType} [object_label_added] - Available if
  * .tag is object_label_added. (file_operations) Added a label
  * @property {TeamLogObjectLabelRemovedType} [object_label_removed] - Available
@@ -12504,10 +12370,6 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMemberDeleteProfilePhotoType} [member_delete_profile_photo]
  * - Available if .tag is member_delete_profile_photo. (members) Deleted team
  * member profile photo
- * @property {TeamLogMemberFolderContentsAccessedType}
- * [member_folder_contents_accessed] - Available if .tag is
- * member_folder_contents_accessed. (members) Admin browsed a team member's
- * folder contents
  * @property {TeamLogMemberPermanentlyDeleteAccountContentsType}
  * [member_permanently_delete_account_contents] - Available if .tag is
  * member_permanently_delete_account_contents. (members) Permanently deleted
@@ -12700,45 +12562,10 @@ is only present when needed to discriminate between multiple possible subtypes.
  * password_reset. (passwords) Reset password
  * @property {TeamLogPasswordResetAllType} [password_reset_all] - Available if
  * .tag is password_reset_all. (passwords) Reset all team member passwords
- * @property {TeamLogProtectActionAddCollaboratorType}
- * [protect_action_add_collaborator] - Available if .tag is
- * protect_action_add_collaborator. (protect) Added collaborators via Dropbox
- * Protect
- * @property {TeamLogProtectActionAddLinkType} [protect_action_add_link] -
- * Available if .tag is protect_action_add_link. (protect) Added a link via
- * Dropbox Protect
- * @property {TeamLogProtectActionDeleteType} [protect_action_delete] -
- * Available if .tag is protect_action_delete. (protect) Deleted content via
- * Dropbox Protect
- * @property {TeamLogProtectActionExportType} [protect_action_export] -
- * Available if .tag is protect_action_export. (protect) Exported content via
- * Dropbox Protect
- * @property {TeamLogProtectActionRemoveCollaboratorType}
- * [protect_action_remove_collaborator] - Available if .tag is
- * protect_action_remove_collaborator. (protect) Removed collaborators via
- * Dropbox Protect
- * @property {TeamLogProtectActionRemoveLinkType} [protect_action_remove_link] -
- * Available if .tag is protect_action_remove_link. (protect) Removed a link via
- * Dropbox Protect
- * @property {TeamLogProtectActionStopSharingType} [protect_action_stop_sharing]
- * - Available if .tag is protect_action_stop_sharing. (protect) Stopped sharing
- * content via Dropbox Protect
  * @property {TeamLogProtectInternalDomainsChangedType}
  * [protect_internal_domains_changed] - Available if .tag is
  * protect_internal_domains_changed. (protect) Modified Protect internal domains
  * list
- * @property {TeamLogProtectPolicyActivatedType} [protect_policy_activated] -
- * Available if .tag is protect_policy_activated. (protect) Activated a Dropbox
- * Protect policy
- * @property {TeamLogProtectPolicyDeactivatedType} [protect_policy_deactivated]
- * - Available if .tag is protect_policy_deactivated. (protect) Deactivated a
- * Dropbox Protect policy
- * @property {TeamLogProtectPolicyScheduledType} [protect_policy_scheduled] -
- * Available if .tag is protect_policy_scheduled. (protect) Scheduled a Dropbox
- * Protect policy
- * @property {TeamLogProtectPolicyUpdatedType} [protect_policy_updated] -
- * Available if .tag is protect_policy_updated. (protect) Updated a Dropbox
- * Protect policy
  * @property {TeamLogClassificationCreateReportType}
  * [classification_create_report] - Available if .tag is
  * classification_create_report. (reports) Created Classification report
@@ -12864,28 +12691,29 @@ is only present when needed to discriminate between multiple possible subtypes.
  * file_transfers_transfer_view. (sharing) Viewed transfer
  * @property {TeamLogMediaHubProjectTeamAddType} [media_hub_project_team_add] -
  * Available if .tag is media_hub_project_team_add. (sharing) Added member to
- * Replay project
+ * Media Hub project
  * @property {TeamLogMediaHubProjectTeamDeleteType}
  * [media_hub_project_team_delete] - Available if .tag is
- * media_hub_project_team_delete. (sharing) Removed member from Replay project
+ * media_hub_project_team_delete. (sharing) Removed member from Media Hub
+ * project
  * @property {TeamLogMediaHubProjectTeamRoleChangedType}
  * [media_hub_project_team_role_changed] - Available if .tag is
- * media_hub_project_team_role_changed. (sharing) Changed member role in Replay
- * project
+ * media_hub_project_team_role_changed. (sharing) Changed member role in Media
+ * Hub project
  * @property {TeamLogMediaHubSharedLinkAudienceChangedType}
  * [media_hub_shared_link_audience_changed] - Available if .tag is
- * media_hub_shared_link_audience_changed. (sharing) Changed Replay shared link
- * audience
+ * media_hub_shared_link_audience_changed. (sharing) Changed Media Hub shared
+ * link audience
  * @property {TeamLogMediaHubSharedLinkCreatedType}
  * [media_hub_shared_link_created] - Available if .tag is
- * media_hub_shared_link_created. (sharing) Created Replay shared link
+ * media_hub_shared_link_created. (sharing) Created Media Hub shared link
  * @property {TeamLogMediaHubSharedLinkDownloadSettingChangedType}
  * [media_hub_shared_link_download_setting_changed] - Available if .tag is
- * media_hub_shared_link_download_setting_changed. (sharing) Changed Replay
+ * media_hub_shared_link_download_setting_changed. (sharing) Changed Media Hub
  * shared link download setting
  * @property {TeamLogMediaHubSharedLinkRevokedType}
  * [media_hub_shared_link_revoked] - Available if .tag is
- * media_hub_shared_link_revoked. (sharing) Revoked Replay shared link
+ * media_hub_shared_link_revoked. (sharing) Revoked Media Hub shared link
  * @property {TeamLogNoteAclInviteOnlyType} [note_acl_invite_only] - Available
  * if .tag is note_acl_invite_only. (sharing) Changed Paper doc to invite-only
  * (deprecated, no longer logged)
@@ -13488,15 +13316,15 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMediaHubAddingPeoplePolicyChangedType}
  * [media_hub_adding_people_policy_changed] - Available if .tag is
  * media_hub_adding_people_policy_changed. (team_policies) Changed the policy
- * for adding people to Replay content
+ * for adding people to Media Hub content
  * @property {TeamLogMediaHubDownloadPolicyChangedType}
  * [media_hub_download_policy_changed] - Available if .tag is
  * media_hub_download_policy_changed. (team_policies) Changed the policy for
- * downloading Replay content
+ * downloading Media Hub content
  * @property {TeamLogMediaHubLinkSharingPolicyChangedType}
  * [media_hub_link_sharing_policy_changed] - Available if .tag is
  * media_hub_link_sharing_policy_changed. (team_policies) Changed the policy for
- * sharing Replay content
+ * sharing Media Hub content
  * @property {TeamLogMemberRequestsChangePolicyType}
  * [member_requests_change_policy] - Available if .tag is
  * member_requests_change_policy. (team_policies) Changed whether users can find
@@ -13897,13 +13725,13 @@ is only present when needed to discriminate between multiple possible subtypes.
  * [team_merge_request_sent_shown_to_secondary_team] - Available if .tag is
  * team_merge_request_sent_shown_to_secondary_team. (trusted_teams) Requested to
  * merge your team into another Dropbox team
- * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_folder_contents_accessed'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_action_add_collaborator'|'protect_action_add_link'|'protect_action_delete'|'protect_action_export'|'protect_action_remove_collaborator'|'protect_action_remove_link'|'protect_action_stop_sharing'|'protect_internal_domains_changed'|'protect_policy_activated'|'protect_policy_deactivated'|'protect_policy_scheduled'|'protect_policy_updated'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_internal_domains_changed'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
  * The type of the event.
  * @typedef {Object} TeamLogEventTypeArg
- * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_folder_contents_accessed'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_action_add_collaborator'|'protect_action_add_link'|'protect_action_delete'|'protect_action_export'|'protect_action_remove_collaborator'|'protect_action_remove_link'|'protect_action_stop_sharing'|'protect_internal_domains_changed'|'protect_policy_activated'|'protect_policy_deactivated'|'protect_policy_scheduled'|'protect_policy_updated'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_internal_domains_changed'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -15593,7 +15421,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for adding people to Replay content.
+ * Changed the policy for adding people to Media Hub content.
  * @typedef {Object} TeamLogMediaHubAddingPeoplePolicyChangedDetails
  * @property {TeamLogMediaHubAddingPeoplePolicy} new_value - To.
  * @property {TeamLogMediaHubAddingPeoplePolicy} previous_value - From.
@@ -15611,7 +15439,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for downloading Replay content.
+ * Changed the policy for downloading Media Hub content.
  * @typedef {Object} TeamLogMediaHubDownloadPolicyChangedDetails
  * @property {TeamLogMediaHubDownloadPolicy} new_value - To.
  * @property {TeamLogMediaHubDownloadPolicy} previous_value - From.
@@ -15623,7 +15451,7 @@ possible subtypes.
  */
 
 /**
- * Downloaded files in Replay.
+ * Downloaded files in Media Hub.
  * @typedef {Object} TeamLogMediaHubFileDownloadedDetails
  */
 
@@ -15639,7 +15467,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for sharing Replay content.
+ * Changed the policy for sharing Media Hub content.
  * @typedef {Object} TeamLogMediaHubLinkSharingPolicyChangedDetails
  * @property {TeamLogMediaHubLinkSharingPolicy} new_value - To.
  * @property {TeamLogMediaHubLinkSharingPolicy} previous_value - From.
@@ -15651,22 +15479,14 @@ possible subtypes.
  */
 
 /**
- * Replay project
- * @typedef {Object} TeamLogMediaHubProjectLogInfo
- * @property {string} project_name - Replay project name.
- * @property {string} [project_id] - Replay project ID.
- */
-
-/**
  * Media Hub project role
  * @typedef {Object} TeamLogMediaHubProjectRole
  * @property {('editor'|'owner'|'reviewer'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
- * Added member to Replay project.
+ * Added member to Media Hub project.
  * @typedef {Object} TeamLogMediaHubProjectTeamAddDetails
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15675,9 +15495,8 @@ possible subtypes.
  */
 
 /**
- * Removed member from Replay project.
+ * Removed member from Media Hub project.
  * @typedef {Object} TeamLogMediaHubProjectTeamDeleteDetails
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15686,12 +15505,11 @@ possible subtypes.
  */
 
 /**
- * Changed member role in Replay project.
+ * Changed member role in Media Hub project.
  * @typedef {Object} TeamLogMediaHubProjectTeamRoleChangedDetails
  * @property {TeamLogMediaHubProjectRole} previous_role - Previous Media Hub
  * project role.
  * @property {TeamLogMediaHubProjectRole} new_role - New Media Hub project role.
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15706,7 +15524,7 @@ possible subtypes.
  */
 
 /**
- * Changed Replay shared link audience.
+ * Changed Media Hub shared link audience.
  * @typedef {Object} TeamLogMediaHubSharedLinkAudienceChangedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
@@ -15714,7 +15532,6 @@ possible subtypes.
  * Hub shared link audience.
  * @property {TeamLogMediaHubSharedLinkAudience} new_value - New Media Hub
  * shared link audience.
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15723,13 +15540,12 @@ possible subtypes.
  */
 
 /**
- * Created Replay shared link.
+ * Created Media Hub shared link.
  * @typedef {Object} TeamLogMediaHubSharedLinkCreatedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
  * @property {TeamLogMediaHubSharedLinkAudience} audience - Media Hub shared
  * link audience.
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15744,7 +15560,7 @@ possible subtypes.
  */
 
 /**
- * Changed Replay shared link download setting.
+ * Changed Media Hub shared link download setting.
  * @typedef {Object} TeamLogMediaHubSharedLinkDownloadSettingChangedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
@@ -15752,7 +15568,6 @@ possible subtypes.
  * Previous Media Hub shared link download setting.
  * @property {TeamLogMediaHubSharedLinkDownloadSetting} new_value - New Media
  * Hub shared link download setting.
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15761,11 +15576,10 @@ possible subtypes.
  */
 
 /**
- * Revoked Replay shared link.
+ * Revoked Media Hub shared link.
  * @typedef {Object} TeamLogMediaHubSharedLinkRevokedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
- * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15939,16 +15753,6 @@ possible subtypes.
 
 /**
  * @typedef {Object} TeamLogMemberDeleteProfilePhotoType
- * @property {string} description
- */
-
-/**
- * Admin browsed a team member's folder contents.
- * @typedef {Object} TeamLogMemberFolderContentsAccessedDetails
- */
-
-/**
- * @typedef {Object} TeamLogMemberFolderContentsAccessedType
  * @property {string} description
  */
 
@@ -17390,83 +17194,6 @@ subtypes.
  */
 
 /**
- * Added collaborators via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionAddCollaboratorDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionAddCollaboratorType
- * @property {string} description
- */
-
-/**
- * Added a link via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionAddLinkDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionAddLinkType
- * @property {string} description
- */
-
-/**
- * Deleted content via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionDeleteDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionDeleteType
- * @property {string} description
- */
-
-/**
- * Exported content via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionExportDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionExportType
- * @property {string} description
- */
-
-/**
- * Removed collaborators via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionRemoveCollaboratorDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionRemoveCollaboratorType
- * @property {string} description
- */
-
-/**
- * Removed a link via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionRemoveLinkDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionRemoveLinkType
- * @property {string} description
- */
-
-/**
- * Stopped sharing content via Dropbox Protect.
- * @typedef {Object} TeamLogProtectActionStopSharingDetails
- * @property {string} action_id - Action ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectActionStopSharingType
- * @property {string} description
- */
-
-/**
  * Modified Protect internal domains list.
  * @typedef {Object} TeamLogProtectInternalDomainsChangedDetails
  * @property {Array.<string>} [domains_added] - Domains added to the internal
@@ -17477,50 +17204,6 @@ subtypes.
 
 /**
  * @typedef {Object} TeamLogProtectInternalDomainsChangedType
- * @property {string} description
- */
-
-/**
- * Activated a Dropbox Protect policy.
- * @typedef {Object} TeamLogProtectPolicyActivatedDetails
- * @property {string} policy_id - Policy ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectPolicyActivatedType
- * @property {string} description
- */
-
-/**
- * Deactivated a Dropbox Protect policy.
- * @typedef {Object} TeamLogProtectPolicyDeactivatedDetails
- * @property {string} policy_id - Policy ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectPolicyDeactivatedType
- * @property {string} description
- */
-
-/**
- * Scheduled a Dropbox Protect policy.
- * @typedef {Object} TeamLogProtectPolicyScheduledDetails
- * @property {string} policy_id - Policy ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectPolicyScheduledType
- * @property {string} description
- */
-
-/**
- * Updated a Dropbox Protect policy.
- * @typedef {Object} TeamLogProtectPolicyUpdatedDetails
- * @property {string} policy_id - Policy ID.
- */
-
-/**
- * @typedef {Object} TeamLogProtectPolicyUpdatedType
  * @property {string} description
  */
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -3293,24 +3293,40 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
+ * Reason a transcript job failed. Returned in the `failed` variant of
+ * `GetTranscriptAsyncCheckResult`. This is a semantic error union: the HTTP
+ * status of the poll request itself is unaffected (a poll that surfaces a
+ * failed job is still a normal successful poll response). Callers should branch
+ * on the variant.
  * @typedef {Object} RivieraContentApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error.
- * @property {string} [user_error] - Available if .tag is user_error.
+ * @property {string} [server_error] - Available if .tag is server_error. An
+ * unexpected, typically transient, server-side failure. The string is a
+ * human-readable message; retrying with backoff may succeed.
+ * @property {string} [user_error] - Available if .tag is user_error. The
+ * request could not be processed as supplied (a problem with the caller's
+ * input). The string is a human-readable message; retrying the same request
+ * will not help.
  * @property {RivieraMediaDurationError} [media_duration_error] - Available if
  * .tag is media_duration_error.
  * @property {('server_error'|'user_error'|'media_duration_error'|'no_audio_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
- * @typedef {Object} RivieraErrorCode
- * @property {('unknown_error'|'bad_request'|'api_error'|'access_error'|'ratelimit_error'|'unavailable'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
  * @typedef {Object} RivieraFileIdOrUrl
- * @property {string} [file_id] - Available if .tag is file_id.
- * @property {string} [url] - Available if .tag is url.
- * @property {string} [path] - Available if .tag is path.
+ * @property {string} [file_id] - Available if .tag is file_id. A Dropbox-issued
+ * file id (format: "id:<id>") for a file the authenticated user has access to.
+ * @property {string} [url] - Available if .tag is url. Either a Dropbox shared
+ * link (www.dropbox.com) or an external HTTP or HTTPS URL pointing to a
+ * supported file. - Dropbox shared links are resolved internally using the
+ * caller's authenticated identity and the link's visibility / download
+ * settings. They therefore require an authenticated user context (anonymous
+ * `url` requests against Dropbox links are rejected with an `access_error`).
+ * Links protected by a password are rejected with
+ * `shared_link_password_protected`; links with downloads disabled are rejected
+ * with `link_download_disabled_error`. - External URLs are fetched through the
+ * backend's egress proxy and must point at a supported file extension.
+ * @property {string} [path] - Available if .tag is path. An absolute Dropbox
+ * path, e.g. "/folder/example.pdf".
  * @property {('file_id'|'url'|'path'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3320,20 +3336,10 @@ only present when needed to discriminate between multiple possible subtypes.
  * the document to convert to markdown.
  * @typedef {Object} RivieraGetMarkdownArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the document
- * to convert. Callers must set exactly one of the oneof variants: - file_id: a
- * Dropbox-issued file id (format: "id:<id>") for a file the authenticated user
- * has access to. - path: an absolute Dropbox path, e.g. "/folder/report.docx".
- * - url: either a Dropbox shared link (www.dropbox.com) or an external HTTPS
- * URL pointing to a supported document file. - Dropbox shared links are
- * resolved internally using the caller's authenticated identity and the link's
- * visibility / download settings. They therefore require an authenticated user
- * context (anonymous `url` requests against Dropbox links are rejected with an
- * `ACCESS_ERROR`). Links protected by a password are rejected with
- * `shared_link_password_protected`; links with downloads disabled are rejected
- * with `link_download_disabled_error`. - External URLs are fetched over HTTPS
- * through the backend's egress proxy and must point at a supported document
- * file extension. The referenced file must be a document in a supported format;
- * requests against unsupported formats return `unsupported_format_error`.
+ * to convert. Callers must set exactly one of the `FileIdOrUrl` variants. The
+ * referenced file must be a document in a supported format (see the route
+ * description for the list); requests against unsupported formats return
+ * `unsupported_format_error`.
  * @property {boolean} enable_ocr - Enable OCR for PDF documents. Processing is
  * slower when enabled.
  * @property {boolean} embed_images - When true, embed images as base64 data
@@ -3345,15 +3351,9 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetMarkdownAsyncCheckResult
  * @property {RivieraGetMarkdownResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraGetMarkdownAsyncError} [failed] - Available if .tag is
- * failed.
+ * @property {RivieraMarkdownConversionApiV2Error} [failed] - Available if .tag
+ * is failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * @typedef {Object} RivieraGetMarkdownAsyncError
- * @property {RivieraErrorCode} error_code
- * @property {RivieraMarkdownConversionApiV2Error} [error_details]
  */
 
 /**
@@ -3367,23 +3367,12 @@ only present when needed to discriminate between multiple possible subtypes.
  * the file whose metadata should be extracted.
  * @typedef {Object} RivieraGetMetadataArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the file to
- * extract metadata from. Callers must set exactly one of the oneof variants: -
- * file_id: a Dropbox-issued file id (format: "id:<id>") for a file the
- * authenticated user has access to. - path: an absolute Dropbox path, e.g.
- * "/folder/photo.jpg". - url: either a Dropbox shared link (www.dropbox.com) or
- * an external HTTPS URL pointing to a supported file. - Dropbox shared links
- * are resolved internally using the caller's authenticated identity and the
- * link's visibility / download settings. They therefore require an
- * authenticated user context (anonymous `url` requests against Dropbox links
- * are rejected with an `ACCESS_ERROR`). Links protected by a password are
- * rejected with `shared_link_password_protected`; links with downloads disabled
- * are rejected with `link_download_disabled_error`. - External URLs are fetched
- * over HTTPS through the backend's egress proxy and must point at a supported
- * file extension. The kind of metadata returned is determined by the file type:
- * image files return EXIF metadata, audio/video files return media metadata,
- * PDFs return PDF metadata, and MS Office documents (docx, pptx, xlsx) return
- * Office metadata. Requests against unsupported formats return
- * `unsupported_format_error`.
+ * extract metadata from. Callers must set exactly one of the `FileIdOrUrl`
+ * variants. The kind of metadata returned is determined by the file type: image
+ * files return EXIF metadata, audio/video files return media metadata, PDFs
+ * return PDF metadata, and MS Office documents (docx, pptx, xlsx) return Office
+ * metadata. See the route description for the supported formats. Requests
+ * against unsupported formats return `unsupported_format_error`.
  */
 
 /**
@@ -3391,15 +3380,9 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetMetadataAsyncCheckResult
  * @property {RivieraGetMetadataResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraGetMetadataAsyncError} [failed] - Available if .tag is
- * failed.
+ * @property {RivieraMetadataExtractionApiV2Error} [failed] - Available if .tag
+ * is failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * @typedef {Object} RivieraGetMetadataAsyncError
- * @property {RivieraErrorCode} error_code
- * @property {RivieraMetadataExtractionApiV2Error} [error_details]
  */
 
 /**
@@ -3411,32 +3394,52 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
+ * Arguments for the asynchronous `get_text_async` route. Exactly one of
+ * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to identify
+ * the document whose plain-text content should be extracted.
+ * @typedef {Object} RivieraGetTextArgs
+ * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the document
+ * to extract text from. Callers must set exactly one of the `FileIdOrUrl`
+ * variants. Text extraction is supported for common document formats (Word,
+ * PowerPoint, Excel, PDF, RTF, and Dropbox document types); see the route
+ * description for the supported formats. Requests against unsupported formats
+ * return `unsupported_format_error`. NOTE: for the `url` variant, only Dropbox
+ * shared links (www.dropbox.com) are supported. External (non-Dropbox) URLs are
+ * not supported and return `unsupported_format_error`; import the file into
+ * Dropbox and reference it by `file_id` or `path` instead.
+ */
+
+/**
+ * Result type for EventBus async check - must end in "CheckResult"
+ * @typedef {Object} RivieraGetTextAsyncCheckResult
+ * @property {RivieraGetTextResult} [complete] - Available if .tag is complete.
+ * @property {RivieraTextExtractionApiV2Error} [failed] - Available if .tag is
+ * failed.
+ * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * @typedef {Object} RivieraGetTextResult
+ * @property {string} text - The plain-text content extracted from the document.
+ * For multi-page documents the text is concatenated in document order. May be
+ * empty when no text is detected in the source.
+ */
+
+/**
  * Arguments for the asynchronous `get_transcript_async` route. Exactly one of
  * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to identify
  * the audio or video asset to transcribe.
  * @typedef {Object} RivieraGetTranscriptArgs
  * @property {RivieraFileIdOrUrl} [file_id_or_url] - Identifier of the media
- * asset to transcribe. Callers must set exactly one of the oneof variants: -
- * file_id: a Dropbox-issued file id (format: "id:<id>") for a file the
- * authenticated user has access to. - path: an absolute Dropbox path, e.g.
- * "/folder/recording.mp4". - url: either a Dropbox shared link
- * (www.dropbox.com) or an external HTTPS URL pointing to a supported
- * audio/video file. - Dropbox shared links are resolved internally using the
- * caller's authenticated identity and the link's visibility / download
- * settings. They therefore require an authenticated user context (anonymous
- * `url` requests against Dropbox links are rejected with an `ACCESS_ERROR`).
- * Links protected by a password are rejected with
- * `shared_link_password_protected`; links with downloads disabled are rejected
- * with `link_download_disabled_error`. - External URLs are fetched over HTTPS
- * through the backend's egress proxy and must point at a supported audio/video
- * file extension. The referenced asset must be an audio or video file in a
- * supported format; requests against files with no audio track return a
- * `no_audio_error`.
+ * asset to transcribe. Callers must set exactly one of the `FileIdOrUrl`
+ * variants. The referenced asset must be an audio or video file in a supported
+ * format (see the route description for the list); requests against files with
+ * no audio track return a `no_audio_error`.
  * @property {RivieraTimestampLevel} timestamp_level - Granularity of the time
- * offsets returned for each transcript segment. Defaults to `SENTENCE. -
- * SENTENCE: one segment per spoken sentence (recommended). - WORD: one segment
- * per word, useful for fine-grained alignment such as captioning or
- * highlight-as-you-listen experiences.
+ * offsets returned for each transcript segment. Defaults to `SENTENCE` when the
+ * field is omitted. - SENTENCE: one segment per spoken sentence (recommended).
+ * - WORD: one segment per word, useful for fine-grained alignment such as
+ * captioning or highlight-as-you-listen experiences.
  * @property {string} included_special_words - Comma-delimited list of
  * non-lexical filler words to preserve in the transcript output, e.g. `"uh, ah,
  * uhm"`. By default these fillers are stripped. Unrecognized tokens are
@@ -3453,15 +3456,8 @@ only present when needed to discriminate between multiple possible subtypes.
  * @typedef {Object} RivieraGetTranscriptAsyncCheckResult
  * @property {RivieraGetTranscriptResult} [complete] - Available if .tag is
  * complete.
- * @property {RivieraGetTranscriptAsyncError} [failed] - Available if .tag is
- * failed.
+ * @property {RivieraContentApiV2Error} [failed] - Available if .tag is failed.
  * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
- */
-
-/**
- * @typedef {Object} RivieraGetTranscriptAsyncError
- * @property {RivieraErrorCode} error_code
- * @property {RivieraContentApiV2Error} [error_details]
  */
 
 /**
@@ -3473,9 +3469,19 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
+ * Reason a markdown conversion job failed. Returned in the `failed` variant of
+ * `GetMarkdownAsyncCheckResult`. This is a semantic error union: the HTTP
+ * status of the poll request itself is unaffected (a poll that surfaces a
+ * failed job is still a normal successful poll response). Callers should branch
+ * on the variant.
  * @typedef {Object} RivieraMarkdownConversionApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error.
- * @property {string} [user_error] - Available if .tag is user_error.
+ * @property {string} [server_error] - Available if .tag is server_error. An
+ * unexpected, typically transient, server-side failure. The string is a
+ * human-readable message; retrying with backoff may succeed.
+ * @property {string} [user_error] - Available if .tag is user_error. The
+ * request could not be processed as supplied (a problem with the caller's
+ * input). The string is a human-readable message; retrying the same request
+ * will not help.
  * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3485,9 +3491,19 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
+ * Reason a metadata extraction job failed. Returned in the `failed` variant of
+ * `GetMetadataAsyncCheckResult`. This is a semantic error union: the HTTP
+ * status of the poll request itself is unaffected (a poll that surfaces a
+ * failed job is still a normal successful poll response). Callers should branch
+ * on the variant.
  * @typedef {Object} RivieraMetadataExtractionApiV2Error
- * @property {string} [server_error] - Available if .tag is server_error.
- * @property {string} [user_error] - Available if .tag is user_error.
+ * @property {string} [server_error] - Available if .tag is server_error. An
+ * unexpected, typically transient, server-side failure. The string is a
+ * human-readable message; retrying with backoff may succeed.
+ * @property {string} [user_error] - Available if .tag is user_error. The
+ * request could not be processed as supplied (a problem with the caller's
+ * input). The string is a human-readable message; retrying the same request
+ * will not help.
  * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
  */
 
@@ -3505,8 +3521,25 @@ only present when needed to discriminate between multiple possible subtypes.
  */
 
 /**
+ * Reason a text extraction job failed. Returned in the `failed` variant of
+ * `GetTextAsyncCheckResult`. This is a semantic error union: the HTTP status of
+ * the poll request itself is unaffected (a poll that surfaces a failed job is
+ * still a normal successful poll response). Callers should branch on the
+ * variant.
+ * @typedef {Object} RivieraTextExtractionApiV2Error
+ * @property {string} [server_error] - Available if .tag is server_error. An
+ * unexpected, typically transient, server-side failure. The string is a
+ * human-readable message; retrying with backoff may succeed.
+ * @property {string} [user_error] - Available if .tag is user_error. The
+ * request could not be processed as supplied (a problem with the caller's
+ * input). The string is a human-readable message; retrying the same request
+ * will not help.
+ * @property {('server_error'|'user_error'|'unsupported_format_error'|'link_download_disabled_error'|'shared_link_password_protected'|'limit_exceeded_error'|'conversion_failure_error'|'not_found_error'|'is_a_folder_error'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
  * @typedef {Object} RivieraTimestampLevel
- * @property {('unknown'|'sentence'|'word'|'other')} .tag - Tag identifying the union variant.
+ * @property {('sentence'|'word'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -5146,7 +5179,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * `link_access_level` field of `LinkPermissions`. This is used in conjunction
  * with team policies and shared folder policies to determine the final
  * effective audience type in the `effective_audience` field of
- * `LinkPermissions.
+ * `LinkPermissions`.
  * @property {SharingRequestedLinkAccessLevel} [access] - Requested access level
  * you want the audience to gain from this link. Note, modifying access level
  * for an existing link is not supported.
@@ -5507,6 +5540,73 @@ only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
  * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * Launches one action-specific bulk suspend job.
+ * @typedef {Object} TeamBulkSuspendArg
+ * @property {Array.<TeamBulkSuspendMemberTarget>} members - Must contain
+ * between 1 and 500 targets. The launch handler also rejects duplicate client
+ * item IDs and duplicate member selectors.
+ */
+
+/**
+ * @typedef {Object} TeamBulkSuspendComplete
+ * @property {number} requested
+ * @property {number} suspended
+ * @property {number} failed
+ * @property {number} unknown
+ * @property {TeamBulkSuspendReportDeliveryStatus} report_delivery
+ */
+
+/**
+ * A typed launch rejection. Authorization failures continue to use the API v2
+ * authentication/permission error surface.
+ * @typedef {Object} TeamBulkSuspendError
+ * @property {('invalid_request'|'too_many_members'|'duplicate_client_item_id'|'duplicate_team_member_id'|'acting_admin'|'last_admin'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * Coarse job state. Live row progress and report contents are intentionally
+ * omitted; callers receive row details in the terminal email report.
+ * @typedef {Object} TeamBulkSuspendJobStatus
+ * @property {TeamBulkSuspendComplete} [complete] - Available if .tag is
+ * complete.
+ * @property {TeamBulkSuspendTaskFailure} [failed] - Available if .tag is
+ * failed.
+ * @property {('in_progress'|'complete'|'failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * One member selected for suspension. The opaque client item ID correlates the
+ * eventual report row with the caller's input without sending CSV data.
+ * @typedef {Object} TeamBulkSuspendMemberTarget
+ * @property {string} client_item_id
+ * @property {TeamMembersDeactivateArg} suspend_arg
+ */
+
+/**
+ * @typedef {Object} TeamBulkSuspendReportDeliveryStatus
+ * @property {('bulk_suspend_report_delivery_status_unspecified'|'bulk_suspend_report_delivery_status_pending'|'bulk_suspend_report_delivery_status_delivered'|'bulk_suspend_report_delivery_status_failed'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * Stable machine-readable reasons used by the terminal row report.
+ * @typedef {Object} TeamBulkSuspendRowFailure
+ * @property {('user_not_found'|'user_not_in_team'|'other'|'suspend_inactive_user'|'suspend_last_admin'|'team_license_limit'|'protected_acting_admin'|'permission_changed'|'suspend_failed')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * The terminal outcome for one requested member. Row outcomes are delivered in
+ * the report rather than embedded in the status response.
+ * @typedef {Object} TeamBulkSuspendRowOutcome
+ * @property {TeamBulkSuspendRowFailure} [failed] - Available if .tag is failed.
+ * @property {('suspended'|'failed'|'unknown'|'other')} .tag - Tag identifying the union variant.
+ */
+
+/**
+ * @typedef {Object} TeamBulkSuspendTaskFailure
+ * @property {('unusable_result'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -7381,7 +7481,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * .tag is status_error.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
- * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
+ * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other'|'folder_count_limit_exceeded')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -7548,7 +7648,7 @@ only present when needed to discriminate between multiple possible subtypes.
  * .tag is status_error.
  * @property {TeamTeamFolderTeamSharedDropboxError} [team_shared_dropbox_error]
  * - Available if .tag is team_shared_dropbox_error.
- * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other')} .tag - Tag identifying the union variant.
+ * @property {('access_error'|'status_error'|'team_shared_dropbox_error'|'other'|'folder_count_limit_exceeded')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -10624,6 +10724,9 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMemberDeleteProfilePhotoDetails}
  * [member_delete_profile_photo_details] - Available if .tag is
  * member_delete_profile_photo_details.
+ * @property {TeamLogMemberFolderContentsAccessedDetails}
+ * [member_folder_contents_accessed_details] - Available if .tag is
+ * member_folder_contents_accessed_details.
  * @property {TeamLogMemberPermanentlyDeleteAccountContentsDetails}
  * [member_permanently_delete_account_contents_details] - Available if .tag is
  * member_permanently_delete_account_contents_details.
@@ -10796,9 +10899,40 @@ is only present when needed to discriminate between multiple possible subtypes.
  * if .tag is password_reset_details.
  * @property {TeamLogPasswordResetAllDetails} [password_reset_all_details] -
  * Available if .tag is password_reset_all_details.
+ * @property {TeamLogProtectActionAddCollaboratorDetails}
+ * [protect_action_add_collaborator_details] - Available if .tag is
+ * protect_action_add_collaborator_details.
+ * @property {TeamLogProtectActionAddLinkDetails}
+ * [protect_action_add_link_details] - Available if .tag is
+ * protect_action_add_link_details.
+ * @property {TeamLogProtectActionDeleteDetails} [protect_action_delete_details]
+ * - Available if .tag is protect_action_delete_details.
+ * @property {TeamLogProtectActionExportDetails} [protect_action_export_details]
+ * - Available if .tag is protect_action_export_details.
+ * @property {TeamLogProtectActionRemoveCollaboratorDetails}
+ * [protect_action_remove_collaborator_details] - Available if .tag is
+ * protect_action_remove_collaborator_details.
+ * @property {TeamLogProtectActionRemoveLinkDetails}
+ * [protect_action_remove_link_details] - Available if .tag is
+ * protect_action_remove_link_details.
+ * @property {TeamLogProtectActionStopSharingDetails}
+ * [protect_action_stop_sharing_details] - Available if .tag is
+ * protect_action_stop_sharing_details.
  * @property {TeamLogProtectInternalDomainsChangedDetails}
  * [protect_internal_domains_changed_details] - Available if .tag is
  * protect_internal_domains_changed_details.
+ * @property {TeamLogProtectPolicyActivatedDetails}
+ * [protect_policy_activated_details] - Available if .tag is
+ * protect_policy_activated_details.
+ * @property {TeamLogProtectPolicyDeactivatedDetails}
+ * [protect_policy_deactivated_details] - Available if .tag is
+ * protect_policy_deactivated_details.
+ * @property {TeamLogProtectPolicyScheduledDetails}
+ * [protect_policy_scheduled_details] - Available if .tag is
+ * protect_policy_scheduled_details.
+ * @property {TeamLogProtectPolicyUpdatedDetails}
+ * [protect_policy_updated_details] - Available if .tag is
+ * protect_policy_updated_details.
  * @property {TeamLogClassificationCreateReportDetails}
  * [classification_create_report_details] - Available if .tag is
  * classification_create_report_details.
@@ -11746,7 +11880,7 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMissingDetails} [missing_details] - Available if .tag is
  * missing_details. Hints that this event was returned with missing details due
  * to an internal error.
- * @property {('admin_alerting_alert_state_changed_details'|'admin_alerting_changed_alert_config_details'|'admin_alerting_triggered_alert_details'|'ransomware_restore_process_completed_details'|'ransomware_restore_process_started_details'|'app_blocked_by_permissions_details'|'app_link_team_details'|'app_link_user_details'|'app_unlink_team_details'|'app_unlink_user_details'|'integration_connected_details'|'integration_disconnected_details'|'file_add_comment_details'|'file_change_comment_subscription_details'|'file_delete_comment_details'|'file_edit_comment_details'|'file_like_comment_details'|'file_resolve_comment_details'|'file_unlike_comment_details'|'file_unresolve_comment_details'|'dash_added_comment_to_stack_details'|'dash_added_connector_details'|'dash_added_link_to_stack_details'|'dash_added_team_email_domain_allowlist_details'|'dash_admin_added_org_wide_connector_details'|'dash_admin_disabled_connector_details'|'dash_admin_enabled_connector_details'|'dash_admin_removed_org_wide_connector_details'|'dash_archived_stack_details'|'dash_changed_audience_of_shared_link_to_stack_details'|'dash_cloned_stack_details'|'dash_connector_tools_call_details'|'dash_created_stack_details'|'dash_deleted_comment_from_stack_details'|'dash_deleted_stack_details'|'dash_edited_comment_in_stack_details'|'dash_external_user_opened_stack_details'|'dash_first_launched_desktop_details'|'dash_first_launched_extension_details'|'dash_first_launched_web_start_page_details'|'dash_opened_shared_link_to_stack_details'|'dash_opened_stack_details'|'dash_preview_opt_out_status_changed_details'|'dash_removed_connector_details'|'dash_removed_link_from_stack_details'|'dash_removed_shared_link_to_stack_details'|'dash_removed_team_email_domain_allowlist_details'|'dash_renamed_stack_details'|'dash_shared_link_to_stack_details'|'dash_unarchived_stack_details'|'dash_viewed_company_stack_details'|'dash_viewed_external_ai_activity_report_details'|'governance_policy_add_folders_details'|'governance_policy_add_folder_failed_details'|'governance_policy_content_disposed_details'|'governance_policy_create_details'|'governance_policy_delete_details'|'governance_policy_edit_details_details'|'governance_policy_edit_duration_details'|'governance_policy_export_created_details'|'governance_policy_export_removed_details'|'governance_policy_remove_folders_details'|'governance_policy_report_created_details'|'governance_policy_zip_part_downloaded_details'|'legal_holds_activate_a_hold_details'|'legal_holds_add_members_details'|'legal_holds_change_hold_details_details'|'legal_holds_change_hold_name_details'|'legal_holds_export_a_hold_details'|'legal_holds_export_cancelled_details'|'legal_holds_export_downloaded_details'|'legal_holds_export_removed_details'|'legal_holds_release_a_hold_details'|'legal_holds_remove_members_details'|'legal_holds_report_a_hold_details'|'device_change_ip_desktop_details'|'device_change_ip_mobile_details'|'device_change_ip_web_details'|'device_delete_on_unlink_fail_details'|'device_delete_on_unlink_success_details'|'device_link_fail_details'|'device_link_success_details'|'device_management_disabled_details'|'device_management_enabled_details'|'device_sync_backup_status_changed_details'|'device_unlink_details'|'dropbox_passwords_exported_details'|'dropbox_passwords_new_device_enrolled_details'|'emm_refresh_auth_token_details'|'external_drive_backup_eligibility_status_checked_details'|'external_drive_backup_status_changed_details'|'account_capture_change_availability_details'|'account_capture_migrate_account_details'|'account_capture_notification_emails_sent_details'|'account_capture_relinquish_account_details'|'disabled_domain_invites_details'|'domain_invites_approve_request_to_join_team_details'|'domain_invites_decline_request_to_join_team_details'|'domain_invites_email_existing_users_details'|'domain_invites_request_to_join_team_details'|'domain_invites_set_invite_new_user_pref_to_no_details'|'domain_invites_set_invite_new_user_pref_to_yes_details'|'domain_verification_add_domain_fail_details'|'domain_verification_add_domain_success_details'|'domain_verification_remove_domain_details'|'enabled_domain_invites_details'|'encrypted_folder_cancel_team_key_rotation_details'|'encrypted_folder_enroll_backup_key_details'|'encrypted_folder_enroll_client_details'|'encrypted_folder_enroll_team_details'|'encrypted_folder_finish_team_unenrollment_details'|'encrypted_folder_init_team_key_rotation_details'|'encrypted_folder_init_team_unenrollment_details'|'encrypted_folder_remove_backup_key_details'|'encrypted_folder_rotate_team_key_details'|'encrypted_folder_unenroll_client_details'|'team_encryption_key_activate_key_details'|'team_encryption_key_cancel_key_deletion_details'|'team_encryption_key_create_key_details'|'team_encryption_key_deactivate_key_details'|'team_encryption_key_delete_key_details'|'team_encryption_key_disable_key_details'|'team_encryption_key_enable_key_details'|'team_encryption_key_rotate_key_details'|'team_encryption_key_schedule_key_deletion_details'|'apply_naming_convention_details'|'create_folder_details'|'file_add_details'|'file_add_from_automation_details'|'file_copy_details'|'file_delete_details'|'file_download_details'|'file_edit_details'|'file_get_copy_reference_details'|'file_locking_lock_status_changed_details'|'file_move_details'|'file_permanently_delete_details'|'file_preview_details'|'file_rename_details'|'file_restore_details'|'file_revert_details'|'file_rollback_changes_details'|'file_save_copy_reference_details'|'folder_overview_description_changed_details'|'folder_overview_item_pinned_details'|'folder_overview_item_unpinned_details'|'media_hub_file_downloaded_details'|'object_label_added_details'|'object_label_removed_details'|'object_label_updated_value_details'|'organize_folder_with_tidy_details'|'replay_file_delete_details'|'replay_file_downloaded_details'|'replay_team_project_created_details'|'rewind_folder_details'|'undo_naming_convention_details'|'undo_organize_folder_with_tidy_details'|'user_tags_added_details'|'user_tags_removed_details'|'email_ingest_receive_file_details'|'file_request_auto_close_details'|'file_request_change_details'|'file_request_close_details'|'file_request_create_details'|'file_request_delete_details'|'file_request_receive_file_details'|'group_add_external_id_details'|'group_add_member_details'|'group_change_external_id_details'|'group_change_management_type_details'|'group_change_member_role_details'|'group_create_details'|'group_delete_details'|'group_description_updated_details'|'group_external_sharing_setting_override_changed_details'|'group_join_policy_updated_details'|'group_moved_details'|'group_remove_external_id_details'|'group_remove_member_details'|'group_rename_details'|'account_lock_or_unlocked_details'|'emm_error_details'|'guest_admin_signed_in_via_trusted_teams_details'|'guest_admin_signed_out_via_trusted_teams_details'|'login_fail_details'|'login_success_details'|'logout_details'|'reseller_support_session_end_details'|'reseller_support_session_start_details'|'sign_in_as_session_end_details'|'sign_in_as_session_start_details'|'sso_error_details'|'addon_assigned_details'|'addon_removed_details'|'backup_admin_invitation_sent_details'|'backup_invitation_opened_details'|'create_team_invite_link_details'|'delete_team_invite_link_details'|'member_add_external_id_details'|'member_add_name_details'|'member_change_admin_role_details'|'member_change_email_details'|'member_change_external_id_details'|'member_change_membership_type_details'|'member_change_name_details'|'member_change_reseller_role_details'|'member_change_status_details'|'member_delete_manual_contacts_details'|'member_delete_profile_photo_details'|'member_permanently_delete_account_contents_details'|'member_remove_external_id_details'|'member_set_profile_photo_details'|'member_space_limits_add_custom_quota_details'|'member_space_limits_change_custom_quota_details'|'member_space_limits_change_status_details'|'member_space_limits_remove_custom_quota_details'|'member_suggest_details'|'member_transfer_account_contents_details'|'pending_secondary_email_added_details'|'product_assigned_to_member_details'|'product_removed_from_member_details'|'secondary_email_deleted_details'|'secondary_email_verified_details'|'secondary_mails_policy_changed_details'|'binder_add_page_details'|'binder_add_section_details'|'binder_remove_page_details'|'binder_remove_section_details'|'binder_rename_page_details'|'binder_rename_section_details'|'binder_reorder_page_details'|'binder_reorder_section_details'|'paper_content_add_member_details'|'paper_content_add_to_folder_details'|'paper_content_archive_details'|'paper_content_create_details'|'paper_content_permanently_delete_details'|'paper_content_remove_from_folder_details'|'paper_content_remove_member_details'|'paper_content_rename_details'|'paper_content_restore_details'|'paper_doc_add_comment_details'|'paper_doc_change_member_role_details'|'paper_doc_change_sharing_policy_details'|'paper_doc_change_subscription_details'|'paper_doc_deleted_details'|'paper_doc_delete_comment_details'|'paper_doc_download_details'|'paper_doc_edit_details'|'paper_doc_edit_comment_details'|'paper_doc_followed_details'|'paper_doc_mention_details'|'paper_doc_ownership_changed_details'|'paper_doc_request_access_details'|'paper_doc_resolve_comment_details'|'paper_doc_revert_details'|'paper_doc_slack_share_details'|'paper_doc_team_invite_details'|'paper_doc_trashed_details'|'paper_doc_unresolve_comment_details'|'paper_doc_untrashed_details'|'paper_doc_view_details'|'paper_external_view_allow_details'|'paper_external_view_default_team_details'|'paper_external_view_forbid_details'|'paper_folder_change_subscription_details'|'paper_folder_deleted_details'|'paper_folder_followed_details'|'paper_folder_team_invite_details'|'paper_published_link_change_permission_details'|'paper_published_link_create_details'|'paper_published_link_disabled_details'|'paper_published_link_view_details'|'password_change_details'|'password_reset_details'|'password_reset_all_details'|'protect_internal_domains_changed_details'|'classification_create_report_details'|'classification_create_report_fail_details'|'emm_create_exceptions_report_details'|'emm_create_usage_report_details'|'export_members_report_details'|'export_members_report_fail_details'|'external_sharing_create_report_details'|'external_sharing_report_failed_details'|'member_access_details_create_report_details'|'member_access_details_create_report_failed_details'|'no_expiration_link_gen_create_report_details'|'no_expiration_link_gen_report_failed_details'|'no_password_link_gen_create_report_details'|'no_password_link_gen_report_failed_details'|'no_password_link_view_create_report_details'|'no_password_link_view_report_failed_details'|'outdated_link_view_create_report_details'|'outdated_link_view_report_failed_details'|'paper_admin_export_start_details'|'ransomware_alert_create_report_details'|'ransomware_alert_create_report_failed_details'|'shared_folders_create_report_details'|'shared_folders_create_report_failed_details'|'smart_sync_create_admin_privilege_report_details'|'team_activity_create_report_details'|'team_activity_create_report_fail_details'|'team_folders_create_report_details'|'team_folders_create_report_failed_details'|'team_storage_create_report_details'|'team_storage_create_report_failed_details'|'collection_share_details'|'file_transfers_file_add_details'|'file_transfers_transfer_delete_details'|'file_transfers_transfer_download_details'|'file_transfers_transfer_send_details'|'file_transfers_transfer_view_details'|'media_hub_project_team_add_details'|'media_hub_project_team_delete_details'|'media_hub_project_team_role_changed_details'|'media_hub_shared_link_audience_changed_details'|'media_hub_shared_link_created_details'|'media_hub_shared_link_download_setting_changed_details'|'media_hub_shared_link_revoked_details'|'note_acl_invite_only_details'|'note_acl_link_details'|'note_acl_team_link_details'|'note_shared_details'|'note_share_receive_details'|'open_note_shared_details'|'replay_file_shared_link_created_details'|'replay_file_shared_link_modified_details'|'replay_project_team_add_details'|'replay_project_team_delete_details'|'send_and_track_file_added_details'|'send_and_track_file_renamed_details'|'send_and_track_file_updated_details'|'send_and_track_link_created_details'|'send_and_track_link_deleted_details'|'send_and_track_link_updated_details'|'send_and_track_link_viewed_details'|'send_and_track_removed_file_and_associated_links_details'|'sf_add_group_details'|'sf_allow_non_members_to_view_shared_links_details'|'sf_external_invite_warn_details'|'sf_fb_invite_details'|'sf_fb_invite_change_role_details'|'sf_fb_uninvite_details'|'sf_invite_group_details'|'sf_team_grant_access_details'|'sf_team_invite_details'|'sf_team_invite_change_role_details'|'sf_team_join_details'|'sf_team_join_from_oob_link_details'|'sf_team_uninvite_details'|'shared_content_add_invitees_details'|'shared_content_add_link_expiry_details'|'shared_content_add_link_password_details'|'shared_content_add_member_details'|'shared_content_change_downloads_policy_details'|'shared_content_change_invitee_role_details'|'shared_content_change_link_audience_details'|'shared_content_change_link_expiry_details'|'shared_content_change_link_password_details'|'shared_content_change_member_role_details'|'shared_content_change_viewer_info_policy_details'|'shared_content_claim_invitation_details'|'shared_content_copy_details'|'shared_content_download_details'|'shared_content_relinquish_membership_details'|'shared_content_remove_invitees_details'|'shared_content_remove_link_expiry_details'|'shared_content_remove_link_password_details'|'shared_content_remove_member_details'|'shared_content_request_access_details'|'shared_content_restore_invitees_details'|'shared_content_restore_member_details'|'shared_content_unshare_details'|'shared_content_view_details'|'shared_folder_change_link_policy_details'|'shared_folder_change_members_inheritance_policy_details'|'shared_folder_change_members_management_policy_details'|'shared_folder_change_members_policy_details'|'shared_folder_create_details'|'shared_folder_decline_invitation_details'|'shared_folder_mount_details'|'shared_folder_nest_details'|'shared_folder_transfer_ownership_details'|'shared_folder_unmount_details'|'shared_link_add_expiry_details'|'shared_link_change_expiry_details'|'shared_link_change_visibility_details'|'shared_link_copy_details'|'shared_link_create_details'|'shared_link_disable_details'|'shared_link_download_details'|'shared_link_remove_expiry_details'|'shared_link_remove_visitor_details'|'shared_link_settings_add_expiration_details'|'shared_link_settings_add_password_details'|'shared_link_settings_allow_download_disabled_details'|'shared_link_settings_allow_download_enabled_details'|'shared_link_settings_change_audience_details'|'shared_link_settings_change_expiration_details'|'shared_link_settings_change_password_details'|'shared_link_settings_remove_expiration_details'|'shared_link_settings_remove_password_details'|'shared_link_share_details'|'shared_link_view_details'|'shared_note_opened_details'|'shmodel_disable_downloads_details'|'shmodel_enable_downloads_details'|'shmodel_group_share_details'|'showcase_access_granted_details'|'showcase_add_member_details'|'showcase_archived_details'|'showcase_created_details'|'showcase_delete_comment_details'|'showcase_edited_details'|'showcase_edit_comment_details'|'showcase_file_added_details'|'showcase_file_download_details'|'showcase_file_removed_details'|'showcase_file_view_details'|'showcase_permanently_deleted_details'|'showcase_post_comment_details'|'showcase_remove_member_details'|'showcase_renamed_details'|'showcase_request_access_details'|'showcase_resolve_comment_details'|'showcase_restored_details'|'showcase_trashed_details'|'showcase_trashed_deprecated_details'|'showcase_unresolve_comment_details'|'showcase_untrashed_details'|'showcase_untrashed_deprecated_details'|'showcase_view_details'|'sign_signature_request_canceled_details'|'sign_signature_request_completed_details'|'sign_signature_request_declined_details'|'sign_signature_request_opened_details'|'sign_signature_request_reminder_sent_details'|'sign_signature_request_sent_details'|'sign_template_created_details'|'sign_template_shared_details'|'risc_security_event_details'|'sso_add_cert_details'|'sso_add_login_url_details'|'sso_add_logout_url_details'|'sso_change_cert_details'|'sso_change_login_url_details'|'sso_change_logout_url_details'|'sso_change_saml_identity_mode_details'|'sso_remove_cert_details'|'sso_remove_login_url_details'|'sso_remove_logout_url_details'|'team_folder_change_status_details'|'team_folder_create_details'|'team_folder_downgrade_details'|'team_folder_permanently_delete_details'|'team_folder_rename_details'|'team_folder_space_limits_change_caps_type_details'|'team_folder_space_limits_change_limit_details'|'team_folder_space_limits_change_notification_target_details'|'team_selective_sync_settings_changed_details'|'account_capture_change_policy_details'|'admin_email_reminders_changed_details'|'ai_third_party_sharing_dropbox_base_policy_changed_details'|'allow_download_disabled_details'|'allow_download_enabled_details'|'apple_login_change_policy_details'|'app_permissions_changed_details'|'camera_uploads_policy_changed_details'|'capture_team_space_policy_changed_details'|'capture_transcript_policy_changed_details'|'classification_change_policy_details'|'computer_backup_policy_changed_details'|'content_administration_policy_changed_details'|'content_deletion_protection_change_policy_details'|'dash_external_sharing_policy_changed_details'|'data_placement_restriction_change_policy_details'|'data_placement_restriction_satisfy_policy_details'|'device_approvals_add_exception_details'|'device_approvals_change_desktop_policy_details'|'device_approvals_change_mobile_policy_details'|'device_approvals_change_overage_action_details'|'device_approvals_change_unlink_action_details'|'device_approvals_remove_exception_details'|'directory_restrictions_add_members_details'|'directory_restrictions_remove_members_details'|'dropbox_passwords_policy_changed_details'|'email_ingest_policy_changed_details'|'emm_add_exception_details'|'emm_change_policy_details'|'emm_remove_exception_details'|'extended_version_history_change_policy_details'|'external_drive_backup_policy_changed_details'|'file_comments_change_policy_details'|'file_locking_policy_changed_details'|'file_provider_migration_policy_changed_details'|'file_requests_change_policy_details'|'file_requests_emails_enabled_details'|'file_requests_emails_restricted_to_team_only_details'|'file_transfers_policy_changed_details'|'flexible_file_names_policy_changed_details'|'folder_link_restriction_policy_changed_details'|'google_sso_change_policy_details'|'group_user_management_change_policy_details'|'integration_policy_changed_details'|'invite_acceptance_email_policy_changed_details'|'media_hub_adding_people_policy_changed_details'|'media_hub_download_policy_changed_details'|'media_hub_link_sharing_policy_changed_details'|'member_requests_change_policy_details'|'member_send_invite_policy_changed_details'|'member_space_limits_add_exception_details'|'member_space_limits_change_caps_type_policy_details'|'member_space_limits_change_policy_details'|'member_space_limits_remove_exception_details'|'member_suggestions_change_policy_details'|'microsoft_login_change_policy_details'|'microsoft_office_addin_change_policy_details'|'multi_team_identity_policy_changed_details'|'network_control_change_policy_details'|'paper_change_deployment_policy_details'|'paper_change_member_link_policy_details'|'paper_change_member_policy_details'|'paper_change_policy_details'|'paper_default_folder_policy_changed_details'|'paper_desktop_policy_changed_details'|'paper_enabled_users_group_addition_details'|'paper_enabled_users_group_removal_details'|'passkey_login_policy_changed_details'|'password_strength_requirements_change_policy_details'|'permanent_delete_change_policy_details'|'previews_ai_policy_changed_details'|'replay_adding_people_policy_changed_details'|'replay_sharing_policy_changed_details'|'reseller_support_change_policy_details'|'rewind_policy_changed_details'|'send_and_track_policy_changed_details'|'send_external_sharing_policy_changed_details'|'send_for_signature_policy_changed_details'|'shared_link_default_permissions_policy_changed_details'|'sharing_change_folder_join_policy_details'|'sharing_change_link_allow_change_expiration_policy_details'|'sharing_change_link_default_expiration_policy_details'|'sharing_change_link_enforce_password_policy_details'|'sharing_change_link_policy_details'|'sharing_change_member_policy_details'|'showcase_change_download_policy_details'|'showcase_change_enabled_policy_details'|'showcase_change_external_sharing_policy_details'|'sign_external_sharing_policy_changed_details'|'sign_template_creation_permission_changed_details'|'smarter_smart_sync_policy_changed_details'|'smart_sync_change_policy_details'|'smart_sync_not_opt_out_details'|'smart_sync_opt_out_details'|'sso_change_policy_details'|'stack_cross_team_access_policy_changed_details'|'team_branding_policy_changed_details'|'team_extensions_policy_changed_details'|'team_member_storage_request_policy_changed_details'|'team_selective_sync_policy_changed_details'|'team_sharing_whitelist_subjects_changed_details'|'tfa_add_exception_details'|'tfa_change_policy_details'|'tfa_remove_exception_details'|'top_level_content_policy_changed_details'|'two_account_change_policy_details'|'viewer_info_policy_changed_details'|'watermarking_policy_changed_details'|'web_sessions_change_active_session_limit_details'|'web_sessions_change_fixed_length_policy_details'|'web_sessions_change_idle_length_policy_details'|'data_residency_migration_request_successful_details'|'data_residency_migration_request_unsuccessful_details'|'team_merge_from_details'|'team_merge_to_details'|'team_profile_add_background_details'|'team_profile_add_logo_details'|'team_profile_change_background_details'|'team_profile_change_default_language_details'|'team_profile_change_logo_details'|'team_profile_change_name_details'|'team_profile_remove_background_details'|'team_profile_remove_logo_details'|'passkey_add_details'|'passkey_remove_details'|'tfa_add_backup_phone_details'|'tfa_add_security_key_details'|'tfa_change_backup_phone_details'|'tfa_change_status_details'|'tfa_remove_backup_phone_details'|'tfa_remove_security_key_details'|'tfa_reset_details'|'changed_enterprise_admin_role_details'|'changed_enterprise_connected_team_status_details'|'ended_enterprise_admin_session_details'|'ended_enterprise_admin_session_deprecated_details'|'enterprise_settings_locking_details'|'guest_admin_change_status_details'|'started_enterprise_admin_session_details'|'team_merge_request_accepted_details'|'team_merge_request_accepted_shown_to_primary_team_details'|'team_merge_request_accepted_shown_to_secondary_team_details'|'team_merge_request_auto_canceled_details'|'team_merge_request_canceled_details'|'team_merge_request_canceled_shown_to_primary_team_details'|'team_merge_request_canceled_shown_to_secondary_team_details'|'team_merge_request_expired_details'|'team_merge_request_expired_shown_to_primary_team_details'|'team_merge_request_expired_shown_to_secondary_team_details'|'team_merge_request_rejected_shown_to_primary_team_details'|'team_merge_request_rejected_shown_to_secondary_team_details'|'team_merge_request_reminder_details'|'team_merge_request_reminder_shown_to_primary_team_details'|'team_merge_request_reminder_shown_to_secondary_team_details'|'team_merge_request_revoked_details'|'team_merge_request_sent_shown_to_primary_team_details'|'team_merge_request_sent_shown_to_secondary_team_details'|'missing_details'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed_details'|'admin_alerting_changed_alert_config_details'|'admin_alerting_triggered_alert_details'|'ransomware_restore_process_completed_details'|'ransomware_restore_process_started_details'|'app_blocked_by_permissions_details'|'app_link_team_details'|'app_link_user_details'|'app_unlink_team_details'|'app_unlink_user_details'|'integration_connected_details'|'integration_disconnected_details'|'file_add_comment_details'|'file_change_comment_subscription_details'|'file_delete_comment_details'|'file_edit_comment_details'|'file_like_comment_details'|'file_resolve_comment_details'|'file_unlike_comment_details'|'file_unresolve_comment_details'|'dash_added_comment_to_stack_details'|'dash_added_connector_details'|'dash_added_link_to_stack_details'|'dash_added_team_email_domain_allowlist_details'|'dash_admin_added_org_wide_connector_details'|'dash_admin_disabled_connector_details'|'dash_admin_enabled_connector_details'|'dash_admin_removed_org_wide_connector_details'|'dash_archived_stack_details'|'dash_changed_audience_of_shared_link_to_stack_details'|'dash_cloned_stack_details'|'dash_connector_tools_call_details'|'dash_created_stack_details'|'dash_deleted_comment_from_stack_details'|'dash_deleted_stack_details'|'dash_edited_comment_in_stack_details'|'dash_external_user_opened_stack_details'|'dash_first_launched_desktop_details'|'dash_first_launched_extension_details'|'dash_first_launched_web_start_page_details'|'dash_opened_shared_link_to_stack_details'|'dash_opened_stack_details'|'dash_preview_opt_out_status_changed_details'|'dash_removed_connector_details'|'dash_removed_link_from_stack_details'|'dash_removed_shared_link_to_stack_details'|'dash_removed_team_email_domain_allowlist_details'|'dash_renamed_stack_details'|'dash_shared_link_to_stack_details'|'dash_unarchived_stack_details'|'dash_viewed_company_stack_details'|'dash_viewed_external_ai_activity_report_details'|'governance_policy_add_folders_details'|'governance_policy_add_folder_failed_details'|'governance_policy_content_disposed_details'|'governance_policy_create_details'|'governance_policy_delete_details'|'governance_policy_edit_details_details'|'governance_policy_edit_duration_details'|'governance_policy_export_created_details'|'governance_policy_export_removed_details'|'governance_policy_remove_folders_details'|'governance_policy_report_created_details'|'governance_policy_zip_part_downloaded_details'|'legal_holds_activate_a_hold_details'|'legal_holds_add_members_details'|'legal_holds_change_hold_details_details'|'legal_holds_change_hold_name_details'|'legal_holds_export_a_hold_details'|'legal_holds_export_cancelled_details'|'legal_holds_export_downloaded_details'|'legal_holds_export_removed_details'|'legal_holds_release_a_hold_details'|'legal_holds_remove_members_details'|'legal_holds_report_a_hold_details'|'device_change_ip_desktop_details'|'device_change_ip_mobile_details'|'device_change_ip_web_details'|'device_delete_on_unlink_fail_details'|'device_delete_on_unlink_success_details'|'device_link_fail_details'|'device_link_success_details'|'device_management_disabled_details'|'device_management_enabled_details'|'device_sync_backup_status_changed_details'|'device_unlink_details'|'dropbox_passwords_exported_details'|'dropbox_passwords_new_device_enrolled_details'|'emm_refresh_auth_token_details'|'external_drive_backup_eligibility_status_checked_details'|'external_drive_backup_status_changed_details'|'account_capture_change_availability_details'|'account_capture_migrate_account_details'|'account_capture_notification_emails_sent_details'|'account_capture_relinquish_account_details'|'disabled_domain_invites_details'|'domain_invites_approve_request_to_join_team_details'|'domain_invites_decline_request_to_join_team_details'|'domain_invites_email_existing_users_details'|'domain_invites_request_to_join_team_details'|'domain_invites_set_invite_new_user_pref_to_no_details'|'domain_invites_set_invite_new_user_pref_to_yes_details'|'domain_verification_add_domain_fail_details'|'domain_verification_add_domain_success_details'|'domain_verification_remove_domain_details'|'enabled_domain_invites_details'|'encrypted_folder_cancel_team_key_rotation_details'|'encrypted_folder_enroll_backup_key_details'|'encrypted_folder_enroll_client_details'|'encrypted_folder_enroll_team_details'|'encrypted_folder_finish_team_unenrollment_details'|'encrypted_folder_init_team_key_rotation_details'|'encrypted_folder_init_team_unenrollment_details'|'encrypted_folder_remove_backup_key_details'|'encrypted_folder_rotate_team_key_details'|'encrypted_folder_unenroll_client_details'|'team_encryption_key_activate_key_details'|'team_encryption_key_cancel_key_deletion_details'|'team_encryption_key_create_key_details'|'team_encryption_key_deactivate_key_details'|'team_encryption_key_delete_key_details'|'team_encryption_key_disable_key_details'|'team_encryption_key_enable_key_details'|'team_encryption_key_rotate_key_details'|'team_encryption_key_schedule_key_deletion_details'|'apply_naming_convention_details'|'create_folder_details'|'file_add_details'|'file_add_from_automation_details'|'file_copy_details'|'file_delete_details'|'file_download_details'|'file_edit_details'|'file_get_copy_reference_details'|'file_locking_lock_status_changed_details'|'file_move_details'|'file_permanently_delete_details'|'file_preview_details'|'file_rename_details'|'file_restore_details'|'file_revert_details'|'file_rollback_changes_details'|'file_save_copy_reference_details'|'folder_overview_description_changed_details'|'folder_overview_item_pinned_details'|'folder_overview_item_unpinned_details'|'media_hub_file_downloaded_details'|'object_label_added_details'|'object_label_removed_details'|'object_label_updated_value_details'|'organize_folder_with_tidy_details'|'replay_file_delete_details'|'replay_file_downloaded_details'|'replay_team_project_created_details'|'rewind_folder_details'|'undo_naming_convention_details'|'undo_organize_folder_with_tidy_details'|'user_tags_added_details'|'user_tags_removed_details'|'email_ingest_receive_file_details'|'file_request_auto_close_details'|'file_request_change_details'|'file_request_close_details'|'file_request_create_details'|'file_request_delete_details'|'file_request_receive_file_details'|'group_add_external_id_details'|'group_add_member_details'|'group_change_external_id_details'|'group_change_management_type_details'|'group_change_member_role_details'|'group_create_details'|'group_delete_details'|'group_description_updated_details'|'group_external_sharing_setting_override_changed_details'|'group_join_policy_updated_details'|'group_moved_details'|'group_remove_external_id_details'|'group_remove_member_details'|'group_rename_details'|'account_lock_or_unlocked_details'|'emm_error_details'|'guest_admin_signed_in_via_trusted_teams_details'|'guest_admin_signed_out_via_trusted_teams_details'|'login_fail_details'|'login_success_details'|'logout_details'|'reseller_support_session_end_details'|'reseller_support_session_start_details'|'sign_in_as_session_end_details'|'sign_in_as_session_start_details'|'sso_error_details'|'addon_assigned_details'|'addon_removed_details'|'backup_admin_invitation_sent_details'|'backup_invitation_opened_details'|'create_team_invite_link_details'|'delete_team_invite_link_details'|'member_add_external_id_details'|'member_add_name_details'|'member_change_admin_role_details'|'member_change_email_details'|'member_change_external_id_details'|'member_change_membership_type_details'|'member_change_name_details'|'member_change_reseller_role_details'|'member_change_status_details'|'member_delete_manual_contacts_details'|'member_delete_profile_photo_details'|'member_folder_contents_accessed_details'|'member_permanently_delete_account_contents_details'|'member_remove_external_id_details'|'member_set_profile_photo_details'|'member_space_limits_add_custom_quota_details'|'member_space_limits_change_custom_quota_details'|'member_space_limits_change_status_details'|'member_space_limits_remove_custom_quota_details'|'member_suggest_details'|'member_transfer_account_contents_details'|'pending_secondary_email_added_details'|'product_assigned_to_member_details'|'product_removed_from_member_details'|'secondary_email_deleted_details'|'secondary_email_verified_details'|'secondary_mails_policy_changed_details'|'binder_add_page_details'|'binder_add_section_details'|'binder_remove_page_details'|'binder_remove_section_details'|'binder_rename_page_details'|'binder_rename_section_details'|'binder_reorder_page_details'|'binder_reorder_section_details'|'paper_content_add_member_details'|'paper_content_add_to_folder_details'|'paper_content_archive_details'|'paper_content_create_details'|'paper_content_permanently_delete_details'|'paper_content_remove_from_folder_details'|'paper_content_remove_member_details'|'paper_content_rename_details'|'paper_content_restore_details'|'paper_doc_add_comment_details'|'paper_doc_change_member_role_details'|'paper_doc_change_sharing_policy_details'|'paper_doc_change_subscription_details'|'paper_doc_deleted_details'|'paper_doc_delete_comment_details'|'paper_doc_download_details'|'paper_doc_edit_details'|'paper_doc_edit_comment_details'|'paper_doc_followed_details'|'paper_doc_mention_details'|'paper_doc_ownership_changed_details'|'paper_doc_request_access_details'|'paper_doc_resolve_comment_details'|'paper_doc_revert_details'|'paper_doc_slack_share_details'|'paper_doc_team_invite_details'|'paper_doc_trashed_details'|'paper_doc_unresolve_comment_details'|'paper_doc_untrashed_details'|'paper_doc_view_details'|'paper_external_view_allow_details'|'paper_external_view_default_team_details'|'paper_external_view_forbid_details'|'paper_folder_change_subscription_details'|'paper_folder_deleted_details'|'paper_folder_followed_details'|'paper_folder_team_invite_details'|'paper_published_link_change_permission_details'|'paper_published_link_create_details'|'paper_published_link_disabled_details'|'paper_published_link_view_details'|'password_change_details'|'password_reset_details'|'password_reset_all_details'|'protect_action_add_collaborator_details'|'protect_action_add_link_details'|'protect_action_delete_details'|'protect_action_export_details'|'protect_action_remove_collaborator_details'|'protect_action_remove_link_details'|'protect_action_stop_sharing_details'|'protect_internal_domains_changed_details'|'protect_policy_activated_details'|'protect_policy_deactivated_details'|'protect_policy_scheduled_details'|'protect_policy_updated_details'|'classification_create_report_details'|'classification_create_report_fail_details'|'emm_create_exceptions_report_details'|'emm_create_usage_report_details'|'export_members_report_details'|'export_members_report_fail_details'|'external_sharing_create_report_details'|'external_sharing_report_failed_details'|'member_access_details_create_report_details'|'member_access_details_create_report_failed_details'|'no_expiration_link_gen_create_report_details'|'no_expiration_link_gen_report_failed_details'|'no_password_link_gen_create_report_details'|'no_password_link_gen_report_failed_details'|'no_password_link_view_create_report_details'|'no_password_link_view_report_failed_details'|'outdated_link_view_create_report_details'|'outdated_link_view_report_failed_details'|'paper_admin_export_start_details'|'ransomware_alert_create_report_details'|'ransomware_alert_create_report_failed_details'|'shared_folders_create_report_details'|'shared_folders_create_report_failed_details'|'smart_sync_create_admin_privilege_report_details'|'team_activity_create_report_details'|'team_activity_create_report_fail_details'|'team_folders_create_report_details'|'team_folders_create_report_failed_details'|'team_storage_create_report_details'|'team_storage_create_report_failed_details'|'collection_share_details'|'file_transfers_file_add_details'|'file_transfers_transfer_delete_details'|'file_transfers_transfer_download_details'|'file_transfers_transfer_send_details'|'file_transfers_transfer_view_details'|'media_hub_project_team_add_details'|'media_hub_project_team_delete_details'|'media_hub_project_team_role_changed_details'|'media_hub_shared_link_audience_changed_details'|'media_hub_shared_link_created_details'|'media_hub_shared_link_download_setting_changed_details'|'media_hub_shared_link_revoked_details'|'note_acl_invite_only_details'|'note_acl_link_details'|'note_acl_team_link_details'|'note_shared_details'|'note_share_receive_details'|'open_note_shared_details'|'replay_file_shared_link_created_details'|'replay_file_shared_link_modified_details'|'replay_project_team_add_details'|'replay_project_team_delete_details'|'send_and_track_file_added_details'|'send_and_track_file_renamed_details'|'send_and_track_file_updated_details'|'send_and_track_link_created_details'|'send_and_track_link_deleted_details'|'send_and_track_link_updated_details'|'send_and_track_link_viewed_details'|'send_and_track_removed_file_and_associated_links_details'|'sf_add_group_details'|'sf_allow_non_members_to_view_shared_links_details'|'sf_external_invite_warn_details'|'sf_fb_invite_details'|'sf_fb_invite_change_role_details'|'sf_fb_uninvite_details'|'sf_invite_group_details'|'sf_team_grant_access_details'|'sf_team_invite_details'|'sf_team_invite_change_role_details'|'sf_team_join_details'|'sf_team_join_from_oob_link_details'|'sf_team_uninvite_details'|'shared_content_add_invitees_details'|'shared_content_add_link_expiry_details'|'shared_content_add_link_password_details'|'shared_content_add_member_details'|'shared_content_change_downloads_policy_details'|'shared_content_change_invitee_role_details'|'shared_content_change_link_audience_details'|'shared_content_change_link_expiry_details'|'shared_content_change_link_password_details'|'shared_content_change_member_role_details'|'shared_content_change_viewer_info_policy_details'|'shared_content_claim_invitation_details'|'shared_content_copy_details'|'shared_content_download_details'|'shared_content_relinquish_membership_details'|'shared_content_remove_invitees_details'|'shared_content_remove_link_expiry_details'|'shared_content_remove_link_password_details'|'shared_content_remove_member_details'|'shared_content_request_access_details'|'shared_content_restore_invitees_details'|'shared_content_restore_member_details'|'shared_content_unshare_details'|'shared_content_view_details'|'shared_folder_change_link_policy_details'|'shared_folder_change_members_inheritance_policy_details'|'shared_folder_change_members_management_policy_details'|'shared_folder_change_members_policy_details'|'shared_folder_create_details'|'shared_folder_decline_invitation_details'|'shared_folder_mount_details'|'shared_folder_nest_details'|'shared_folder_transfer_ownership_details'|'shared_folder_unmount_details'|'shared_link_add_expiry_details'|'shared_link_change_expiry_details'|'shared_link_change_visibility_details'|'shared_link_copy_details'|'shared_link_create_details'|'shared_link_disable_details'|'shared_link_download_details'|'shared_link_remove_expiry_details'|'shared_link_remove_visitor_details'|'shared_link_settings_add_expiration_details'|'shared_link_settings_add_password_details'|'shared_link_settings_allow_download_disabled_details'|'shared_link_settings_allow_download_enabled_details'|'shared_link_settings_change_audience_details'|'shared_link_settings_change_expiration_details'|'shared_link_settings_change_password_details'|'shared_link_settings_remove_expiration_details'|'shared_link_settings_remove_password_details'|'shared_link_share_details'|'shared_link_view_details'|'shared_note_opened_details'|'shmodel_disable_downloads_details'|'shmodel_enable_downloads_details'|'shmodel_group_share_details'|'showcase_access_granted_details'|'showcase_add_member_details'|'showcase_archived_details'|'showcase_created_details'|'showcase_delete_comment_details'|'showcase_edited_details'|'showcase_edit_comment_details'|'showcase_file_added_details'|'showcase_file_download_details'|'showcase_file_removed_details'|'showcase_file_view_details'|'showcase_permanently_deleted_details'|'showcase_post_comment_details'|'showcase_remove_member_details'|'showcase_renamed_details'|'showcase_request_access_details'|'showcase_resolve_comment_details'|'showcase_restored_details'|'showcase_trashed_details'|'showcase_trashed_deprecated_details'|'showcase_unresolve_comment_details'|'showcase_untrashed_details'|'showcase_untrashed_deprecated_details'|'showcase_view_details'|'sign_signature_request_canceled_details'|'sign_signature_request_completed_details'|'sign_signature_request_declined_details'|'sign_signature_request_opened_details'|'sign_signature_request_reminder_sent_details'|'sign_signature_request_sent_details'|'sign_template_created_details'|'sign_template_shared_details'|'risc_security_event_details'|'sso_add_cert_details'|'sso_add_login_url_details'|'sso_add_logout_url_details'|'sso_change_cert_details'|'sso_change_login_url_details'|'sso_change_logout_url_details'|'sso_change_saml_identity_mode_details'|'sso_remove_cert_details'|'sso_remove_login_url_details'|'sso_remove_logout_url_details'|'team_folder_change_status_details'|'team_folder_create_details'|'team_folder_downgrade_details'|'team_folder_permanently_delete_details'|'team_folder_rename_details'|'team_folder_space_limits_change_caps_type_details'|'team_folder_space_limits_change_limit_details'|'team_folder_space_limits_change_notification_target_details'|'team_selective_sync_settings_changed_details'|'account_capture_change_policy_details'|'admin_email_reminders_changed_details'|'ai_third_party_sharing_dropbox_base_policy_changed_details'|'allow_download_disabled_details'|'allow_download_enabled_details'|'apple_login_change_policy_details'|'app_permissions_changed_details'|'camera_uploads_policy_changed_details'|'capture_team_space_policy_changed_details'|'capture_transcript_policy_changed_details'|'classification_change_policy_details'|'computer_backup_policy_changed_details'|'content_administration_policy_changed_details'|'content_deletion_protection_change_policy_details'|'dash_external_sharing_policy_changed_details'|'data_placement_restriction_change_policy_details'|'data_placement_restriction_satisfy_policy_details'|'device_approvals_add_exception_details'|'device_approvals_change_desktop_policy_details'|'device_approvals_change_mobile_policy_details'|'device_approvals_change_overage_action_details'|'device_approvals_change_unlink_action_details'|'device_approvals_remove_exception_details'|'directory_restrictions_add_members_details'|'directory_restrictions_remove_members_details'|'dropbox_passwords_policy_changed_details'|'email_ingest_policy_changed_details'|'emm_add_exception_details'|'emm_change_policy_details'|'emm_remove_exception_details'|'extended_version_history_change_policy_details'|'external_drive_backup_policy_changed_details'|'file_comments_change_policy_details'|'file_locking_policy_changed_details'|'file_provider_migration_policy_changed_details'|'file_requests_change_policy_details'|'file_requests_emails_enabled_details'|'file_requests_emails_restricted_to_team_only_details'|'file_transfers_policy_changed_details'|'flexible_file_names_policy_changed_details'|'folder_link_restriction_policy_changed_details'|'google_sso_change_policy_details'|'group_user_management_change_policy_details'|'integration_policy_changed_details'|'invite_acceptance_email_policy_changed_details'|'media_hub_adding_people_policy_changed_details'|'media_hub_download_policy_changed_details'|'media_hub_link_sharing_policy_changed_details'|'member_requests_change_policy_details'|'member_send_invite_policy_changed_details'|'member_space_limits_add_exception_details'|'member_space_limits_change_caps_type_policy_details'|'member_space_limits_change_policy_details'|'member_space_limits_remove_exception_details'|'member_suggestions_change_policy_details'|'microsoft_login_change_policy_details'|'microsoft_office_addin_change_policy_details'|'multi_team_identity_policy_changed_details'|'network_control_change_policy_details'|'paper_change_deployment_policy_details'|'paper_change_member_link_policy_details'|'paper_change_member_policy_details'|'paper_change_policy_details'|'paper_default_folder_policy_changed_details'|'paper_desktop_policy_changed_details'|'paper_enabled_users_group_addition_details'|'paper_enabled_users_group_removal_details'|'passkey_login_policy_changed_details'|'password_strength_requirements_change_policy_details'|'permanent_delete_change_policy_details'|'previews_ai_policy_changed_details'|'replay_adding_people_policy_changed_details'|'replay_sharing_policy_changed_details'|'reseller_support_change_policy_details'|'rewind_policy_changed_details'|'send_and_track_policy_changed_details'|'send_external_sharing_policy_changed_details'|'send_for_signature_policy_changed_details'|'shared_link_default_permissions_policy_changed_details'|'sharing_change_folder_join_policy_details'|'sharing_change_link_allow_change_expiration_policy_details'|'sharing_change_link_default_expiration_policy_details'|'sharing_change_link_enforce_password_policy_details'|'sharing_change_link_policy_details'|'sharing_change_member_policy_details'|'showcase_change_download_policy_details'|'showcase_change_enabled_policy_details'|'showcase_change_external_sharing_policy_details'|'sign_external_sharing_policy_changed_details'|'sign_template_creation_permission_changed_details'|'smarter_smart_sync_policy_changed_details'|'smart_sync_change_policy_details'|'smart_sync_not_opt_out_details'|'smart_sync_opt_out_details'|'sso_change_policy_details'|'stack_cross_team_access_policy_changed_details'|'team_branding_policy_changed_details'|'team_extensions_policy_changed_details'|'team_member_storage_request_policy_changed_details'|'team_selective_sync_policy_changed_details'|'team_sharing_whitelist_subjects_changed_details'|'tfa_add_exception_details'|'tfa_change_policy_details'|'tfa_remove_exception_details'|'top_level_content_policy_changed_details'|'two_account_change_policy_details'|'viewer_info_policy_changed_details'|'watermarking_policy_changed_details'|'web_sessions_change_active_session_limit_details'|'web_sessions_change_fixed_length_policy_details'|'web_sessions_change_idle_length_policy_details'|'data_residency_migration_request_successful_details'|'data_residency_migration_request_unsuccessful_details'|'team_merge_from_details'|'team_merge_to_details'|'team_profile_add_background_details'|'team_profile_add_logo_details'|'team_profile_change_background_details'|'team_profile_change_default_language_details'|'team_profile_change_logo_details'|'team_profile_change_name_details'|'team_profile_remove_background_details'|'team_profile_remove_logo_details'|'passkey_add_details'|'passkey_remove_details'|'tfa_add_backup_phone_details'|'tfa_add_security_key_details'|'tfa_change_backup_phone_details'|'tfa_change_status_details'|'tfa_remove_backup_phone_details'|'tfa_remove_security_key_details'|'tfa_reset_details'|'changed_enterprise_admin_role_details'|'changed_enterprise_connected_team_status_details'|'ended_enterprise_admin_session_details'|'ended_enterprise_admin_session_deprecated_details'|'enterprise_settings_locking_details'|'guest_admin_change_status_details'|'started_enterprise_admin_session_details'|'team_merge_request_accepted_details'|'team_merge_request_accepted_shown_to_primary_team_details'|'team_merge_request_accepted_shown_to_secondary_team_details'|'team_merge_request_auto_canceled_details'|'team_merge_request_canceled_details'|'team_merge_request_canceled_shown_to_primary_team_details'|'team_merge_request_canceled_shown_to_secondary_team_details'|'team_merge_request_expired_details'|'team_merge_request_expired_shown_to_primary_team_details'|'team_merge_request_expired_shown_to_secondary_team_details'|'team_merge_request_rejected_shown_to_primary_team_details'|'team_merge_request_rejected_shown_to_secondary_team_details'|'team_merge_request_reminder_details'|'team_merge_request_reminder_shown_to_primary_team_details'|'team_merge_request_reminder_shown_to_secondary_team_details'|'team_merge_request_revoked_details'|'team_merge_request_sent_shown_to_primary_team_details'|'team_merge_request_sent_shown_to_secondary_team_details'|'missing_details'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -12205,7 +12339,7 @@ is only present when needed to discriminate between multiple possible subtypes.
  * overview
  * @property {TeamLogMediaHubFileDownloadedType} [media_hub_file_downloaded] -
  * Available if .tag is media_hub_file_downloaded. (file_operations) Downloaded
- * files in Media Hub
+ * files in Replay
  * @property {TeamLogObjectLabelAddedType} [object_label_added] - Available if
  * .tag is object_label_added. (file_operations) Added a label
  * @property {TeamLogObjectLabelRemovedType} [object_label_removed] - Available
@@ -12370,6 +12504,10 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMemberDeleteProfilePhotoType} [member_delete_profile_photo]
  * - Available if .tag is member_delete_profile_photo. (members) Deleted team
  * member profile photo
+ * @property {TeamLogMemberFolderContentsAccessedType}
+ * [member_folder_contents_accessed] - Available if .tag is
+ * member_folder_contents_accessed. (members) Admin browsed a team member's
+ * folder contents
  * @property {TeamLogMemberPermanentlyDeleteAccountContentsType}
  * [member_permanently_delete_account_contents] - Available if .tag is
  * member_permanently_delete_account_contents. (members) Permanently deleted
@@ -12562,10 +12700,45 @@ is only present when needed to discriminate between multiple possible subtypes.
  * password_reset. (passwords) Reset password
  * @property {TeamLogPasswordResetAllType} [password_reset_all] - Available if
  * .tag is password_reset_all. (passwords) Reset all team member passwords
+ * @property {TeamLogProtectActionAddCollaboratorType}
+ * [protect_action_add_collaborator] - Available if .tag is
+ * protect_action_add_collaborator. (protect) Added collaborators via Dropbox
+ * Protect
+ * @property {TeamLogProtectActionAddLinkType} [protect_action_add_link] -
+ * Available if .tag is protect_action_add_link. (protect) Added a link via
+ * Dropbox Protect
+ * @property {TeamLogProtectActionDeleteType} [protect_action_delete] -
+ * Available if .tag is protect_action_delete. (protect) Deleted content via
+ * Dropbox Protect
+ * @property {TeamLogProtectActionExportType} [protect_action_export] -
+ * Available if .tag is protect_action_export. (protect) Exported content via
+ * Dropbox Protect
+ * @property {TeamLogProtectActionRemoveCollaboratorType}
+ * [protect_action_remove_collaborator] - Available if .tag is
+ * protect_action_remove_collaborator. (protect) Removed collaborators via
+ * Dropbox Protect
+ * @property {TeamLogProtectActionRemoveLinkType} [protect_action_remove_link] -
+ * Available if .tag is protect_action_remove_link. (protect) Removed a link via
+ * Dropbox Protect
+ * @property {TeamLogProtectActionStopSharingType} [protect_action_stop_sharing]
+ * - Available if .tag is protect_action_stop_sharing. (protect) Stopped sharing
+ * content via Dropbox Protect
  * @property {TeamLogProtectInternalDomainsChangedType}
  * [protect_internal_domains_changed] - Available if .tag is
  * protect_internal_domains_changed. (protect) Modified Protect internal domains
  * list
+ * @property {TeamLogProtectPolicyActivatedType} [protect_policy_activated] -
+ * Available if .tag is protect_policy_activated. (protect) Activated a Dropbox
+ * Protect policy
+ * @property {TeamLogProtectPolicyDeactivatedType} [protect_policy_deactivated]
+ * - Available if .tag is protect_policy_deactivated. (protect) Deactivated a
+ * Dropbox Protect policy
+ * @property {TeamLogProtectPolicyScheduledType} [protect_policy_scheduled] -
+ * Available if .tag is protect_policy_scheduled. (protect) Scheduled a Dropbox
+ * Protect policy
+ * @property {TeamLogProtectPolicyUpdatedType} [protect_policy_updated] -
+ * Available if .tag is protect_policy_updated. (protect) Updated a Dropbox
+ * Protect policy
  * @property {TeamLogClassificationCreateReportType}
  * [classification_create_report] - Available if .tag is
  * classification_create_report. (reports) Created Classification report
@@ -12691,29 +12864,28 @@ is only present when needed to discriminate between multiple possible subtypes.
  * file_transfers_transfer_view. (sharing) Viewed transfer
  * @property {TeamLogMediaHubProjectTeamAddType} [media_hub_project_team_add] -
  * Available if .tag is media_hub_project_team_add. (sharing) Added member to
- * Media Hub project
+ * Replay project
  * @property {TeamLogMediaHubProjectTeamDeleteType}
  * [media_hub_project_team_delete] - Available if .tag is
- * media_hub_project_team_delete. (sharing) Removed member from Media Hub
- * project
+ * media_hub_project_team_delete. (sharing) Removed member from Replay project
  * @property {TeamLogMediaHubProjectTeamRoleChangedType}
  * [media_hub_project_team_role_changed] - Available if .tag is
- * media_hub_project_team_role_changed. (sharing) Changed member role in Media
- * Hub project
+ * media_hub_project_team_role_changed. (sharing) Changed member role in Replay
+ * project
  * @property {TeamLogMediaHubSharedLinkAudienceChangedType}
  * [media_hub_shared_link_audience_changed] - Available if .tag is
- * media_hub_shared_link_audience_changed. (sharing) Changed Media Hub shared
- * link audience
+ * media_hub_shared_link_audience_changed. (sharing) Changed Replay shared link
+ * audience
  * @property {TeamLogMediaHubSharedLinkCreatedType}
  * [media_hub_shared_link_created] - Available if .tag is
- * media_hub_shared_link_created. (sharing) Created Media Hub shared link
+ * media_hub_shared_link_created. (sharing) Created Replay shared link
  * @property {TeamLogMediaHubSharedLinkDownloadSettingChangedType}
  * [media_hub_shared_link_download_setting_changed] - Available if .tag is
- * media_hub_shared_link_download_setting_changed. (sharing) Changed Media Hub
+ * media_hub_shared_link_download_setting_changed. (sharing) Changed Replay
  * shared link download setting
  * @property {TeamLogMediaHubSharedLinkRevokedType}
  * [media_hub_shared_link_revoked] - Available if .tag is
- * media_hub_shared_link_revoked. (sharing) Revoked Media Hub shared link
+ * media_hub_shared_link_revoked. (sharing) Revoked Replay shared link
  * @property {TeamLogNoteAclInviteOnlyType} [note_acl_invite_only] - Available
  * if .tag is note_acl_invite_only. (sharing) Changed Paper doc to invite-only
  * (deprecated, no longer logged)
@@ -13316,15 +13488,15 @@ is only present when needed to discriminate between multiple possible subtypes.
  * @property {TeamLogMediaHubAddingPeoplePolicyChangedType}
  * [media_hub_adding_people_policy_changed] - Available if .tag is
  * media_hub_adding_people_policy_changed. (team_policies) Changed the policy
- * for adding people to Media Hub content
+ * for adding people to Replay content
  * @property {TeamLogMediaHubDownloadPolicyChangedType}
  * [media_hub_download_policy_changed] - Available if .tag is
  * media_hub_download_policy_changed. (team_policies) Changed the policy for
- * downloading Media Hub content
+ * downloading Replay content
  * @property {TeamLogMediaHubLinkSharingPolicyChangedType}
  * [media_hub_link_sharing_policy_changed] - Available if .tag is
  * media_hub_link_sharing_policy_changed. (team_policies) Changed the policy for
- * sharing Media Hub content
+ * sharing Replay content
  * @property {TeamLogMemberRequestsChangePolicyType}
  * [member_requests_change_policy] - Available if .tag is
  * member_requests_change_policy. (team_policies) Changed whether users can find
@@ -13725,13 +13897,13 @@ is only present when needed to discriminate between multiple possible subtypes.
  * [team_merge_request_sent_shown_to_secondary_team] - Available if .tag is
  * team_merge_request_sent_shown_to_secondary_team. (trusted_teams) Requested to
  * merge your team into another Dropbox team
- * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_internal_domains_changed'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_folder_contents_accessed'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_action_add_collaborator'|'protect_action_add_link'|'protect_action_delete'|'protect_action_export'|'protect_action_remove_collaborator'|'protect_action_remove_link'|'protect_action_stop_sharing'|'protect_internal_domains_changed'|'protect_policy_activated'|'protect_policy_deactivated'|'protect_policy_scheduled'|'protect_policy_updated'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
  * The type of the event.
  * @typedef {Object} TeamLogEventTypeArg
- * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_internal_domains_changed'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
+ * @property {('admin_alerting_alert_state_changed'|'admin_alerting_changed_alert_config'|'admin_alerting_triggered_alert'|'ransomware_restore_process_completed'|'ransomware_restore_process_started'|'app_blocked_by_permissions'|'app_link_team'|'app_link_user'|'app_unlink_team'|'app_unlink_user'|'integration_connected'|'integration_disconnected'|'file_add_comment'|'file_change_comment_subscription'|'file_delete_comment'|'file_edit_comment'|'file_like_comment'|'file_resolve_comment'|'file_unlike_comment'|'file_unresolve_comment'|'dash_added_comment_to_stack'|'dash_added_connector'|'dash_added_link_to_stack'|'dash_added_team_email_domain_allowlist'|'dash_admin_added_org_wide_connector'|'dash_admin_disabled_connector'|'dash_admin_enabled_connector'|'dash_admin_removed_org_wide_connector'|'dash_archived_stack'|'dash_changed_audience_of_shared_link_to_stack'|'dash_cloned_stack'|'dash_connector_tools_call'|'dash_created_stack'|'dash_deleted_comment_from_stack'|'dash_deleted_stack'|'dash_edited_comment_in_stack'|'dash_external_user_opened_stack'|'dash_first_launched_desktop'|'dash_first_launched_extension'|'dash_first_launched_web_start_page'|'dash_opened_shared_link_to_stack'|'dash_opened_stack'|'dash_preview_opt_out_status_changed'|'dash_removed_connector'|'dash_removed_link_from_stack'|'dash_removed_shared_link_to_stack'|'dash_removed_team_email_domain_allowlist'|'dash_renamed_stack'|'dash_shared_link_to_stack'|'dash_unarchived_stack'|'dash_viewed_company_stack'|'dash_viewed_external_ai_activity_report'|'governance_policy_add_folders'|'governance_policy_add_folder_failed'|'governance_policy_content_disposed'|'governance_policy_create'|'governance_policy_delete'|'governance_policy_edit_details'|'governance_policy_edit_duration'|'governance_policy_export_created'|'governance_policy_export_removed'|'governance_policy_remove_folders'|'governance_policy_report_created'|'governance_policy_zip_part_downloaded'|'legal_holds_activate_a_hold'|'legal_holds_add_members'|'legal_holds_change_hold_details'|'legal_holds_change_hold_name'|'legal_holds_export_a_hold'|'legal_holds_export_cancelled'|'legal_holds_export_downloaded'|'legal_holds_export_removed'|'legal_holds_release_a_hold'|'legal_holds_remove_members'|'legal_holds_report_a_hold'|'device_change_ip_desktop'|'device_change_ip_mobile'|'device_change_ip_web'|'device_delete_on_unlink_fail'|'device_delete_on_unlink_success'|'device_link_fail'|'device_link_success'|'device_management_disabled'|'device_management_enabled'|'device_sync_backup_status_changed'|'device_unlink'|'dropbox_passwords_exported'|'dropbox_passwords_new_device_enrolled'|'emm_refresh_auth_token'|'external_drive_backup_eligibility_status_checked'|'external_drive_backup_status_changed'|'account_capture_change_availability'|'account_capture_migrate_account'|'account_capture_notification_emails_sent'|'account_capture_relinquish_account'|'disabled_domain_invites'|'domain_invites_approve_request_to_join_team'|'domain_invites_decline_request_to_join_team'|'domain_invites_email_existing_users'|'domain_invites_request_to_join_team'|'domain_invites_set_invite_new_user_pref_to_no'|'domain_invites_set_invite_new_user_pref_to_yes'|'domain_verification_add_domain_fail'|'domain_verification_add_domain_success'|'domain_verification_remove_domain'|'enabled_domain_invites'|'encrypted_folder_cancel_team_key_rotation'|'encrypted_folder_enroll_backup_key'|'encrypted_folder_enroll_client'|'encrypted_folder_enroll_team'|'encrypted_folder_finish_team_unenrollment'|'encrypted_folder_init_team_key_rotation'|'encrypted_folder_init_team_unenrollment'|'encrypted_folder_remove_backup_key'|'encrypted_folder_rotate_team_key'|'encrypted_folder_unenroll_client'|'team_encryption_key_activate_key'|'team_encryption_key_cancel_key_deletion'|'team_encryption_key_create_key'|'team_encryption_key_deactivate_key'|'team_encryption_key_delete_key'|'team_encryption_key_disable_key'|'team_encryption_key_enable_key'|'team_encryption_key_rotate_key'|'team_encryption_key_schedule_key_deletion'|'apply_naming_convention'|'create_folder'|'file_add'|'file_add_from_automation'|'file_copy'|'file_delete'|'file_download'|'file_edit'|'file_get_copy_reference'|'file_locking_lock_status_changed'|'file_move'|'file_permanently_delete'|'file_preview'|'file_rename'|'file_restore'|'file_revert'|'file_rollback_changes'|'file_save_copy_reference'|'folder_overview_description_changed'|'folder_overview_item_pinned'|'folder_overview_item_unpinned'|'media_hub_file_downloaded'|'object_label_added'|'object_label_removed'|'object_label_updated_value'|'organize_folder_with_tidy'|'replay_file_delete'|'replay_file_downloaded'|'replay_team_project_created'|'rewind_folder'|'undo_naming_convention'|'undo_organize_folder_with_tidy'|'user_tags_added'|'user_tags_removed'|'email_ingest_receive_file'|'file_request_auto_close'|'file_request_change'|'file_request_close'|'file_request_create'|'file_request_delete'|'file_request_receive_file'|'group_add_external_id'|'group_add_member'|'group_change_external_id'|'group_change_management_type'|'group_change_member_role'|'group_create'|'group_delete'|'group_description_updated'|'group_external_sharing_setting_override_changed'|'group_join_policy_updated'|'group_moved'|'group_remove_external_id'|'group_remove_member'|'group_rename'|'account_lock_or_unlocked'|'emm_error'|'guest_admin_signed_in_via_trusted_teams'|'guest_admin_signed_out_via_trusted_teams'|'login_fail'|'login_success'|'logout'|'reseller_support_session_end'|'reseller_support_session_start'|'sign_in_as_session_end'|'sign_in_as_session_start'|'sso_error'|'addon_assigned'|'addon_removed'|'backup_admin_invitation_sent'|'backup_invitation_opened'|'create_team_invite_link'|'delete_team_invite_link'|'member_add_external_id'|'member_add_name'|'member_change_admin_role'|'member_change_email'|'member_change_external_id'|'member_change_membership_type'|'member_change_name'|'member_change_reseller_role'|'member_change_status'|'member_delete_manual_contacts'|'member_delete_profile_photo'|'member_folder_contents_accessed'|'member_permanently_delete_account_contents'|'member_remove_external_id'|'member_set_profile_photo'|'member_space_limits_add_custom_quota'|'member_space_limits_change_custom_quota'|'member_space_limits_change_status'|'member_space_limits_remove_custom_quota'|'member_suggest'|'member_transfer_account_contents'|'pending_secondary_email_added'|'product_assigned_to_member'|'product_removed_from_member'|'secondary_email_deleted'|'secondary_email_verified'|'secondary_mails_policy_changed'|'binder_add_page'|'binder_add_section'|'binder_remove_page'|'binder_remove_section'|'binder_rename_page'|'binder_rename_section'|'binder_reorder_page'|'binder_reorder_section'|'paper_content_add_member'|'paper_content_add_to_folder'|'paper_content_archive'|'paper_content_create'|'paper_content_permanently_delete'|'paper_content_remove_from_folder'|'paper_content_remove_member'|'paper_content_rename'|'paper_content_restore'|'paper_doc_add_comment'|'paper_doc_change_member_role'|'paper_doc_change_sharing_policy'|'paper_doc_change_subscription'|'paper_doc_deleted'|'paper_doc_delete_comment'|'paper_doc_download'|'paper_doc_edit'|'paper_doc_edit_comment'|'paper_doc_followed'|'paper_doc_mention'|'paper_doc_ownership_changed'|'paper_doc_request_access'|'paper_doc_resolve_comment'|'paper_doc_revert'|'paper_doc_slack_share'|'paper_doc_team_invite'|'paper_doc_trashed'|'paper_doc_unresolve_comment'|'paper_doc_untrashed'|'paper_doc_view'|'paper_external_view_allow'|'paper_external_view_default_team'|'paper_external_view_forbid'|'paper_folder_change_subscription'|'paper_folder_deleted'|'paper_folder_followed'|'paper_folder_team_invite'|'paper_published_link_change_permission'|'paper_published_link_create'|'paper_published_link_disabled'|'paper_published_link_view'|'password_change'|'password_reset'|'password_reset_all'|'protect_action_add_collaborator'|'protect_action_add_link'|'protect_action_delete'|'protect_action_export'|'protect_action_remove_collaborator'|'protect_action_remove_link'|'protect_action_stop_sharing'|'protect_internal_domains_changed'|'protect_policy_activated'|'protect_policy_deactivated'|'protect_policy_scheduled'|'protect_policy_updated'|'classification_create_report'|'classification_create_report_fail'|'emm_create_exceptions_report'|'emm_create_usage_report'|'export_members_report'|'export_members_report_fail'|'external_sharing_create_report'|'external_sharing_report_failed'|'member_access_details_create_report'|'member_access_details_create_report_failed'|'no_expiration_link_gen_create_report'|'no_expiration_link_gen_report_failed'|'no_password_link_gen_create_report'|'no_password_link_gen_report_failed'|'no_password_link_view_create_report'|'no_password_link_view_report_failed'|'outdated_link_view_create_report'|'outdated_link_view_report_failed'|'paper_admin_export_start'|'ransomware_alert_create_report'|'ransomware_alert_create_report_failed'|'shared_folders_create_report'|'shared_folders_create_report_failed'|'smart_sync_create_admin_privilege_report'|'team_activity_create_report'|'team_activity_create_report_fail'|'team_folders_create_report'|'team_folders_create_report_failed'|'team_storage_create_report'|'team_storage_create_report_failed'|'collection_share'|'file_transfers_file_add'|'file_transfers_transfer_delete'|'file_transfers_transfer_download'|'file_transfers_transfer_send'|'file_transfers_transfer_view'|'media_hub_project_team_add'|'media_hub_project_team_delete'|'media_hub_project_team_role_changed'|'media_hub_shared_link_audience_changed'|'media_hub_shared_link_created'|'media_hub_shared_link_download_setting_changed'|'media_hub_shared_link_revoked'|'note_acl_invite_only'|'note_acl_link'|'note_acl_team_link'|'note_shared'|'note_share_receive'|'open_note_shared'|'replay_file_shared_link_created'|'replay_file_shared_link_modified'|'replay_project_team_add'|'replay_project_team_delete'|'send_and_track_file_added'|'send_and_track_file_renamed'|'send_and_track_file_updated'|'send_and_track_link_created'|'send_and_track_link_deleted'|'send_and_track_link_updated'|'send_and_track_link_viewed'|'send_and_track_removed_file_and_associated_links'|'sf_add_group'|'sf_allow_non_members_to_view_shared_links'|'sf_external_invite_warn'|'sf_fb_invite'|'sf_fb_invite_change_role'|'sf_fb_uninvite'|'sf_invite_group'|'sf_team_grant_access'|'sf_team_invite'|'sf_team_invite_change_role'|'sf_team_join'|'sf_team_join_from_oob_link'|'sf_team_uninvite'|'shared_content_add_invitees'|'shared_content_add_link_expiry'|'shared_content_add_link_password'|'shared_content_add_member'|'shared_content_change_downloads_policy'|'shared_content_change_invitee_role'|'shared_content_change_link_audience'|'shared_content_change_link_expiry'|'shared_content_change_link_password'|'shared_content_change_member_role'|'shared_content_change_viewer_info_policy'|'shared_content_claim_invitation'|'shared_content_copy'|'shared_content_download'|'shared_content_relinquish_membership'|'shared_content_remove_invitees'|'shared_content_remove_link_expiry'|'shared_content_remove_link_password'|'shared_content_remove_member'|'shared_content_request_access'|'shared_content_restore_invitees'|'shared_content_restore_member'|'shared_content_unshare'|'shared_content_view'|'shared_folder_change_link_policy'|'shared_folder_change_members_inheritance_policy'|'shared_folder_change_members_management_policy'|'shared_folder_change_members_policy'|'shared_folder_create'|'shared_folder_decline_invitation'|'shared_folder_mount'|'shared_folder_nest'|'shared_folder_transfer_ownership'|'shared_folder_unmount'|'shared_link_add_expiry'|'shared_link_change_expiry'|'shared_link_change_visibility'|'shared_link_copy'|'shared_link_create'|'shared_link_disable'|'shared_link_download'|'shared_link_remove_expiry'|'shared_link_remove_visitor'|'shared_link_settings_add_expiration'|'shared_link_settings_add_password'|'shared_link_settings_allow_download_disabled'|'shared_link_settings_allow_download_enabled'|'shared_link_settings_change_audience'|'shared_link_settings_change_expiration'|'shared_link_settings_change_password'|'shared_link_settings_remove_expiration'|'shared_link_settings_remove_password'|'shared_link_share'|'shared_link_view'|'shared_note_opened'|'shmodel_disable_downloads'|'shmodel_enable_downloads'|'shmodel_group_share'|'showcase_access_granted'|'showcase_add_member'|'showcase_archived'|'showcase_created'|'showcase_delete_comment'|'showcase_edited'|'showcase_edit_comment'|'showcase_file_added'|'showcase_file_download'|'showcase_file_removed'|'showcase_file_view'|'showcase_permanently_deleted'|'showcase_post_comment'|'showcase_remove_member'|'showcase_renamed'|'showcase_request_access'|'showcase_resolve_comment'|'showcase_restored'|'showcase_trashed'|'showcase_trashed_deprecated'|'showcase_unresolve_comment'|'showcase_untrashed'|'showcase_untrashed_deprecated'|'showcase_view'|'sign_signature_request_canceled'|'sign_signature_request_completed'|'sign_signature_request_declined'|'sign_signature_request_opened'|'sign_signature_request_reminder_sent'|'sign_signature_request_sent'|'sign_template_created'|'sign_template_shared'|'risc_security_event'|'sso_add_cert'|'sso_add_login_url'|'sso_add_logout_url'|'sso_change_cert'|'sso_change_login_url'|'sso_change_logout_url'|'sso_change_saml_identity_mode'|'sso_remove_cert'|'sso_remove_login_url'|'sso_remove_logout_url'|'team_folder_change_status'|'team_folder_create'|'team_folder_downgrade'|'team_folder_permanently_delete'|'team_folder_rename'|'team_folder_space_limits_change_caps_type'|'team_folder_space_limits_change_limit'|'team_folder_space_limits_change_notification_target'|'team_selective_sync_settings_changed'|'account_capture_change_policy'|'admin_email_reminders_changed'|'ai_third_party_sharing_dropbox_base_policy_changed'|'allow_download_disabled'|'allow_download_enabled'|'apple_login_change_policy'|'app_permissions_changed'|'camera_uploads_policy_changed'|'capture_team_space_policy_changed'|'capture_transcript_policy_changed'|'classification_change_policy'|'computer_backup_policy_changed'|'content_administration_policy_changed'|'content_deletion_protection_change_policy'|'dash_external_sharing_policy_changed'|'data_placement_restriction_change_policy'|'data_placement_restriction_satisfy_policy'|'device_approvals_add_exception'|'device_approvals_change_desktop_policy'|'device_approvals_change_mobile_policy'|'device_approvals_change_overage_action'|'device_approvals_change_unlink_action'|'device_approvals_remove_exception'|'directory_restrictions_add_members'|'directory_restrictions_remove_members'|'dropbox_passwords_policy_changed'|'email_ingest_policy_changed'|'emm_add_exception'|'emm_change_policy'|'emm_remove_exception'|'extended_version_history_change_policy'|'external_drive_backup_policy_changed'|'file_comments_change_policy'|'file_locking_policy_changed'|'file_provider_migration_policy_changed'|'file_requests_change_policy'|'file_requests_emails_enabled'|'file_requests_emails_restricted_to_team_only'|'file_transfers_policy_changed'|'flexible_file_names_policy_changed'|'folder_link_restriction_policy_changed'|'google_sso_change_policy'|'group_user_management_change_policy'|'integration_policy_changed'|'invite_acceptance_email_policy_changed'|'media_hub_adding_people_policy_changed'|'media_hub_download_policy_changed'|'media_hub_link_sharing_policy_changed'|'member_requests_change_policy'|'member_send_invite_policy_changed'|'member_space_limits_add_exception'|'member_space_limits_change_caps_type_policy'|'member_space_limits_change_policy'|'member_space_limits_remove_exception'|'member_suggestions_change_policy'|'microsoft_login_change_policy'|'microsoft_office_addin_change_policy'|'multi_team_identity_policy_changed'|'network_control_change_policy'|'paper_change_deployment_policy'|'paper_change_member_link_policy'|'paper_change_member_policy'|'paper_change_policy'|'paper_default_folder_policy_changed'|'paper_desktop_policy_changed'|'paper_enabled_users_group_addition'|'paper_enabled_users_group_removal'|'passkey_login_policy_changed'|'password_strength_requirements_change_policy'|'permanent_delete_change_policy'|'previews_ai_policy_changed'|'replay_adding_people_policy_changed'|'replay_sharing_policy_changed'|'reseller_support_change_policy'|'rewind_policy_changed'|'send_and_track_policy_changed'|'send_external_sharing_policy_changed'|'send_for_signature_policy_changed'|'shared_link_default_permissions_policy_changed'|'sharing_change_folder_join_policy'|'sharing_change_link_allow_change_expiration_policy'|'sharing_change_link_default_expiration_policy'|'sharing_change_link_enforce_password_policy'|'sharing_change_link_policy'|'sharing_change_member_policy'|'showcase_change_download_policy'|'showcase_change_enabled_policy'|'showcase_change_external_sharing_policy'|'sign_external_sharing_policy_changed'|'sign_template_creation_permission_changed'|'smarter_smart_sync_policy_changed'|'smart_sync_change_policy'|'smart_sync_not_opt_out'|'smart_sync_opt_out'|'sso_change_policy'|'stack_cross_team_access_policy_changed'|'team_branding_policy_changed'|'team_extensions_policy_changed'|'team_member_storage_request_policy_changed'|'team_selective_sync_policy_changed'|'team_sharing_whitelist_subjects_changed'|'tfa_add_exception'|'tfa_change_policy'|'tfa_remove_exception'|'top_level_content_policy_changed'|'two_account_change_policy'|'viewer_info_policy_changed'|'watermarking_policy_changed'|'web_sessions_change_active_session_limit'|'web_sessions_change_fixed_length_policy'|'web_sessions_change_idle_length_policy'|'data_residency_migration_request_successful'|'data_residency_migration_request_unsuccessful'|'team_merge_from'|'team_merge_to'|'team_profile_add_background'|'team_profile_add_logo'|'team_profile_change_background'|'team_profile_change_default_language'|'team_profile_change_logo'|'team_profile_change_name'|'team_profile_remove_background'|'team_profile_remove_logo'|'passkey_add'|'passkey_remove'|'tfa_add_backup_phone'|'tfa_add_security_key'|'tfa_change_backup_phone'|'tfa_change_status'|'tfa_remove_backup_phone'|'tfa_remove_security_key'|'tfa_reset'|'changed_enterprise_admin_role'|'changed_enterprise_connected_team_status'|'ended_enterprise_admin_session'|'ended_enterprise_admin_session_deprecated'|'enterprise_settings_locking'|'guest_admin_change_status'|'started_enterprise_admin_session'|'team_merge_request_accepted'|'team_merge_request_accepted_shown_to_primary_team'|'team_merge_request_accepted_shown_to_secondary_team'|'team_merge_request_auto_canceled'|'team_merge_request_canceled'|'team_merge_request_canceled_shown_to_primary_team'|'team_merge_request_canceled_shown_to_secondary_team'|'team_merge_request_expired'|'team_merge_request_expired_shown_to_primary_team'|'team_merge_request_expired_shown_to_secondary_team'|'team_merge_request_rejected_shown_to_primary_team'|'team_merge_request_rejected_shown_to_secondary_team'|'team_merge_request_reminder'|'team_merge_request_reminder_shown_to_primary_team'|'team_merge_request_reminder_shown_to_secondary_team'|'team_merge_request_revoked'|'team_merge_request_sent_shown_to_primary_team'|'team_merge_request_sent_shown_to_secondary_team'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
@@ -15421,7 +15593,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for adding people to Media Hub content.
+ * Changed the policy for adding people to Replay content.
  * @typedef {Object} TeamLogMediaHubAddingPeoplePolicyChangedDetails
  * @property {TeamLogMediaHubAddingPeoplePolicy} new_value - To.
  * @property {TeamLogMediaHubAddingPeoplePolicy} previous_value - From.
@@ -15439,7 +15611,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for downloading Media Hub content.
+ * Changed the policy for downloading Replay content.
  * @typedef {Object} TeamLogMediaHubDownloadPolicyChangedDetails
  * @property {TeamLogMediaHubDownloadPolicy} new_value - To.
  * @property {TeamLogMediaHubDownloadPolicy} previous_value - From.
@@ -15451,7 +15623,7 @@ possible subtypes.
  */
 
 /**
- * Downloaded files in Media Hub.
+ * Downloaded files in Replay.
  * @typedef {Object} TeamLogMediaHubFileDownloadedDetails
  */
 
@@ -15467,7 +15639,7 @@ possible subtypes.
  */
 
 /**
- * Changed the policy for sharing Media Hub content.
+ * Changed the policy for sharing Replay content.
  * @typedef {Object} TeamLogMediaHubLinkSharingPolicyChangedDetails
  * @property {TeamLogMediaHubLinkSharingPolicy} new_value - To.
  * @property {TeamLogMediaHubLinkSharingPolicy} previous_value - From.
@@ -15479,14 +15651,22 @@ possible subtypes.
  */
 
 /**
+ * Replay project
+ * @typedef {Object} TeamLogMediaHubProjectLogInfo
+ * @property {string} project_name - Replay project name.
+ * @property {string} [project_id] - Replay project ID.
+ */
+
+/**
  * Media Hub project role
  * @typedef {Object} TeamLogMediaHubProjectRole
  * @property {('editor'|'owner'|'reviewer'|'other')} .tag - Tag identifying the union variant.
  */
 
 /**
- * Added member to Media Hub project.
+ * Added member to Replay project.
  * @typedef {Object} TeamLogMediaHubProjectTeamAddDetails
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15495,8 +15675,9 @@ possible subtypes.
  */
 
 /**
- * Removed member from Media Hub project.
+ * Removed member from Replay project.
  * @typedef {Object} TeamLogMediaHubProjectTeamDeleteDetails
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15505,11 +15686,12 @@ possible subtypes.
  */
 
 /**
- * Changed member role in Media Hub project.
+ * Changed member role in Replay project.
  * @typedef {Object} TeamLogMediaHubProjectTeamRoleChangedDetails
  * @property {TeamLogMediaHubProjectRole} previous_role - Previous Media Hub
  * project role.
  * @property {TeamLogMediaHubProjectRole} new_role - New Media Hub project role.
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15524,7 +15706,7 @@ possible subtypes.
  */
 
 /**
- * Changed Media Hub shared link audience.
+ * Changed Replay shared link audience.
  * @typedef {Object} TeamLogMediaHubSharedLinkAudienceChangedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
@@ -15532,6 +15714,7 @@ possible subtypes.
  * Hub shared link audience.
  * @property {TeamLogMediaHubSharedLinkAudience} new_value - New Media Hub
  * shared link audience.
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15540,12 +15723,13 @@ possible subtypes.
  */
 
 /**
- * Created Media Hub shared link.
+ * Created Replay shared link.
  * @typedef {Object} TeamLogMediaHubSharedLinkCreatedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
  * @property {TeamLogMediaHubSharedLinkAudience} audience - Media Hub shared
  * link audience.
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15560,7 +15744,7 @@ possible subtypes.
  */
 
 /**
- * Changed Media Hub shared link download setting.
+ * Changed Replay shared link download setting.
  * @typedef {Object} TeamLogMediaHubSharedLinkDownloadSettingChangedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
@@ -15568,6 +15752,7 @@ possible subtypes.
  * Previous Media Hub shared link download setting.
  * @property {TeamLogMediaHubSharedLinkDownloadSetting} new_value - New Media
  * Hub shared link download setting.
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15576,10 +15761,11 @@ possible subtypes.
  */
 
 /**
- * Revoked Media Hub shared link.
+ * Revoked Replay shared link.
  * @typedef {Object} TeamLogMediaHubSharedLinkRevokedDetails
  * @property {TeamLogMediaHubSharedLinkTargetType} target_type - Media Hub
  * shared link target type.
+ * @property {TeamLogMediaHubProjectLogInfo} [project] - Replay project.
  */
 
 /**
@@ -15753,6 +15939,16 @@ possible subtypes.
 
 /**
  * @typedef {Object} TeamLogMemberDeleteProfilePhotoType
+ * @property {string} description
+ */
+
+/**
+ * Admin browsed a team member's folder contents.
+ * @typedef {Object} TeamLogMemberFolderContentsAccessedDetails
+ */
+
+/**
+ * @typedef {Object} TeamLogMemberFolderContentsAccessedType
  * @property {string} description
  */
 
@@ -17194,6 +17390,83 @@ subtypes.
  */
 
 /**
+ * Added collaborators via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionAddCollaboratorDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionAddCollaboratorType
+ * @property {string} description
+ */
+
+/**
+ * Added a link via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionAddLinkDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionAddLinkType
+ * @property {string} description
+ */
+
+/**
+ * Deleted content via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionDeleteDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionDeleteType
+ * @property {string} description
+ */
+
+/**
+ * Exported content via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionExportDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionExportType
+ * @property {string} description
+ */
+
+/**
+ * Removed collaborators via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionRemoveCollaboratorDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionRemoveCollaboratorType
+ * @property {string} description
+ */
+
+/**
+ * Removed a link via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionRemoveLinkDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionRemoveLinkType
+ * @property {string} description
+ */
+
+/**
+ * Stopped sharing content via Dropbox Protect.
+ * @typedef {Object} TeamLogProtectActionStopSharingDetails
+ * @property {string} action_id - Action ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectActionStopSharingType
+ * @property {string} description
+ */
+
+/**
  * Modified Protect internal domains list.
  * @typedef {Object} TeamLogProtectInternalDomainsChangedDetails
  * @property {Array.<string>} [domains_added] - Domains added to the internal
@@ -17204,6 +17477,50 @@ subtypes.
 
 /**
  * @typedef {Object} TeamLogProtectInternalDomainsChangedType
+ * @property {string} description
+ */
+
+/**
+ * Activated a Dropbox Protect policy.
+ * @typedef {Object} TeamLogProtectPolicyActivatedDetails
+ * @property {string} policy_id - Policy ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectPolicyActivatedType
+ * @property {string} description
+ */
+
+/**
+ * Deactivated a Dropbox Protect policy.
+ * @typedef {Object} TeamLogProtectPolicyDeactivatedDetails
+ * @property {string} policy_id - Policy ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectPolicyDeactivatedType
+ * @property {string} description
+ */
+
+/**
+ * Scheduled a Dropbox Protect policy.
+ * @typedef {Object} TeamLogProtectPolicyScheduledDetails
+ * @property {string} policy_id - Policy ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectPolicyScheduledType
+ * @property {string} description
+ */
+
+/**
+ * Updated a Dropbox Protect policy.
+ * @typedef {Object} TeamLogProtectPolicyUpdatedDetails
+ * @property {string} policy_id - Policy ID.
+ */
+
+/**
+ * @typedef {Object} TeamLogProtectPolicyUpdatedType
  * @property {string} description
  */
 

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -73,21 +73,21 @@ export default class Dropbox {
     Object.assign(this, routes);
   }
 
-  request(path, args, auth, host, style) {
-    // scope is provided after "style", but unused in requests, so it's not in parameters
+  request(path, args, auth, host, style, scope, options) {
+    // scope is currently unused by the transport layer
     switch (style) {
       case RPC:
-        return this.rpcRequest(path, args, auth, host);
+        return this.rpcRequest(path, args, auth, host, options);
       case DOWNLOAD:
-        return this.downloadRequest(path, args, auth, host);
+        return this.downloadRequest(path, args, auth, host, options);
       case UPLOAD:
-        return this.uploadRequest(path, args, auth, host);
+        return this.uploadRequest(path, args, auth, host, options);
       default:
         throw new Error(`Invalid request style: ${style}`);
     }
   }
 
-  rpcRequest(path, body, auth, host) {
+  rpcRequest(path, body, auth, host, options) {
     return this.auth.checkAndRefreshAccessToken()
       .then(() => {
         const fetchOptions = {
@@ -95,6 +95,10 @@ export default class Dropbox {
           body: (body) ? JSON.stringify(body) : null,
           headers: {},
         };
+
+        if (options && options.signal) {
+          fetchOptions.signal = options.signal;
+        }
 
         if (body) {
           fetchOptions.headers['Content-Type'] = 'application/json';
@@ -112,7 +116,7 @@ export default class Dropbox {
       .then((res) => parseResponse(res));
   }
 
-  downloadRequest(path, args, auth, host) {
+  downloadRequest(path, args, auth, host, options) {
     return this.auth.checkAndRefreshAccessToken()
       .then(() => {
         const fetchOptions = {
@@ -121,6 +125,10 @@ export default class Dropbox {
             'Dropbox-API-Arg': httpHeaderSafeJson(args),
           },
         };
+
+        if (options && options.signal) {
+          fetchOptions.signal = options.signal;
+        }
 
         this.setAuthHeaders(auth, fetchOptions);
         this.setCommonHeaders(fetchOptions);
@@ -134,7 +142,7 @@ export default class Dropbox {
       .then((res) => parseDownloadResponse(res));
   }
 
-  uploadRequest(path, args, auth, host) {
+  uploadRequest(path, args, auth, host, options) {
     return this.auth.checkAndRefreshAccessToken()
       .then(async () => {
         const requestArgs = Object.assign({}, args); // eslint-disable-line prefer-object-spread
@@ -154,6 +162,10 @@ export default class Dropbox {
             'Dropbox-API-Arg': httpHeaderSafeJson(requestArgs),
           },
         };
+
+        if (options && options.signal) {
+          fetchOptions.signal = options.signal;
+        }
 
         if (contents && typeof contents.pipe === 'function') {
           fetchOptions.duplex = 'half';

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -165,13 +165,6 @@ describe('Dropbox', () => {
         fetch: fetchStub,
       });
 
-      fetchStub.resolves({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        text: () => Promise.resolve('{}'),
-      });
-
       return dbx.uploadRequest(
         'path',
         { contents: 'test' },

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -151,6 +151,39 @@ describe('Dropbox', () => {
       });
     });
 
+    it('passes request signal to upload fetch', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      return dbx.uploadRequest(
+        'path',
+        { contents: 'test' },
+        USER_AUTH,
+        'content',
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
+    });
+
     it('preserves an explicit content_hash', () => {
       const fetchStub = sinon.stub().resolves(
         new Response('{}', { status: 200 }),
@@ -193,18 +226,11 @@ describe('Dropbox', () => {
         ok: true,
         status: 200,
         headers: new Headers(),
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const dbx = new Dropbox({
         fetch: fetchStub,
-      });
-
-      fetchStub.resolves({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        text: () => Promise.resolve('{}'),
       });
 
       return dbx.rpcRequest(
@@ -212,69 +238,6 @@ describe('Dropbox', () => {
         {},
         USER_AUTH,
         'api',
-        { signal: controller.signal },
-      ).then(() => {
-        const fetchOptions = fetchStub.firstCall.args[1];
-        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
-      });
-    });
-
-    it('passes request signal to download fetch', () => {
-      const controller = new AbortController();
-
-      const fetchStub = sinon.stub().resolves({
-        ok: true,
-        status: 200,
-        headers: {
-          get: (name) => (
-            name === 'dropbox-api-result' ? '{}' : null
-          ),
-        },
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-      });
-
-      const dbx = new Dropbox({
-        fetch: fetchStub,
-      });
-
-      return dbx.downloadRequest(
-        'path',
-        {},
-        USER_AUTH,
-        'content',
-        { signal: controller.signal },
-      ).then(() => {
-        const fetchOptions = fetchStub.firstCall.args[1];
-        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
-      });
-    });
-
-    it('passes request signal to upload fetch', () => {
-      const controller = new AbortController();
-
-      const fetchStub = sinon.stub().resolves({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        text: () => Promise.resolve('{}'),
-      });
-
-      const dbx = new Dropbox({
-        fetch: fetchStub,
-      });
-
-      fetchStub.resolves({
-        ok: true,
-        status: 200,
-        headers: new Headers(),
-        text: () => Promise.resolve('{}'),
-      });
-
-      return dbx.uploadRequest(
-        'path',
-        { contents: 'test' },
-        USER_AUTH,
-        'content',
         { signal: controller.signal },
       ).then(() => {
         const fetchOptions = fetchStub.firstCall.args[1];
@@ -431,6 +394,36 @@ describe('Dropbox', () => {
       chai.assert.isTrue(downloadSpy.calledOnce);
       chai.assert.equal('path', dbx.downloadRequest.getCall(0).args[0]);
       chai.assert.deepEqual({}, dbx.downloadRequest.getCall(0).args[1]);
+    });
+
+    it('passes request signal to download fetch', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name) => (
+            name === 'dropbox-api-result' ? '{}' : null
+          ),
+        },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      return dbx.downloadRequest(
+        'path',
+        {},
+        USER_AUTH,
+        'content',
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
     });
   });
 

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -98,6 +98,29 @@ describe('Dropbox', () => {
       chai.assert.deepEqual({}, dbx.rpcRequest.getCall(0).args[1]);
     });
 
+    it('passes request signal through a generated route', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      return dbx.filesGetMetadata(
+        { path: '/test.txt' },
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
+    });
+
     it('completes a cookie auth RPC request', () => {
       const dbxAuth = new DropboxAuth();
       const dbx = new Dropbox({ auth: dbxAuth });

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -186,6 +186,102 @@ describe('Dropbox', () => {
       });
     });
 
+    it('passes request signal to RPC fetch', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () => Promise.resolve({}),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      return dbx.rpcRequest(
+        'path',
+        {},
+        USER_AUTH,
+        'api',
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
+    });
+
+    it('passes request signal to download fetch', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name) => (
+            name === 'dropbox-api-result' ? '{}' : null
+          ),
+        },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      return dbx.downloadRequest(
+        'path',
+        {},
+        USER_AUTH,
+        'content',
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
+    });
+
+    it('passes request signal to upload fetch', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({
+        fetch: fetchStub,
+      });
+
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      return dbx.uploadRequest(
+        'path',
+        { contents: 'test' },
+        USER_AUTH,
+        'content',
+        { signal: controller.signal },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(fetchOptions.signal, controller.signal);
+      });
+    });
+
     it('does not add content_hash when autoContentHash is false', () => {
       const fetchStub = sinon.stub().resolves(
         new Response('{}', { status: 200 }),

--- a/types/dropbox_types.d.ts
+++ b/types/dropbox_types.d.ts
@@ -7421,20 +7421,11 @@
       end_time?: number;
     }
 
-    /**
-     * An unexpected, typically transient, server-side failure. The string is a
-     * human-readable message; retrying with backoff may succeed.
-     */
     export interface ContentApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
-    /**
-     * The request could not be processed as supplied (a problem with the
-     * caller's input). The string is a human-readable message; retrying the
-     * same request will not help.
-     */
     export interface ContentApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7478,44 +7469,63 @@
       '.tag': 'other';
     }
 
-    /**
-     * Reason a transcript job failed. Returned in the `failed` variant of
-     * `GetTranscriptAsyncCheckResult`. This is a semantic error union: the HTTP
-     * status of the poll request itself is unaffected (a poll that surfaces a
-     * failed job is still a normal successful poll response). Callers should
-     * branch on the variant.
-     */
     export type ContentApiV2Error = ContentApiV2ErrorServerError | ContentApiV2ErrorUserError | ContentApiV2ErrorMediaDurationError | ContentApiV2ErrorNoAudioError | ContentApiV2ErrorLinkDownloadDisabledError | ContentApiV2ErrorSharedLinkPasswordProtected | ContentApiV2ErrorLimitExceededError | ContentApiV2ErrorNotFoundError | ContentApiV2ErrorIsAFolderError | ContentApiV2ErrorOther;
 
+    export interface ErrorCodeUnknownError {
+      '.tag': 'unknown_error';
+    }
+
     /**
-     * A Dropbox-issued file id (format: "id:<id>") for a file the authenticated
-     * user has access to.
+     * 400
      */
+    export interface ErrorCodeBadRequest {
+      '.tag': 'bad_request';
+    }
+
+    /**
+     * 409
+     */
+    export interface ErrorCodeApiError {
+      '.tag': 'api_error';
+    }
+
+    /**
+     * 403
+     */
+    export interface ErrorCodeAccessError {
+      '.tag': 'access_error';
+    }
+
+    /**
+     * 429
+     */
+    export interface ErrorCodeRatelimitError {
+      '.tag': 'ratelimit_error';
+    }
+
+    /**
+     * 503
+     */
+    export interface ErrorCodeUnavailable {
+      '.tag': 'unavailable';
+    }
+
+    export interface ErrorCodeOther {
+      '.tag': 'other';
+    }
+
+    export type ErrorCode = ErrorCodeUnknownError | ErrorCodeBadRequest | ErrorCodeApiError | ErrorCodeAccessError | ErrorCodeRatelimitError | ErrorCodeUnavailable | ErrorCodeOther;
+
     export interface FileIdOrUrlFileId {
       '.tag': 'file_id';
       file_id: string;
     }
 
-    /**
-     * Either a Dropbox shared link (www.dropbox.com) or an external HTTP or
-     * HTTPS URL pointing to a supported file. - Dropbox shared links are
-     * resolved internally using the caller's authenticated identity and the
-     * link's visibility / download settings. They therefore require an
-     * authenticated user context (anonymous `url` requests against Dropbox
-     * links are rejected with an `access_error`). Links protected by a password
-     * are rejected with `shared_link_password_protected`; links with downloads
-     * disabled are rejected with `link_download_disabled_error`. - External
-     * URLs are fetched through the backend's egress proxy and must point at a
-     * supported file extension.
-     */
     export interface FileIdOrUrlUrl {
       '.tag': 'url';
       url: string;
     }
 
-    /**
-     * An absolute Dropbox path, e.g. "/folder/example.pdf".
-     */
     export interface FileIdOrUrlPath {
       '.tag': 'path';
       path: string;
@@ -7535,9 +7545,21 @@
     export interface GetMarkdownArgs {
       /**
        * Identifier of the document to convert. Callers must set exactly one of
-       * the `FileIdOrUrl` variants. The referenced file must be a document in a
-       * supported format (see the route description for the list); requests
-       * against unsupported formats return `unsupported_format_error`.
+       * the oneof variants: - file_id: a Dropbox-issued file id (format:
+       * "id:<id>") for a file the authenticated user has access to. - path: an
+       * absolute Dropbox path, e.g. "/folder/report.docx". - url: either a
+       * Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
+       * to a supported document file. - Dropbox shared links are resolved
+       * internally using the caller's authenticated identity and the link's
+       * visibility / download settings. They therefore require an authenticated
+       * user context (anonymous `url` requests against Dropbox links are
+       * rejected with an `ACCESS_ERROR`). Links protected by a password are
+       * rejected with `shared_link_password_protected`; links with downloads
+       * disabled are rejected with `link_download_disabled_error`. - External
+       * URLs are fetched over HTTPS through the backend's egress proxy and must
+       * point at a supported document file extension. The referenced file must
+       * be a document in a supported format; requests against unsupported
+       * formats return `unsupported_format_error`.
        */
       file_id_or_url?: FileIdOrUrl;
       /**
@@ -7558,9 +7580,8 @@
       '.tag': 'complete';
     }
 
-    export interface GetMarkdownAsyncCheckResultFailed {
+    export interface GetMarkdownAsyncCheckResultFailed extends GetMarkdownAsyncError {
       '.tag': 'failed';
-      failed: MarkdownConversionApiV2Error;
     }
 
     export interface GetMarkdownAsyncCheckResultOther {
@@ -7571,6 +7592,19 @@
      * Result type for EventBus async check
      */
     export type GetMarkdownAsyncCheckResult = GetMarkdownAsyncCheckResultInProgress | GetMarkdownAsyncCheckResultComplete | GetMarkdownAsyncCheckResultFailed | GetMarkdownAsyncCheckResultOther;
+
+    export interface GetMarkdownAsyncError {
+      /**
+       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
+       * Void, False, None), UnionField('bad_request', Void, False, None),
+       * UnionField('api_error', Void, False, None), UnionField('access_error',
+       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
+       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
+       * True, None)]), 'unknown_error').
+       */
+      error_code?: ErrorCode;
+      error_details?: MarkdownConversionApiV2Error;
+    }
 
     export interface GetMarkdownResult {
       /**
@@ -7587,11 +7621,22 @@
     export interface GetMetadataArgs {
       /**
        * Identifier of the file to extract metadata from. Callers must set
-       * exactly one of the `FileIdOrUrl` variants. The kind of metadata
-       * returned is determined by the file type: image files return EXIF
-       * metadata, audio/video files return media metadata, PDFs return PDF
-       * metadata, and MS Office documents (docx, pptx, xlsx) return Office
-       * metadata. See the route description for the supported formats. Requests
+       * exactly one of the oneof variants: - file_id: a Dropbox-issued file id
+       * (format: "id:<id>") for a file the authenticated user has access to. -
+       * path: an absolute Dropbox path, e.g. "/folder/photo.jpg". - url: either
+       * a Dropbox shared link (www.dropbox.com) or an external HTTPS URL
+       * pointing to a supported file. - Dropbox shared links are resolved
+       * internally using the caller's authenticated identity and the link's
+       * visibility / download settings. They therefore require an authenticated
+       * user context (anonymous `url` requests against Dropbox links are
+       * rejected with an `ACCESS_ERROR`). Links protected by a password are
+       * rejected with `shared_link_password_protected`; links with downloads
+       * disabled are rejected with `link_download_disabled_error`. - External
+       * URLs are fetched over HTTPS through the backend's egress proxy and must
+       * point at a supported file extension. The kind of metadata returned is
+       * determined by the file type: image files return EXIF metadata,
+       * audio/video files return media metadata, PDFs return PDF metadata, and
+       * MS Office documents (docx, pptx, xlsx) return Office metadata. Requests
        * against unsupported formats return `unsupported_format_error`.
        */
       file_id_or_url?: FileIdOrUrl;
@@ -7605,9 +7650,8 @@
       '.tag': 'complete';
     }
 
-    export interface GetMetadataAsyncCheckResultFailed {
+    export interface GetMetadataAsyncCheckResultFailed extends GetMetadataAsyncError {
       '.tag': 'failed';
-      failed: MetadataExtractionApiV2Error;
     }
 
     export interface GetMetadataAsyncCheckResultOther {
@@ -7618,6 +7662,19 @@
      * Result type for EventBus async check - must end in "CheckResult"
      */
     export type GetMetadataAsyncCheckResult = GetMetadataAsyncCheckResultInProgress | GetMetadataAsyncCheckResultComplete | GetMetadataAsyncCheckResultFailed | GetMetadataAsyncCheckResultOther;
+
+    export interface GetMetadataAsyncError {
+      /**
+       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
+       * Void, False, None), UnionField('bad_request', Void, False, None),
+       * UnionField('api_error', Void, False, None), UnionField('access_error',
+       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
+       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
+       * True, None)]), 'unknown_error').
+       */
+      error_code?: ErrorCode;
+      error_details?: MetadataExtractionApiV2Error;
+    }
 
     export interface GetMetadataResult {
       /**
@@ -7634,55 +7691,6 @@
     }
 
     /**
-     * Arguments for the asynchronous `get_text_async` route. Exactly one of
-     * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
-     * identify the document whose plain-text content should be extracted.
-     */
-    export interface GetTextArgs {
-      /**
-       * Identifier of the document to extract text from. Callers must set
-       * exactly one of the `FileIdOrUrl` variants. Text extraction is supported
-       * for common document formats (Word, PowerPoint, Excel, PDF, RTF, and
-       * Dropbox document types); see the route description for the supported
-       * formats. Requests against unsupported formats return
-       * `unsupported_format_error`. NOTE: for the `url` variant, only Dropbox
-       * shared links (www.dropbox.com) are supported. External (non-Dropbox)
-       * URLs are not supported and return `unsupported_format_error`; import
-       * the file into Dropbox and reference it by `file_id` or `path` instead.
-       */
-      file_id_or_url?: FileIdOrUrl;
-    }
-
-    export interface GetTextAsyncCheckResultInProgress {
-      '.tag': 'in_progress';
-    }
-
-    export interface GetTextAsyncCheckResultComplete extends GetTextResult {
-      '.tag': 'complete';
-    }
-
-    export interface GetTextAsyncCheckResultFailed {
-      '.tag': 'failed';
-      failed: TextExtractionApiV2Error;
-    }
-
-    export interface GetTextAsyncCheckResultOther {
-      '.tag': 'other';
-    }
-
-    /**
-     * Result type for EventBus async check - must end in "CheckResult"
-     */
-    export type GetTextAsyncCheckResult = GetTextAsyncCheckResultInProgress | GetTextAsyncCheckResultComplete | GetTextAsyncCheckResultFailed | GetTextAsyncCheckResultOther;
-
-    export interface GetTextResult {
-      /**
-       * Defaults to .
-       */
-      text?: string;
-    }
-
-    /**
      * Arguments for the asynchronous `get_transcript_async` route. Exactly one
      * of `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
      * identify the audio or video asset to transcribe.
@@ -7690,16 +7698,28 @@
     export interface GetTranscriptArgs {
       /**
        * Identifier of the media asset to transcribe. Callers must set exactly
-       * one of the `FileIdOrUrl` variants. The referenced asset must be an
-       * audio or video file in a supported format (see the route description
-       * for the list); requests against files with no audio track return a
-       * `no_audio_error`.
+       * one of the oneof variants: - file_id: a Dropbox-issued file id (format:
+       * "id:<id>") for a file the authenticated user has access to. - path: an
+       * absolute Dropbox path, e.g. "/folder/recording.mp4". - url: either a
+       * Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
+       * to a supported audio/video file. - Dropbox shared links are resolved
+       * internally using the caller's authenticated identity and the link's
+       * visibility / download settings. They therefore require an authenticated
+       * user context (anonymous `url` requests against Dropbox links are
+       * rejected with an `ACCESS_ERROR`). Links protected by a password are
+       * rejected with `shared_link_password_protected`; links with downloads
+       * disabled are rejected with `link_download_disabled_error`. - External
+       * URLs are fetched over HTTPS through the backend's egress proxy and must
+       * point at a supported audio/video file extension. The referenced asset
+       * must be an audio or video file in a supported format; requests against
+       * files with no audio track return a `no_audio_error`.
        */
       file_id_or_url?: FileIdOrUrl;
       /**
-       * Defaults to TagRef(Union('TimestampLevel', [UnionField('sentence',
-       * Void, False, None), UnionField('word', Void, False, None),
-       * UnionField('other', Void, True, None)]), 'sentence').
+       * Defaults to TagRef(Union('TimestampLevel', [UnionField('unknown', Void,
+       * False, None), UnionField('sentence', Void, False, None),
+       * UnionField('word', Void, False, None), UnionField('other', Void, True,
+       * None)]), 'unknown').
        */
       timestamp_level?: TimestampLevel;
       /**
@@ -7720,9 +7740,8 @@
       '.tag': 'complete';
     }
 
-    export interface GetTranscriptAsyncCheckResultFailed {
+    export interface GetTranscriptAsyncCheckResultFailed extends GetTranscriptAsyncError {
       '.tag': 'failed';
-      failed: ContentApiV2Error;
     }
 
     export interface GetTranscriptAsyncCheckResultOther {
@@ -7734,6 +7753,19 @@
      */
     export type GetTranscriptAsyncCheckResult = GetTranscriptAsyncCheckResultInProgress | GetTranscriptAsyncCheckResultComplete | GetTranscriptAsyncCheckResultFailed | GetTranscriptAsyncCheckResultOther;
 
+    export interface GetTranscriptAsyncError {
+      /**
+       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
+       * Void, False, None), UnionField('bad_request', Void, False, None),
+       * UnionField('api_error', Void, False, None), UnionField('access_error',
+       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
+       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
+       * True, None)]), 'unknown_error').
+       */
+      error_code?: ErrorCode;
+      error_details?: ContentApiV2Error;
+    }
+
     export interface GetTranscriptResult {
       /**
        * The structured transcript produced for the requested media asset, with
@@ -7743,20 +7775,11 @@
       structured_transcript?: ApiStructuredTranscript;
     }
 
-    /**
-     * An unexpected, typically transient, server-side failure. The string is a
-     * human-readable message; retrying with backoff may succeed.
-     */
     export interface MarkdownConversionApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
-    /**
-     * The request could not be processed as supplied (a problem with the
-     * caller's input). The string is a human-readable message; retrying the
-     * same request will not help.
-     */
     export interface MarkdownConversionApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7800,13 +7823,6 @@
       '.tag': 'other';
     }
 
-    /**
-     * Reason a markdown conversion job failed. Returned in the `failed` variant
-     * of `GetMarkdownAsyncCheckResult`. This is a semantic error union: the
-     * HTTP status of the poll request itself is unaffected (a poll that
-     * surfaces a failed job is still a normal successful poll response).
-     * Callers should branch on the variant.
-     */
     export type MarkdownConversionApiV2Error = MarkdownConversionApiV2ErrorServerError | MarkdownConversionApiV2ErrorUserError | MarkdownConversionApiV2ErrorUnsupportedFormatError | MarkdownConversionApiV2ErrorLinkDownloadDisabledError | MarkdownConversionApiV2ErrorSharedLinkPasswordProtected | MarkdownConversionApiV2ErrorLimitExceededError | MarkdownConversionApiV2ErrorConversionFailureError | MarkdownConversionApiV2ErrorNotFoundError | MarkdownConversionApiV2ErrorIsAFolderError | MarkdownConversionApiV2ErrorOther;
 
     export interface MediaDurationError {
@@ -7816,20 +7832,11 @@
       limit?: number;
     }
 
-    /**
-     * An unexpected, typically transient, server-side failure. The string is a
-     * human-readable message; retrying with backoff may succeed.
-     */
     export interface MetadataExtractionApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
-    /**
-     * The request could not be processed as supplied (a problem with the
-     * caller's input). The string is a human-readable message; retrying the
-     * same request will not help.
-     */
     export interface MetadataExtractionApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7873,13 +7880,6 @@
       '.tag': 'other';
     }
 
-    /**
-     * Reason a metadata extraction job failed. Returned in the `failed` variant
-     * of `GetMetadataAsyncCheckResult`. This is a semantic error union: the
-     * HTTP status of the poll request itself is unaffected (a poll that
-     * surfaces a failed job is still a normal successful poll response).
-     * Callers should branch on the variant.
-     */
     export type MetadataExtractionApiV2Error = MetadataExtractionApiV2ErrorServerError | MetadataExtractionApiV2ErrorUserError | MetadataExtractionApiV2ErrorUnsupportedFormatError | MetadataExtractionApiV2ErrorLinkDownloadDisabledError | MetadataExtractionApiV2ErrorSharedLinkPasswordProtected | MetadataExtractionApiV2ErrorLimitExceededError | MetadataExtractionApiV2ErrorConversionFailureError | MetadataExtractionApiV2ErrorNotFoundError | MetadataExtractionApiV2ErrorIsAFolderError | MetadataExtractionApiV2ErrorOther;
 
     export interface MetadataTypeMetadataTypeUnknown {
@@ -7938,71 +7938,9 @@
      */
     export type OfficeFileType = OfficeFileTypeOfficeFiletypeUnknown | OfficeFileTypeOfficeFiletypeWord | OfficeFileTypeOfficeFiletypePowerpoint | OfficeFileTypeOfficeFiletypeExcel | OfficeFileTypeOther;
 
-    /**
-     * An unexpected, typically transient, server-side failure. The string is a
-     * human-readable message; retrying with backoff may succeed.
-     */
-    export interface TextExtractionApiV2ErrorServerError {
-      '.tag': 'server_error';
-      server_error: string;
+    export interface TimestampLevelUnknown {
+      '.tag': 'unknown';
     }
-
-    /**
-     * The request could not be processed as supplied (a problem with the
-     * caller's input). The string is a human-readable message; retrying the
-     * same request will not help.
-     */
-    export interface TextExtractionApiV2ErrorUserError {
-      '.tag': 'user_error';
-      user_error: string;
-    }
-
-    export interface TextExtractionApiV2ErrorUnsupportedFormatError {
-      '.tag': 'unsupported_format_error';
-    }
-
-    export interface TextExtractionApiV2ErrorLinkDownloadDisabledError {
-      '.tag': 'link_download_disabled_error';
-    }
-
-    export interface TextExtractionApiV2ErrorSharedLinkPasswordProtected {
-      '.tag': 'shared_link_password_protected';
-    }
-
-    export interface TextExtractionApiV2ErrorLimitExceededError {
-      '.tag': 'limit_exceeded_error';
-    }
-
-    export interface TextExtractionApiV2ErrorConversionFailureError {
-      '.tag': 'conversion_failure_error';
-    }
-
-    /**
-     * The referenced file does not exist or is not accessible.
-     */
-    export interface TextExtractionApiV2ErrorNotFoundError {
-      '.tag': 'not_found_error';
-    }
-
-    /**
-     * The target is a folder, not a file.
-     */
-    export interface TextExtractionApiV2ErrorIsAFolderError {
-      '.tag': 'is_a_folder_error';
-    }
-
-    export interface TextExtractionApiV2ErrorOther {
-      '.tag': 'other';
-    }
-
-    /**
-     * Reason a text extraction job failed. Returned in the `failed` variant of
-     * `GetTextAsyncCheckResult`. This is a semantic error union: the HTTP
-     * status of the poll request itself is unaffected (a poll that surfaces a
-     * failed job is still a normal successful poll response). Callers should
-     * branch on the variant.
-     */
-    export type TextExtractionApiV2Error = TextExtractionApiV2ErrorServerError | TextExtractionApiV2ErrorUserError | TextExtractionApiV2ErrorUnsupportedFormatError | TextExtractionApiV2ErrorLinkDownloadDisabledError | TextExtractionApiV2ErrorSharedLinkPasswordProtected | TextExtractionApiV2ErrorLimitExceededError | TextExtractionApiV2ErrorConversionFailureError | TextExtractionApiV2ErrorNotFoundError | TextExtractionApiV2ErrorIsAFolderError | TextExtractionApiV2ErrorOther;
 
     export interface TimestampLevelSentence {
       '.tag': 'sentence';
@@ -8016,7 +7954,7 @@
       '.tag': 'other';
     }
 
-    export type TimestampLevel = TimestampLevelSentence | TimestampLevelWord | TimestampLevelOther;
+    export type TimestampLevel = TimestampLevelUnknown | TimestampLevelSentence | TimestampLevelWord | TimestampLevelOther;
 
     export interface metadata_unionExif extends ApiExifMetadata {
       '.tag': 'exif';
@@ -12088,7 +12026,7 @@
        * link's access level specified in the `link_access_level` field of
        * `LinkPermissions`. This is used in conjunction with team policies and
        * shared folder policies to determine the final effective audience type
-       * in the `effective_audience` field of `LinkPermissions`.
+       * in the `effective_audience` field of `LinkPermissions.
        */
       audience?: LinkAudience;
       /**
@@ -13060,159 +12998,6 @@
      * Base error that all errors for existing team folders should extend.
      */
     export type BaseTeamFolderError = BaseTeamFolderErrorAccessError | BaseTeamFolderErrorStatusError | BaseTeamFolderErrorTeamSharedDropboxError | BaseTeamFolderErrorOther;
-
-    /**
-     * Launches one action-specific bulk suspend job.
-     */
-    export interface BulkSuspendArg {
-      /**
-       * Must contain between 1 and 500 targets. The launch handler also rejects
-       * duplicate client item IDs and duplicate member selectors.
-       */
-      members: Array<BulkSuspendMemberTarget>;
-    }
-
-    export interface BulkSuspendComplete {
-      requested: number;
-      suspended: number;
-      failed: number;
-      unknown: number;
-      report_delivery: BulkSuspendReportDeliveryStatus;
-    }
-
-    export interface BulkSuspendErrorInvalidRequest {
-      '.tag': 'invalid_request';
-    }
-
-    export interface BulkSuspendErrorTooManyMembers {
-      '.tag': 'too_many_members';
-    }
-
-    export interface BulkSuspendErrorDuplicateClientItemId {
-      '.tag': 'duplicate_client_item_id';
-    }
-
-    export interface BulkSuspendErrorDuplicateTeamMemberId {
-      '.tag': 'duplicate_team_member_id';
-    }
-
-    export interface BulkSuspendErrorActingAdmin {
-      '.tag': 'acting_admin';
-    }
-
-    export interface BulkSuspendErrorLastAdmin {
-      '.tag': 'last_admin';
-    }
-
-    export interface BulkSuspendErrorOther {
-      '.tag': 'other';
-    }
-
-    /**
-     * A typed launch rejection. Authorization failures continue to use the API
-     * v2 authentication/permission error surface.
-     */
-    export type BulkSuspendError = BulkSuspendErrorInvalidRequest | BulkSuspendErrorTooManyMembers | BulkSuspendErrorDuplicateClientItemId | BulkSuspendErrorDuplicateTeamMemberId | BulkSuspendErrorActingAdmin | BulkSuspendErrorLastAdmin | BulkSuspendErrorOther;
-
-    export interface BulkSuspendJobStatusComplete extends BulkSuspendComplete {
-      '.tag': 'complete';
-    }
-
-    export interface BulkSuspendJobStatusFailed {
-      '.tag': 'failed';
-      failed: BulkSuspendTaskFailure;
-    }
-
-    export interface BulkSuspendJobStatusOther {
-      '.tag': 'other';
-    }
-
-    /**
-     * Coarse job state. Live row progress and report contents are intentionally
-     * omitted; callers receive row details in the terminal email report.
-     */
-    export type BulkSuspendJobStatus = async.PollResultBase | BulkSuspendJobStatusComplete | BulkSuspendJobStatusFailed | BulkSuspendJobStatusOther;
-
-    /**
-     * One member selected for suspension. The opaque client item ID correlates
-     * the eventual report row with the caller's input without sending CSV data.
-     */
-    export interface BulkSuspendMemberTarget {
-      client_item_id: string;
-      suspend_arg: MembersDeactivateArg;
-    }
-
-    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusUnspecified {
-      '.tag': 'bulk_suspend_report_delivery_status_unspecified';
-    }
-
-    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusPending {
-      '.tag': 'bulk_suspend_report_delivery_status_pending';
-    }
-
-    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusDelivered {
-      '.tag': 'bulk_suspend_report_delivery_status_delivered';
-    }
-
-    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusFailed {
-      '.tag': 'bulk_suspend_report_delivery_status_failed';
-    }
-
-    export interface BulkSuspendReportDeliveryStatusOther {
-      '.tag': 'other';
-    }
-
-    export type BulkSuspendReportDeliveryStatus = BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusUnspecified | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusPending | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusDelivered | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusFailed | BulkSuspendReportDeliveryStatusOther;
-
-    export interface BulkSuspendRowFailureProtectedActingAdmin {
-      '.tag': 'protected_acting_admin';
-    }
-
-    export interface BulkSuspendRowFailurePermissionChanged {
-      '.tag': 'permission_changed';
-    }
-
-    export interface BulkSuspendRowFailureSuspendFailed {
-      '.tag': 'suspend_failed';
-    }
-
-    /**
-     * Stable machine-readable reasons used by the terminal row report.
-     */
-    export type BulkSuspendRowFailure = MembersSuspendError | BulkSuspendRowFailureProtectedActingAdmin | BulkSuspendRowFailurePermissionChanged | BulkSuspendRowFailureSuspendFailed;
-
-    export interface BulkSuspendRowOutcomeSuspended {
-      '.tag': 'suspended';
-    }
-
-    export interface BulkSuspendRowOutcomeFailed {
-      '.tag': 'failed';
-      failed: BulkSuspendRowFailure;
-    }
-
-    export interface BulkSuspendRowOutcomeUnknown {
-      '.tag': 'unknown';
-    }
-
-    export interface BulkSuspendRowOutcomeOther {
-      '.tag': 'other';
-    }
-
-    /**
-     * The terminal outcome for one requested member. Row outcomes are delivered
-     * in the report rather than embedded in the status response.
-     */
-    export type BulkSuspendRowOutcome = BulkSuspendRowOutcomeSuspended | BulkSuspendRowOutcomeFailed | BulkSuspendRowOutcomeUnknown | BulkSuspendRowOutcomeOther;
-
-    export interface BulkSuspendTaskFailureUnusableResult {
-      '.tag': 'unusable_result';
-    }
-
-    export interface BulkSuspendTaskFailureOther {
-      '.tag': 'other';
-    }
-
-    export type BulkSuspendTaskFailure = BulkSuspendTaskFailureUnusableResult | BulkSuspendTaskFailureOther;
 
     /**
      * A maximum of 1000 users can be set for a single call.
@@ -17087,15 +16872,7 @@
 
     export type TeamFolderAccessError = TeamFolderAccessErrorInvalidTeamFolderId | TeamFolderAccessErrorNoAccess | TeamFolderAccessErrorOther;
 
-    /**
-     * The team has reached the maximum number of team folders allowed by its
-     * plan.
-     */
-    export interface TeamFolderActivateErrorFolderCountLimitExceeded {
-      '.tag': 'folder_count_limit_exceeded';
-    }
-
-    export type TeamFolderActivateError = BaseTeamFolderError | TeamFolderActivateErrorFolderCountLimitExceeded;
+    export type TeamFolderActivateError = BaseTeamFolderError;
 
     export interface TeamFolderArchiveArg extends TeamFolderIdArg {
       /**
@@ -17363,15 +17140,7 @@
 
     export type TeamFolderRenameError = BaseTeamFolderError | TeamFolderRenameErrorInvalidFolderName | TeamFolderRenameErrorFolderNameAlreadyUsed | TeamFolderRenameErrorFolderNameReserved;
 
-    /**
-     * The team has reached the maximum number of team folders allowed by its
-     * plan.
-     */
-    export interface TeamFolderRestoreErrorFolderCountLimitExceeded {
-      '.tag': 'folder_count_limit_exceeded';
-    }
-
-    export type TeamFolderRestoreError = BaseTeamFolderError | TeamFolderRestoreErrorFolderCountLimitExceeded;
+    export type TeamFolderRestoreError = BaseTeamFolderError;
 
     /**
      * The team folder and sub-folders are available to all members.
@@ -22800,10 +22569,6 @@
       '.tag': 'member_delete_profile_photo_details';
     }
 
-    export interface EventDetailsMemberFolderContentsAccessedDetails extends MemberFolderContentsAccessedDetails {
-      '.tag': 'member_folder_contents_accessed_details';
-    }
-
     export interface EventDetailsMemberPermanentlyDeleteAccountContentsDetails extends MemberPermanentlyDeleteAccountContentsDetails {
       '.tag': 'member_permanently_delete_account_contents_details';
     }
@@ -23072,52 +22837,8 @@
       '.tag': 'password_reset_all_details';
     }
 
-    export interface EventDetailsProtectActionAddCollaboratorDetails extends ProtectActionAddCollaboratorDetails {
-      '.tag': 'protect_action_add_collaborator_details';
-    }
-
-    export interface EventDetailsProtectActionAddLinkDetails extends ProtectActionAddLinkDetails {
-      '.tag': 'protect_action_add_link_details';
-    }
-
-    export interface EventDetailsProtectActionDeleteDetails extends ProtectActionDeleteDetails {
-      '.tag': 'protect_action_delete_details';
-    }
-
-    export interface EventDetailsProtectActionExportDetails extends ProtectActionExportDetails {
-      '.tag': 'protect_action_export_details';
-    }
-
-    export interface EventDetailsProtectActionRemoveCollaboratorDetails extends ProtectActionRemoveCollaboratorDetails {
-      '.tag': 'protect_action_remove_collaborator_details';
-    }
-
-    export interface EventDetailsProtectActionRemoveLinkDetails extends ProtectActionRemoveLinkDetails {
-      '.tag': 'protect_action_remove_link_details';
-    }
-
-    export interface EventDetailsProtectActionStopSharingDetails extends ProtectActionStopSharingDetails {
-      '.tag': 'protect_action_stop_sharing_details';
-    }
-
     export interface EventDetailsProtectInternalDomainsChangedDetails extends ProtectInternalDomainsChangedDetails {
       '.tag': 'protect_internal_domains_changed_details';
-    }
-
-    export interface EventDetailsProtectPolicyActivatedDetails extends ProtectPolicyActivatedDetails {
-      '.tag': 'protect_policy_activated_details';
-    }
-
-    export interface EventDetailsProtectPolicyDeactivatedDetails extends ProtectPolicyDeactivatedDetails {
-      '.tag': 'protect_policy_deactivated_details';
-    }
-
-    export interface EventDetailsProtectPolicyScheduledDetails extends ProtectPolicyScheduledDetails {
-      '.tag': 'protect_policy_scheduled_details';
-    }
-
-    export interface EventDetailsProtectPolicyUpdatedDetails extends ProtectPolicyUpdatedDetails {
-      '.tag': 'protect_policy_updated_details';
     }
 
     export interface EventDetailsClassificationCreateReportDetails extends ClassificationCreateReportDetails {
@@ -24499,7 +24220,7 @@
     /**
      * Additional fields depending on the event type.
      */
-    export type EventDetails = EventDetailsAdminAlertingAlertStateChangedDetails | EventDetailsAdminAlertingChangedAlertConfigDetails | EventDetailsAdminAlertingTriggeredAlertDetails | EventDetailsRansomwareRestoreProcessCompletedDetails | EventDetailsRansomwareRestoreProcessStartedDetails | EventDetailsAppBlockedByPermissionsDetails | EventDetailsAppLinkTeamDetails | EventDetailsAppLinkUserDetails | EventDetailsAppUnlinkTeamDetails | EventDetailsAppUnlinkUserDetails | EventDetailsIntegrationConnectedDetails | EventDetailsIntegrationDisconnectedDetails | EventDetailsFileAddCommentDetails | EventDetailsFileChangeCommentSubscriptionDetails | EventDetailsFileDeleteCommentDetails | EventDetailsFileEditCommentDetails | EventDetailsFileLikeCommentDetails | EventDetailsFileResolveCommentDetails | EventDetailsFileUnlikeCommentDetails | EventDetailsFileUnresolveCommentDetails | EventDetailsDashAddedCommentToStackDetails | EventDetailsDashAddedConnectorDetails | EventDetailsDashAddedLinkToStackDetails | EventDetailsDashAddedTeamEmailDomainAllowlistDetails | EventDetailsDashAdminAddedOrgWideConnectorDetails | EventDetailsDashAdminDisabledConnectorDetails | EventDetailsDashAdminEnabledConnectorDetails | EventDetailsDashAdminRemovedOrgWideConnectorDetails | EventDetailsDashArchivedStackDetails | EventDetailsDashChangedAudienceOfSharedLinkToStackDetails | EventDetailsDashClonedStackDetails | EventDetailsDashConnectorToolsCallDetails | EventDetailsDashCreatedStackDetails | EventDetailsDashDeletedCommentFromStackDetails | EventDetailsDashDeletedStackDetails | EventDetailsDashEditedCommentInStackDetails | EventDetailsDashExternalUserOpenedStackDetails | EventDetailsDashFirstLaunchedDesktopDetails | EventDetailsDashFirstLaunchedExtensionDetails | EventDetailsDashFirstLaunchedWebStartPageDetails | EventDetailsDashOpenedSharedLinkToStackDetails | EventDetailsDashOpenedStackDetails | EventDetailsDashPreviewOptOutStatusChangedDetails | EventDetailsDashRemovedConnectorDetails | EventDetailsDashRemovedLinkFromStackDetails | EventDetailsDashRemovedSharedLinkToStackDetails | EventDetailsDashRemovedTeamEmailDomainAllowlistDetails | EventDetailsDashRenamedStackDetails | EventDetailsDashSharedLinkToStackDetails | EventDetailsDashUnarchivedStackDetails | EventDetailsDashViewedCompanyStackDetails | EventDetailsDashViewedExternalAiActivityReportDetails | EventDetailsGovernancePolicyAddFoldersDetails | EventDetailsGovernancePolicyAddFolderFailedDetails | EventDetailsGovernancePolicyContentDisposedDetails | EventDetailsGovernancePolicyCreateDetails | EventDetailsGovernancePolicyDeleteDetails | EventDetailsGovernancePolicyEditDetailsDetails | EventDetailsGovernancePolicyEditDurationDetails | EventDetailsGovernancePolicyExportCreatedDetails | EventDetailsGovernancePolicyExportRemovedDetails | EventDetailsGovernancePolicyRemoveFoldersDetails | EventDetailsGovernancePolicyReportCreatedDetails | EventDetailsGovernancePolicyZipPartDownloadedDetails | EventDetailsLegalHoldsActivateAHoldDetails | EventDetailsLegalHoldsAddMembersDetails | EventDetailsLegalHoldsChangeHoldDetailsDetails | EventDetailsLegalHoldsChangeHoldNameDetails | EventDetailsLegalHoldsExportAHoldDetails | EventDetailsLegalHoldsExportCancelledDetails | EventDetailsLegalHoldsExportDownloadedDetails | EventDetailsLegalHoldsExportRemovedDetails | EventDetailsLegalHoldsReleaseAHoldDetails | EventDetailsLegalHoldsRemoveMembersDetails | EventDetailsLegalHoldsReportAHoldDetails | EventDetailsDeviceChangeIpDesktopDetails | EventDetailsDeviceChangeIpMobileDetails | EventDetailsDeviceChangeIpWebDetails | EventDetailsDeviceDeleteOnUnlinkFailDetails | EventDetailsDeviceDeleteOnUnlinkSuccessDetails | EventDetailsDeviceLinkFailDetails | EventDetailsDeviceLinkSuccessDetails | EventDetailsDeviceManagementDisabledDetails | EventDetailsDeviceManagementEnabledDetails | EventDetailsDeviceSyncBackupStatusChangedDetails | EventDetailsDeviceUnlinkDetails | EventDetailsDropboxPasswordsExportedDetails | EventDetailsDropboxPasswordsNewDeviceEnrolledDetails | EventDetailsEmmRefreshAuthTokenDetails | EventDetailsExternalDriveBackupEligibilityStatusCheckedDetails | EventDetailsExternalDriveBackupStatusChangedDetails | EventDetailsAccountCaptureChangeAvailabilityDetails | EventDetailsAccountCaptureMigrateAccountDetails | EventDetailsAccountCaptureNotificationEmailsSentDetails | EventDetailsAccountCaptureRelinquishAccountDetails | EventDetailsDisabledDomainInvitesDetails | EventDetailsDomainInvitesApproveRequestToJoinTeamDetails | EventDetailsDomainInvitesDeclineRequestToJoinTeamDetails | EventDetailsDomainInvitesEmailExistingUsersDetails | EventDetailsDomainInvitesRequestToJoinTeamDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToNoDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToYesDetails | EventDetailsDomainVerificationAddDomainFailDetails | EventDetailsDomainVerificationAddDomainSuccessDetails | EventDetailsDomainVerificationRemoveDomainDetails | EventDetailsEnabledDomainInvitesDetails | EventDetailsEncryptedFolderCancelTeamKeyRotationDetails | EventDetailsEncryptedFolderEnrollBackupKeyDetails | EventDetailsEncryptedFolderEnrollClientDetails | EventDetailsEncryptedFolderEnrollTeamDetails | EventDetailsEncryptedFolderFinishTeamUnenrollmentDetails | EventDetailsEncryptedFolderInitTeamKeyRotationDetails | EventDetailsEncryptedFolderInitTeamUnenrollmentDetails | EventDetailsEncryptedFolderRemoveBackupKeyDetails | EventDetailsEncryptedFolderRotateTeamKeyDetails | EventDetailsEncryptedFolderUnenrollClientDetails | EventDetailsTeamEncryptionKeyActivateKeyDetails | EventDetailsTeamEncryptionKeyCancelKeyDeletionDetails | EventDetailsTeamEncryptionKeyCreateKeyDetails | EventDetailsTeamEncryptionKeyDeactivateKeyDetails | EventDetailsTeamEncryptionKeyDeleteKeyDetails | EventDetailsTeamEncryptionKeyDisableKeyDetails | EventDetailsTeamEncryptionKeyEnableKeyDetails | EventDetailsTeamEncryptionKeyRotateKeyDetails | EventDetailsTeamEncryptionKeyScheduleKeyDeletionDetails | EventDetailsApplyNamingConventionDetails | EventDetailsCreateFolderDetails | EventDetailsFileAddDetails | EventDetailsFileAddFromAutomationDetails | EventDetailsFileCopyDetails | EventDetailsFileDeleteDetails | EventDetailsFileDownloadDetails | EventDetailsFileEditDetails | EventDetailsFileGetCopyReferenceDetails | EventDetailsFileLockingLockStatusChangedDetails | EventDetailsFileMoveDetails | EventDetailsFilePermanentlyDeleteDetails | EventDetailsFilePreviewDetails | EventDetailsFileRenameDetails | EventDetailsFileRestoreDetails | EventDetailsFileRevertDetails | EventDetailsFileRollbackChangesDetails | EventDetailsFileSaveCopyReferenceDetails | EventDetailsFolderOverviewDescriptionChangedDetails | EventDetailsFolderOverviewItemPinnedDetails | EventDetailsFolderOverviewItemUnpinnedDetails | EventDetailsMediaHubFileDownloadedDetails | EventDetailsObjectLabelAddedDetails | EventDetailsObjectLabelRemovedDetails | EventDetailsObjectLabelUpdatedValueDetails | EventDetailsOrganizeFolderWithTidyDetails | EventDetailsReplayFileDeleteDetails | EventDetailsReplayFileDownloadedDetails | EventDetailsReplayTeamProjectCreatedDetails | EventDetailsRewindFolderDetails | EventDetailsUndoNamingConventionDetails | EventDetailsUndoOrganizeFolderWithTidyDetails | EventDetailsUserTagsAddedDetails | EventDetailsUserTagsRemovedDetails | EventDetailsEmailIngestReceiveFileDetails | EventDetailsFileRequestAutoCloseDetails | EventDetailsFileRequestChangeDetails | EventDetailsFileRequestCloseDetails | EventDetailsFileRequestCreateDetails | EventDetailsFileRequestDeleteDetails | EventDetailsFileRequestReceiveFileDetails | EventDetailsGroupAddExternalIdDetails | EventDetailsGroupAddMemberDetails | EventDetailsGroupChangeExternalIdDetails | EventDetailsGroupChangeManagementTypeDetails | EventDetailsGroupChangeMemberRoleDetails | EventDetailsGroupCreateDetails | EventDetailsGroupDeleteDetails | EventDetailsGroupDescriptionUpdatedDetails | EventDetailsGroupExternalSharingSettingOverrideChangedDetails | EventDetailsGroupJoinPolicyUpdatedDetails | EventDetailsGroupMovedDetails | EventDetailsGroupRemoveExternalIdDetails | EventDetailsGroupRemoveMemberDetails | EventDetailsGroupRenameDetails | EventDetailsAccountLockOrUnlockedDetails | EventDetailsEmmErrorDetails | EventDetailsGuestAdminSignedInViaTrustedTeamsDetails | EventDetailsGuestAdminSignedOutViaTrustedTeamsDetails | EventDetailsLoginFailDetails | EventDetailsLoginSuccessDetails | EventDetailsLogoutDetails | EventDetailsResellerSupportSessionEndDetails | EventDetailsResellerSupportSessionStartDetails | EventDetailsSignInAsSessionEndDetails | EventDetailsSignInAsSessionStartDetails | EventDetailsSsoErrorDetails | EventDetailsAddonAssignedDetails | EventDetailsAddonRemovedDetails | EventDetailsBackupAdminInvitationSentDetails | EventDetailsBackupInvitationOpenedDetails | EventDetailsCreateTeamInviteLinkDetails | EventDetailsDeleteTeamInviteLinkDetails | EventDetailsMemberAddExternalIdDetails | EventDetailsMemberAddNameDetails | EventDetailsMemberChangeAdminRoleDetails | EventDetailsMemberChangeEmailDetails | EventDetailsMemberChangeExternalIdDetails | EventDetailsMemberChangeMembershipTypeDetails | EventDetailsMemberChangeNameDetails | EventDetailsMemberChangeResellerRoleDetails | EventDetailsMemberChangeStatusDetails | EventDetailsMemberDeleteManualContactsDetails | EventDetailsMemberDeleteProfilePhotoDetails | EventDetailsMemberFolderContentsAccessedDetails | EventDetailsMemberPermanentlyDeleteAccountContentsDetails | EventDetailsMemberRemoveExternalIdDetails | EventDetailsMemberSetProfilePhotoDetails | EventDetailsMemberSpaceLimitsAddCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeStatusDetails | EventDetailsMemberSpaceLimitsRemoveCustomQuotaDetails | EventDetailsMemberSuggestDetails | EventDetailsMemberTransferAccountContentsDetails | EventDetailsPendingSecondaryEmailAddedDetails | EventDetailsProductAssignedToMemberDetails | EventDetailsProductRemovedFromMemberDetails | EventDetailsSecondaryEmailDeletedDetails | EventDetailsSecondaryEmailVerifiedDetails | EventDetailsSecondaryMailsPolicyChangedDetails | EventDetailsBinderAddPageDetails | EventDetailsBinderAddSectionDetails | EventDetailsBinderRemovePageDetails | EventDetailsBinderRemoveSectionDetails | EventDetailsBinderRenamePageDetails | EventDetailsBinderRenameSectionDetails | EventDetailsBinderReorderPageDetails | EventDetailsBinderReorderSectionDetails | EventDetailsPaperContentAddMemberDetails | EventDetailsPaperContentAddToFolderDetails | EventDetailsPaperContentArchiveDetails | EventDetailsPaperContentCreateDetails | EventDetailsPaperContentPermanentlyDeleteDetails | EventDetailsPaperContentRemoveFromFolderDetails | EventDetailsPaperContentRemoveMemberDetails | EventDetailsPaperContentRenameDetails | EventDetailsPaperContentRestoreDetails | EventDetailsPaperDocAddCommentDetails | EventDetailsPaperDocChangeMemberRoleDetails | EventDetailsPaperDocChangeSharingPolicyDetails | EventDetailsPaperDocChangeSubscriptionDetails | EventDetailsPaperDocDeletedDetails | EventDetailsPaperDocDeleteCommentDetails | EventDetailsPaperDocDownloadDetails | EventDetailsPaperDocEditDetails | EventDetailsPaperDocEditCommentDetails | EventDetailsPaperDocFollowedDetails | EventDetailsPaperDocMentionDetails | EventDetailsPaperDocOwnershipChangedDetails | EventDetailsPaperDocRequestAccessDetails | EventDetailsPaperDocResolveCommentDetails | EventDetailsPaperDocRevertDetails | EventDetailsPaperDocSlackShareDetails | EventDetailsPaperDocTeamInviteDetails | EventDetailsPaperDocTrashedDetails | EventDetailsPaperDocUnresolveCommentDetails | EventDetailsPaperDocUntrashedDetails | EventDetailsPaperDocViewDetails | EventDetailsPaperExternalViewAllowDetails | EventDetailsPaperExternalViewDefaultTeamDetails | EventDetailsPaperExternalViewForbidDetails | EventDetailsPaperFolderChangeSubscriptionDetails | EventDetailsPaperFolderDeletedDetails | EventDetailsPaperFolderFollowedDetails | EventDetailsPaperFolderTeamInviteDetails | EventDetailsPaperPublishedLinkChangePermissionDetails | EventDetailsPaperPublishedLinkCreateDetails | EventDetailsPaperPublishedLinkDisabledDetails | EventDetailsPaperPublishedLinkViewDetails | EventDetailsPasswordChangeDetails | EventDetailsPasswordResetDetails | EventDetailsPasswordResetAllDetails | EventDetailsProtectActionAddCollaboratorDetails | EventDetailsProtectActionAddLinkDetails | EventDetailsProtectActionDeleteDetails | EventDetailsProtectActionExportDetails | EventDetailsProtectActionRemoveCollaboratorDetails | EventDetailsProtectActionRemoveLinkDetails | EventDetailsProtectActionStopSharingDetails | EventDetailsProtectInternalDomainsChangedDetails | EventDetailsProtectPolicyActivatedDetails | EventDetailsProtectPolicyDeactivatedDetails | EventDetailsProtectPolicyScheduledDetails | EventDetailsProtectPolicyUpdatedDetails | EventDetailsClassificationCreateReportDetails | EventDetailsClassificationCreateReportFailDetails | EventDetailsEmmCreateExceptionsReportDetails | EventDetailsEmmCreateUsageReportDetails | EventDetailsExportMembersReportDetails | EventDetailsExportMembersReportFailDetails | EventDetailsExternalSharingCreateReportDetails | EventDetailsExternalSharingReportFailedDetails | EventDetailsMemberAccessDetailsCreateReportDetails | EventDetailsMemberAccessDetailsCreateReportFailedDetails | EventDetailsNoExpirationLinkGenCreateReportDetails | EventDetailsNoExpirationLinkGenReportFailedDetails | EventDetailsNoPasswordLinkGenCreateReportDetails | EventDetailsNoPasswordLinkGenReportFailedDetails | EventDetailsNoPasswordLinkViewCreateReportDetails | EventDetailsNoPasswordLinkViewReportFailedDetails | EventDetailsOutdatedLinkViewCreateReportDetails | EventDetailsOutdatedLinkViewReportFailedDetails | EventDetailsPaperAdminExportStartDetails | EventDetailsRansomwareAlertCreateReportDetails | EventDetailsRansomwareAlertCreateReportFailedDetails | EventDetailsSharedFoldersCreateReportDetails | EventDetailsSharedFoldersCreateReportFailedDetails | EventDetailsSmartSyncCreateAdminPrivilegeReportDetails | EventDetailsTeamActivityCreateReportDetails | EventDetailsTeamActivityCreateReportFailDetails | EventDetailsTeamFoldersCreateReportDetails | EventDetailsTeamFoldersCreateReportFailedDetails | EventDetailsTeamStorageCreateReportDetails | EventDetailsTeamStorageCreateReportFailedDetails | EventDetailsCollectionShareDetails | EventDetailsFileTransfersFileAddDetails | EventDetailsFileTransfersTransferDeleteDetails | EventDetailsFileTransfersTransferDownloadDetails | EventDetailsFileTransfersTransferSendDetails | EventDetailsFileTransfersTransferViewDetails | EventDetailsMediaHubProjectTeamAddDetails | EventDetailsMediaHubProjectTeamDeleteDetails | EventDetailsMediaHubProjectTeamRoleChangedDetails | EventDetailsMediaHubSharedLinkAudienceChangedDetails | EventDetailsMediaHubSharedLinkCreatedDetails | EventDetailsMediaHubSharedLinkDownloadSettingChangedDetails | EventDetailsMediaHubSharedLinkRevokedDetails | EventDetailsNoteAclInviteOnlyDetails | EventDetailsNoteAclLinkDetails | EventDetailsNoteAclTeamLinkDetails | EventDetailsNoteSharedDetails | EventDetailsNoteShareReceiveDetails | EventDetailsOpenNoteSharedDetails | EventDetailsReplayFileSharedLinkCreatedDetails | EventDetailsReplayFileSharedLinkModifiedDetails | EventDetailsReplayProjectTeamAddDetails | EventDetailsReplayProjectTeamDeleteDetails | EventDetailsSendAndTrackFileAddedDetails | EventDetailsSendAndTrackFileRenamedDetails | EventDetailsSendAndTrackFileUpdatedDetails | EventDetailsSendAndTrackLinkCreatedDetails | EventDetailsSendAndTrackLinkDeletedDetails | EventDetailsSendAndTrackLinkUpdatedDetails | EventDetailsSendAndTrackLinkViewedDetails | EventDetailsSendAndTrackRemovedFileAndAssociatedLinksDetails | EventDetailsSfAddGroupDetails | EventDetailsSfAllowNonMembersToViewSharedLinksDetails | EventDetailsSfExternalInviteWarnDetails | EventDetailsSfFbInviteDetails | EventDetailsSfFbInviteChangeRoleDetails | EventDetailsSfFbUninviteDetails | EventDetailsSfInviteGroupDetails | EventDetailsSfTeamGrantAccessDetails | EventDetailsSfTeamInviteDetails | EventDetailsSfTeamInviteChangeRoleDetails | EventDetailsSfTeamJoinDetails | EventDetailsSfTeamJoinFromOobLinkDetails | EventDetailsSfTeamUninviteDetails | EventDetailsSharedContentAddInviteesDetails | EventDetailsSharedContentAddLinkExpiryDetails | EventDetailsSharedContentAddLinkPasswordDetails | EventDetailsSharedContentAddMemberDetails | EventDetailsSharedContentChangeDownloadsPolicyDetails | EventDetailsSharedContentChangeInviteeRoleDetails | EventDetailsSharedContentChangeLinkAudienceDetails | EventDetailsSharedContentChangeLinkExpiryDetails | EventDetailsSharedContentChangeLinkPasswordDetails | EventDetailsSharedContentChangeMemberRoleDetails | EventDetailsSharedContentChangeViewerInfoPolicyDetails | EventDetailsSharedContentClaimInvitationDetails | EventDetailsSharedContentCopyDetails | EventDetailsSharedContentDownloadDetails | EventDetailsSharedContentRelinquishMembershipDetails | EventDetailsSharedContentRemoveInviteesDetails | EventDetailsSharedContentRemoveLinkExpiryDetails | EventDetailsSharedContentRemoveLinkPasswordDetails | EventDetailsSharedContentRemoveMemberDetails | EventDetailsSharedContentRequestAccessDetails | EventDetailsSharedContentRestoreInviteesDetails | EventDetailsSharedContentRestoreMemberDetails | EventDetailsSharedContentUnshareDetails | EventDetailsSharedContentViewDetails | EventDetailsSharedFolderChangeLinkPolicyDetails | EventDetailsSharedFolderChangeMembersInheritancePolicyDetails | EventDetailsSharedFolderChangeMembersManagementPolicyDetails | EventDetailsSharedFolderChangeMembersPolicyDetails | EventDetailsSharedFolderCreateDetails | EventDetailsSharedFolderDeclineInvitationDetails | EventDetailsSharedFolderMountDetails | EventDetailsSharedFolderNestDetails | EventDetailsSharedFolderTransferOwnershipDetails | EventDetailsSharedFolderUnmountDetails | EventDetailsSharedLinkAddExpiryDetails | EventDetailsSharedLinkChangeExpiryDetails | EventDetailsSharedLinkChangeVisibilityDetails | EventDetailsSharedLinkCopyDetails | EventDetailsSharedLinkCreateDetails | EventDetailsSharedLinkDisableDetails | EventDetailsSharedLinkDownloadDetails | EventDetailsSharedLinkRemoveExpiryDetails | EventDetailsSharedLinkRemoveVisitorDetails | EventDetailsSharedLinkSettingsAddExpirationDetails | EventDetailsSharedLinkSettingsAddPasswordDetails | EventDetailsSharedLinkSettingsAllowDownloadDisabledDetails | EventDetailsSharedLinkSettingsAllowDownloadEnabledDetails | EventDetailsSharedLinkSettingsChangeAudienceDetails | EventDetailsSharedLinkSettingsChangeExpirationDetails | EventDetailsSharedLinkSettingsChangePasswordDetails | EventDetailsSharedLinkSettingsRemoveExpirationDetails | EventDetailsSharedLinkSettingsRemovePasswordDetails | EventDetailsSharedLinkShareDetails | EventDetailsSharedLinkViewDetails | EventDetailsSharedNoteOpenedDetails | EventDetailsShmodelDisableDownloadsDetails | EventDetailsShmodelEnableDownloadsDetails | EventDetailsShmodelGroupShareDetails | EventDetailsShowcaseAccessGrantedDetails | EventDetailsShowcaseAddMemberDetails | EventDetailsShowcaseArchivedDetails | EventDetailsShowcaseCreatedDetails | EventDetailsShowcaseDeleteCommentDetails | EventDetailsShowcaseEditedDetails | EventDetailsShowcaseEditCommentDetails | EventDetailsShowcaseFileAddedDetails | EventDetailsShowcaseFileDownloadDetails | EventDetailsShowcaseFileRemovedDetails | EventDetailsShowcaseFileViewDetails | EventDetailsShowcasePermanentlyDeletedDetails | EventDetailsShowcasePostCommentDetails | EventDetailsShowcaseRemoveMemberDetails | EventDetailsShowcaseRenamedDetails | EventDetailsShowcaseRequestAccessDetails | EventDetailsShowcaseResolveCommentDetails | EventDetailsShowcaseRestoredDetails | EventDetailsShowcaseTrashedDetails | EventDetailsShowcaseTrashedDeprecatedDetails | EventDetailsShowcaseUnresolveCommentDetails | EventDetailsShowcaseUntrashedDetails | EventDetailsShowcaseUntrashedDeprecatedDetails | EventDetailsShowcaseViewDetails | EventDetailsSignSignatureRequestCanceledDetails | EventDetailsSignSignatureRequestCompletedDetails | EventDetailsSignSignatureRequestDeclinedDetails | EventDetailsSignSignatureRequestOpenedDetails | EventDetailsSignSignatureRequestReminderSentDetails | EventDetailsSignSignatureRequestSentDetails | EventDetailsSignTemplateCreatedDetails | EventDetailsSignTemplateSharedDetails | EventDetailsRiscSecurityEventDetails | EventDetailsSsoAddCertDetails | EventDetailsSsoAddLoginUrlDetails | EventDetailsSsoAddLogoutUrlDetails | EventDetailsSsoChangeCertDetails | EventDetailsSsoChangeLoginUrlDetails | EventDetailsSsoChangeLogoutUrlDetails | EventDetailsSsoChangeSamlIdentityModeDetails | EventDetailsSsoRemoveCertDetails | EventDetailsSsoRemoveLoginUrlDetails | EventDetailsSsoRemoveLogoutUrlDetails | EventDetailsTeamFolderChangeStatusDetails | EventDetailsTeamFolderCreateDetails | EventDetailsTeamFolderDowngradeDetails | EventDetailsTeamFolderPermanentlyDeleteDetails | EventDetailsTeamFolderRenameDetails | EventDetailsTeamFolderSpaceLimitsChangeCapsTypeDetails | EventDetailsTeamFolderSpaceLimitsChangeLimitDetails | EventDetailsTeamFolderSpaceLimitsChangeNotificationTargetDetails | EventDetailsTeamSelectiveSyncSettingsChangedDetails | EventDetailsAccountCaptureChangePolicyDetails | EventDetailsAdminEmailRemindersChangedDetails | EventDetailsAiThirdPartySharingDropboxBasePolicyChangedDetails | EventDetailsAllowDownloadDisabledDetails | EventDetailsAllowDownloadEnabledDetails | EventDetailsAppleLoginChangePolicyDetails | EventDetailsAppPermissionsChangedDetails | EventDetailsCameraUploadsPolicyChangedDetails | EventDetailsCaptureTeamSpacePolicyChangedDetails | EventDetailsCaptureTranscriptPolicyChangedDetails | EventDetailsClassificationChangePolicyDetails | EventDetailsComputerBackupPolicyChangedDetails | EventDetailsContentAdministrationPolicyChangedDetails | EventDetailsContentDeletionProtectionChangePolicyDetails | EventDetailsDashExternalSharingPolicyChangedDetails | EventDetailsDataPlacementRestrictionChangePolicyDetails | EventDetailsDataPlacementRestrictionSatisfyPolicyDetails | EventDetailsDeviceApprovalsAddExceptionDetails | EventDetailsDeviceApprovalsChangeDesktopPolicyDetails | EventDetailsDeviceApprovalsChangeMobilePolicyDetails | EventDetailsDeviceApprovalsChangeOverageActionDetails | EventDetailsDeviceApprovalsChangeUnlinkActionDetails | EventDetailsDeviceApprovalsRemoveExceptionDetails | EventDetailsDirectoryRestrictionsAddMembersDetails | EventDetailsDirectoryRestrictionsRemoveMembersDetails | EventDetailsDropboxPasswordsPolicyChangedDetails | EventDetailsEmailIngestPolicyChangedDetails | EventDetailsEmmAddExceptionDetails | EventDetailsEmmChangePolicyDetails | EventDetailsEmmRemoveExceptionDetails | EventDetailsExtendedVersionHistoryChangePolicyDetails | EventDetailsExternalDriveBackupPolicyChangedDetails | EventDetailsFileCommentsChangePolicyDetails | EventDetailsFileLockingPolicyChangedDetails | EventDetailsFileProviderMigrationPolicyChangedDetails | EventDetailsFileRequestsChangePolicyDetails | EventDetailsFileRequestsEmailsEnabledDetails | EventDetailsFileRequestsEmailsRestrictedToTeamOnlyDetails | EventDetailsFileTransfersPolicyChangedDetails | EventDetailsFlexibleFileNamesPolicyChangedDetails | EventDetailsFolderLinkRestrictionPolicyChangedDetails | EventDetailsGoogleSsoChangePolicyDetails | EventDetailsGroupUserManagementChangePolicyDetails | EventDetailsIntegrationPolicyChangedDetails | EventDetailsInviteAcceptanceEmailPolicyChangedDetails | EventDetailsMediaHubAddingPeoplePolicyChangedDetails | EventDetailsMediaHubDownloadPolicyChangedDetails | EventDetailsMediaHubLinkSharingPolicyChangedDetails | EventDetailsMemberRequestsChangePolicyDetails | EventDetailsMemberSendInvitePolicyChangedDetails | EventDetailsMemberSpaceLimitsAddExceptionDetails | EventDetailsMemberSpaceLimitsChangeCapsTypePolicyDetails | EventDetailsMemberSpaceLimitsChangePolicyDetails | EventDetailsMemberSpaceLimitsRemoveExceptionDetails | EventDetailsMemberSuggestionsChangePolicyDetails | EventDetailsMicrosoftLoginChangePolicyDetails | EventDetailsMicrosoftOfficeAddinChangePolicyDetails | EventDetailsMultiTeamIdentityPolicyChangedDetails | EventDetailsNetworkControlChangePolicyDetails | EventDetailsPaperChangeDeploymentPolicyDetails | EventDetailsPaperChangeMemberLinkPolicyDetails | EventDetailsPaperChangeMemberPolicyDetails | EventDetailsPaperChangePolicyDetails | EventDetailsPaperDefaultFolderPolicyChangedDetails | EventDetailsPaperDesktopPolicyChangedDetails | EventDetailsPaperEnabledUsersGroupAdditionDetails | EventDetailsPaperEnabledUsersGroupRemovalDetails | EventDetailsPasskeyLoginPolicyChangedDetails | EventDetailsPasswordStrengthRequirementsChangePolicyDetails | EventDetailsPermanentDeleteChangePolicyDetails | EventDetailsPreviewsAiPolicyChangedDetails | EventDetailsReplayAddingPeoplePolicyChangedDetails | EventDetailsReplaySharingPolicyChangedDetails | EventDetailsResellerSupportChangePolicyDetails | EventDetailsRewindPolicyChangedDetails | EventDetailsSendAndTrackPolicyChangedDetails | EventDetailsSendExternalSharingPolicyChangedDetails | EventDetailsSendForSignaturePolicyChangedDetails | EventDetailsSharedLinkDefaultPermissionsPolicyChangedDetails | EventDetailsSharingChangeFolderJoinPolicyDetails | EventDetailsSharingChangeLinkAllowChangeExpirationPolicyDetails | EventDetailsSharingChangeLinkDefaultExpirationPolicyDetails | EventDetailsSharingChangeLinkEnforcePasswordPolicyDetails | EventDetailsSharingChangeLinkPolicyDetails | EventDetailsSharingChangeMemberPolicyDetails | EventDetailsShowcaseChangeDownloadPolicyDetails | EventDetailsShowcaseChangeEnabledPolicyDetails | EventDetailsShowcaseChangeExternalSharingPolicyDetails | EventDetailsSignExternalSharingPolicyChangedDetails | EventDetailsSignTemplateCreationPermissionChangedDetails | EventDetailsSmarterSmartSyncPolicyChangedDetails | EventDetailsSmartSyncChangePolicyDetails | EventDetailsSmartSyncNotOptOutDetails | EventDetailsSmartSyncOptOutDetails | EventDetailsSsoChangePolicyDetails | EventDetailsStackCrossTeamAccessPolicyChangedDetails | EventDetailsTeamBrandingPolicyChangedDetails | EventDetailsTeamExtensionsPolicyChangedDetails | EventDetailsTeamMemberStorageRequestPolicyChangedDetails | EventDetailsTeamSelectiveSyncPolicyChangedDetails | EventDetailsTeamSharingWhitelistSubjectsChangedDetails | EventDetailsTfaAddExceptionDetails | EventDetailsTfaChangePolicyDetails | EventDetailsTfaRemoveExceptionDetails | EventDetailsTopLevelContentPolicyChangedDetails | EventDetailsTwoAccountChangePolicyDetails | EventDetailsViewerInfoPolicyChangedDetails | EventDetailsWatermarkingPolicyChangedDetails | EventDetailsWebSessionsChangeActiveSessionLimitDetails | EventDetailsWebSessionsChangeFixedLengthPolicyDetails | EventDetailsWebSessionsChangeIdleLengthPolicyDetails | EventDetailsDataResidencyMigrationRequestSuccessfulDetails | EventDetailsDataResidencyMigrationRequestUnsuccessfulDetails | EventDetailsTeamMergeFromDetails | EventDetailsTeamMergeToDetails | EventDetailsTeamProfileAddBackgroundDetails | EventDetailsTeamProfileAddLogoDetails | EventDetailsTeamProfileChangeBackgroundDetails | EventDetailsTeamProfileChangeDefaultLanguageDetails | EventDetailsTeamProfileChangeLogoDetails | EventDetailsTeamProfileChangeNameDetails | EventDetailsTeamProfileRemoveBackgroundDetails | EventDetailsTeamProfileRemoveLogoDetails | EventDetailsPasskeyAddDetails | EventDetailsPasskeyRemoveDetails | EventDetailsTfaAddBackupPhoneDetails | EventDetailsTfaAddSecurityKeyDetails | EventDetailsTfaChangeBackupPhoneDetails | EventDetailsTfaChangeStatusDetails | EventDetailsTfaRemoveBackupPhoneDetails | EventDetailsTfaRemoveSecurityKeyDetails | EventDetailsTfaResetDetails | EventDetailsChangedEnterpriseAdminRoleDetails | EventDetailsChangedEnterpriseConnectedTeamStatusDetails | EventDetailsEndedEnterpriseAdminSessionDetails | EventDetailsEndedEnterpriseAdminSessionDeprecatedDetails | EventDetailsEnterpriseSettingsLockingDetails | EventDetailsGuestAdminChangeStatusDetails | EventDetailsStartedEnterpriseAdminSessionDetails | EventDetailsTeamMergeRequestAcceptedDetails | EventDetailsTeamMergeRequestAcceptedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestAcceptedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestAutoCanceledDetails | EventDetailsTeamMergeRequestCanceledDetails | EventDetailsTeamMergeRequestCanceledShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestCanceledShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestExpiredDetails | EventDetailsTeamMergeRequestExpiredShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestExpiredShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestReminderDetails | EventDetailsTeamMergeRequestReminderShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestReminderShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRevokedDetails | EventDetailsTeamMergeRequestSentShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestSentShownToSecondaryTeamDetails | EventDetailsMissingDetails | EventDetailsOther;
+    export type EventDetails = EventDetailsAdminAlertingAlertStateChangedDetails | EventDetailsAdminAlertingChangedAlertConfigDetails | EventDetailsAdminAlertingTriggeredAlertDetails | EventDetailsRansomwareRestoreProcessCompletedDetails | EventDetailsRansomwareRestoreProcessStartedDetails | EventDetailsAppBlockedByPermissionsDetails | EventDetailsAppLinkTeamDetails | EventDetailsAppLinkUserDetails | EventDetailsAppUnlinkTeamDetails | EventDetailsAppUnlinkUserDetails | EventDetailsIntegrationConnectedDetails | EventDetailsIntegrationDisconnectedDetails | EventDetailsFileAddCommentDetails | EventDetailsFileChangeCommentSubscriptionDetails | EventDetailsFileDeleteCommentDetails | EventDetailsFileEditCommentDetails | EventDetailsFileLikeCommentDetails | EventDetailsFileResolveCommentDetails | EventDetailsFileUnlikeCommentDetails | EventDetailsFileUnresolveCommentDetails | EventDetailsDashAddedCommentToStackDetails | EventDetailsDashAddedConnectorDetails | EventDetailsDashAddedLinkToStackDetails | EventDetailsDashAddedTeamEmailDomainAllowlistDetails | EventDetailsDashAdminAddedOrgWideConnectorDetails | EventDetailsDashAdminDisabledConnectorDetails | EventDetailsDashAdminEnabledConnectorDetails | EventDetailsDashAdminRemovedOrgWideConnectorDetails | EventDetailsDashArchivedStackDetails | EventDetailsDashChangedAudienceOfSharedLinkToStackDetails | EventDetailsDashClonedStackDetails | EventDetailsDashConnectorToolsCallDetails | EventDetailsDashCreatedStackDetails | EventDetailsDashDeletedCommentFromStackDetails | EventDetailsDashDeletedStackDetails | EventDetailsDashEditedCommentInStackDetails | EventDetailsDashExternalUserOpenedStackDetails | EventDetailsDashFirstLaunchedDesktopDetails | EventDetailsDashFirstLaunchedExtensionDetails | EventDetailsDashFirstLaunchedWebStartPageDetails | EventDetailsDashOpenedSharedLinkToStackDetails | EventDetailsDashOpenedStackDetails | EventDetailsDashPreviewOptOutStatusChangedDetails | EventDetailsDashRemovedConnectorDetails | EventDetailsDashRemovedLinkFromStackDetails | EventDetailsDashRemovedSharedLinkToStackDetails | EventDetailsDashRemovedTeamEmailDomainAllowlistDetails | EventDetailsDashRenamedStackDetails | EventDetailsDashSharedLinkToStackDetails | EventDetailsDashUnarchivedStackDetails | EventDetailsDashViewedCompanyStackDetails | EventDetailsDashViewedExternalAiActivityReportDetails | EventDetailsGovernancePolicyAddFoldersDetails | EventDetailsGovernancePolicyAddFolderFailedDetails | EventDetailsGovernancePolicyContentDisposedDetails | EventDetailsGovernancePolicyCreateDetails | EventDetailsGovernancePolicyDeleteDetails | EventDetailsGovernancePolicyEditDetailsDetails | EventDetailsGovernancePolicyEditDurationDetails | EventDetailsGovernancePolicyExportCreatedDetails | EventDetailsGovernancePolicyExportRemovedDetails | EventDetailsGovernancePolicyRemoveFoldersDetails | EventDetailsGovernancePolicyReportCreatedDetails | EventDetailsGovernancePolicyZipPartDownloadedDetails | EventDetailsLegalHoldsActivateAHoldDetails | EventDetailsLegalHoldsAddMembersDetails | EventDetailsLegalHoldsChangeHoldDetailsDetails | EventDetailsLegalHoldsChangeHoldNameDetails | EventDetailsLegalHoldsExportAHoldDetails | EventDetailsLegalHoldsExportCancelledDetails | EventDetailsLegalHoldsExportDownloadedDetails | EventDetailsLegalHoldsExportRemovedDetails | EventDetailsLegalHoldsReleaseAHoldDetails | EventDetailsLegalHoldsRemoveMembersDetails | EventDetailsLegalHoldsReportAHoldDetails | EventDetailsDeviceChangeIpDesktopDetails | EventDetailsDeviceChangeIpMobileDetails | EventDetailsDeviceChangeIpWebDetails | EventDetailsDeviceDeleteOnUnlinkFailDetails | EventDetailsDeviceDeleteOnUnlinkSuccessDetails | EventDetailsDeviceLinkFailDetails | EventDetailsDeviceLinkSuccessDetails | EventDetailsDeviceManagementDisabledDetails | EventDetailsDeviceManagementEnabledDetails | EventDetailsDeviceSyncBackupStatusChangedDetails | EventDetailsDeviceUnlinkDetails | EventDetailsDropboxPasswordsExportedDetails | EventDetailsDropboxPasswordsNewDeviceEnrolledDetails | EventDetailsEmmRefreshAuthTokenDetails | EventDetailsExternalDriveBackupEligibilityStatusCheckedDetails | EventDetailsExternalDriveBackupStatusChangedDetails | EventDetailsAccountCaptureChangeAvailabilityDetails | EventDetailsAccountCaptureMigrateAccountDetails | EventDetailsAccountCaptureNotificationEmailsSentDetails | EventDetailsAccountCaptureRelinquishAccountDetails | EventDetailsDisabledDomainInvitesDetails | EventDetailsDomainInvitesApproveRequestToJoinTeamDetails | EventDetailsDomainInvitesDeclineRequestToJoinTeamDetails | EventDetailsDomainInvitesEmailExistingUsersDetails | EventDetailsDomainInvitesRequestToJoinTeamDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToNoDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToYesDetails | EventDetailsDomainVerificationAddDomainFailDetails | EventDetailsDomainVerificationAddDomainSuccessDetails | EventDetailsDomainVerificationRemoveDomainDetails | EventDetailsEnabledDomainInvitesDetails | EventDetailsEncryptedFolderCancelTeamKeyRotationDetails | EventDetailsEncryptedFolderEnrollBackupKeyDetails | EventDetailsEncryptedFolderEnrollClientDetails | EventDetailsEncryptedFolderEnrollTeamDetails | EventDetailsEncryptedFolderFinishTeamUnenrollmentDetails | EventDetailsEncryptedFolderInitTeamKeyRotationDetails | EventDetailsEncryptedFolderInitTeamUnenrollmentDetails | EventDetailsEncryptedFolderRemoveBackupKeyDetails | EventDetailsEncryptedFolderRotateTeamKeyDetails | EventDetailsEncryptedFolderUnenrollClientDetails | EventDetailsTeamEncryptionKeyActivateKeyDetails | EventDetailsTeamEncryptionKeyCancelKeyDeletionDetails | EventDetailsTeamEncryptionKeyCreateKeyDetails | EventDetailsTeamEncryptionKeyDeactivateKeyDetails | EventDetailsTeamEncryptionKeyDeleteKeyDetails | EventDetailsTeamEncryptionKeyDisableKeyDetails | EventDetailsTeamEncryptionKeyEnableKeyDetails | EventDetailsTeamEncryptionKeyRotateKeyDetails | EventDetailsTeamEncryptionKeyScheduleKeyDeletionDetails | EventDetailsApplyNamingConventionDetails | EventDetailsCreateFolderDetails | EventDetailsFileAddDetails | EventDetailsFileAddFromAutomationDetails | EventDetailsFileCopyDetails | EventDetailsFileDeleteDetails | EventDetailsFileDownloadDetails | EventDetailsFileEditDetails | EventDetailsFileGetCopyReferenceDetails | EventDetailsFileLockingLockStatusChangedDetails | EventDetailsFileMoveDetails | EventDetailsFilePermanentlyDeleteDetails | EventDetailsFilePreviewDetails | EventDetailsFileRenameDetails | EventDetailsFileRestoreDetails | EventDetailsFileRevertDetails | EventDetailsFileRollbackChangesDetails | EventDetailsFileSaveCopyReferenceDetails | EventDetailsFolderOverviewDescriptionChangedDetails | EventDetailsFolderOverviewItemPinnedDetails | EventDetailsFolderOverviewItemUnpinnedDetails | EventDetailsMediaHubFileDownloadedDetails | EventDetailsObjectLabelAddedDetails | EventDetailsObjectLabelRemovedDetails | EventDetailsObjectLabelUpdatedValueDetails | EventDetailsOrganizeFolderWithTidyDetails | EventDetailsReplayFileDeleteDetails | EventDetailsReplayFileDownloadedDetails | EventDetailsReplayTeamProjectCreatedDetails | EventDetailsRewindFolderDetails | EventDetailsUndoNamingConventionDetails | EventDetailsUndoOrganizeFolderWithTidyDetails | EventDetailsUserTagsAddedDetails | EventDetailsUserTagsRemovedDetails | EventDetailsEmailIngestReceiveFileDetails | EventDetailsFileRequestAutoCloseDetails | EventDetailsFileRequestChangeDetails | EventDetailsFileRequestCloseDetails | EventDetailsFileRequestCreateDetails | EventDetailsFileRequestDeleteDetails | EventDetailsFileRequestReceiveFileDetails | EventDetailsGroupAddExternalIdDetails | EventDetailsGroupAddMemberDetails | EventDetailsGroupChangeExternalIdDetails | EventDetailsGroupChangeManagementTypeDetails | EventDetailsGroupChangeMemberRoleDetails | EventDetailsGroupCreateDetails | EventDetailsGroupDeleteDetails | EventDetailsGroupDescriptionUpdatedDetails | EventDetailsGroupExternalSharingSettingOverrideChangedDetails | EventDetailsGroupJoinPolicyUpdatedDetails | EventDetailsGroupMovedDetails | EventDetailsGroupRemoveExternalIdDetails | EventDetailsGroupRemoveMemberDetails | EventDetailsGroupRenameDetails | EventDetailsAccountLockOrUnlockedDetails | EventDetailsEmmErrorDetails | EventDetailsGuestAdminSignedInViaTrustedTeamsDetails | EventDetailsGuestAdminSignedOutViaTrustedTeamsDetails | EventDetailsLoginFailDetails | EventDetailsLoginSuccessDetails | EventDetailsLogoutDetails | EventDetailsResellerSupportSessionEndDetails | EventDetailsResellerSupportSessionStartDetails | EventDetailsSignInAsSessionEndDetails | EventDetailsSignInAsSessionStartDetails | EventDetailsSsoErrorDetails | EventDetailsAddonAssignedDetails | EventDetailsAddonRemovedDetails | EventDetailsBackupAdminInvitationSentDetails | EventDetailsBackupInvitationOpenedDetails | EventDetailsCreateTeamInviteLinkDetails | EventDetailsDeleteTeamInviteLinkDetails | EventDetailsMemberAddExternalIdDetails | EventDetailsMemberAddNameDetails | EventDetailsMemberChangeAdminRoleDetails | EventDetailsMemberChangeEmailDetails | EventDetailsMemberChangeExternalIdDetails | EventDetailsMemberChangeMembershipTypeDetails | EventDetailsMemberChangeNameDetails | EventDetailsMemberChangeResellerRoleDetails | EventDetailsMemberChangeStatusDetails | EventDetailsMemberDeleteManualContactsDetails | EventDetailsMemberDeleteProfilePhotoDetails | EventDetailsMemberPermanentlyDeleteAccountContentsDetails | EventDetailsMemberRemoveExternalIdDetails | EventDetailsMemberSetProfilePhotoDetails | EventDetailsMemberSpaceLimitsAddCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeStatusDetails | EventDetailsMemberSpaceLimitsRemoveCustomQuotaDetails | EventDetailsMemberSuggestDetails | EventDetailsMemberTransferAccountContentsDetails | EventDetailsPendingSecondaryEmailAddedDetails | EventDetailsProductAssignedToMemberDetails | EventDetailsProductRemovedFromMemberDetails | EventDetailsSecondaryEmailDeletedDetails | EventDetailsSecondaryEmailVerifiedDetails | EventDetailsSecondaryMailsPolicyChangedDetails | EventDetailsBinderAddPageDetails | EventDetailsBinderAddSectionDetails | EventDetailsBinderRemovePageDetails | EventDetailsBinderRemoveSectionDetails | EventDetailsBinderRenamePageDetails | EventDetailsBinderRenameSectionDetails | EventDetailsBinderReorderPageDetails | EventDetailsBinderReorderSectionDetails | EventDetailsPaperContentAddMemberDetails | EventDetailsPaperContentAddToFolderDetails | EventDetailsPaperContentArchiveDetails | EventDetailsPaperContentCreateDetails | EventDetailsPaperContentPermanentlyDeleteDetails | EventDetailsPaperContentRemoveFromFolderDetails | EventDetailsPaperContentRemoveMemberDetails | EventDetailsPaperContentRenameDetails | EventDetailsPaperContentRestoreDetails | EventDetailsPaperDocAddCommentDetails | EventDetailsPaperDocChangeMemberRoleDetails | EventDetailsPaperDocChangeSharingPolicyDetails | EventDetailsPaperDocChangeSubscriptionDetails | EventDetailsPaperDocDeletedDetails | EventDetailsPaperDocDeleteCommentDetails | EventDetailsPaperDocDownloadDetails | EventDetailsPaperDocEditDetails | EventDetailsPaperDocEditCommentDetails | EventDetailsPaperDocFollowedDetails | EventDetailsPaperDocMentionDetails | EventDetailsPaperDocOwnershipChangedDetails | EventDetailsPaperDocRequestAccessDetails | EventDetailsPaperDocResolveCommentDetails | EventDetailsPaperDocRevertDetails | EventDetailsPaperDocSlackShareDetails | EventDetailsPaperDocTeamInviteDetails | EventDetailsPaperDocTrashedDetails | EventDetailsPaperDocUnresolveCommentDetails | EventDetailsPaperDocUntrashedDetails | EventDetailsPaperDocViewDetails | EventDetailsPaperExternalViewAllowDetails | EventDetailsPaperExternalViewDefaultTeamDetails | EventDetailsPaperExternalViewForbidDetails | EventDetailsPaperFolderChangeSubscriptionDetails | EventDetailsPaperFolderDeletedDetails | EventDetailsPaperFolderFollowedDetails | EventDetailsPaperFolderTeamInviteDetails | EventDetailsPaperPublishedLinkChangePermissionDetails | EventDetailsPaperPublishedLinkCreateDetails | EventDetailsPaperPublishedLinkDisabledDetails | EventDetailsPaperPublishedLinkViewDetails | EventDetailsPasswordChangeDetails | EventDetailsPasswordResetDetails | EventDetailsPasswordResetAllDetails | EventDetailsProtectInternalDomainsChangedDetails | EventDetailsClassificationCreateReportDetails | EventDetailsClassificationCreateReportFailDetails | EventDetailsEmmCreateExceptionsReportDetails | EventDetailsEmmCreateUsageReportDetails | EventDetailsExportMembersReportDetails | EventDetailsExportMembersReportFailDetails | EventDetailsExternalSharingCreateReportDetails | EventDetailsExternalSharingReportFailedDetails | EventDetailsMemberAccessDetailsCreateReportDetails | EventDetailsMemberAccessDetailsCreateReportFailedDetails | EventDetailsNoExpirationLinkGenCreateReportDetails | EventDetailsNoExpirationLinkGenReportFailedDetails | EventDetailsNoPasswordLinkGenCreateReportDetails | EventDetailsNoPasswordLinkGenReportFailedDetails | EventDetailsNoPasswordLinkViewCreateReportDetails | EventDetailsNoPasswordLinkViewReportFailedDetails | EventDetailsOutdatedLinkViewCreateReportDetails | EventDetailsOutdatedLinkViewReportFailedDetails | EventDetailsPaperAdminExportStartDetails | EventDetailsRansomwareAlertCreateReportDetails | EventDetailsRansomwareAlertCreateReportFailedDetails | EventDetailsSharedFoldersCreateReportDetails | EventDetailsSharedFoldersCreateReportFailedDetails | EventDetailsSmartSyncCreateAdminPrivilegeReportDetails | EventDetailsTeamActivityCreateReportDetails | EventDetailsTeamActivityCreateReportFailDetails | EventDetailsTeamFoldersCreateReportDetails | EventDetailsTeamFoldersCreateReportFailedDetails | EventDetailsTeamStorageCreateReportDetails | EventDetailsTeamStorageCreateReportFailedDetails | EventDetailsCollectionShareDetails | EventDetailsFileTransfersFileAddDetails | EventDetailsFileTransfersTransferDeleteDetails | EventDetailsFileTransfersTransferDownloadDetails | EventDetailsFileTransfersTransferSendDetails | EventDetailsFileTransfersTransferViewDetails | EventDetailsMediaHubProjectTeamAddDetails | EventDetailsMediaHubProjectTeamDeleteDetails | EventDetailsMediaHubProjectTeamRoleChangedDetails | EventDetailsMediaHubSharedLinkAudienceChangedDetails | EventDetailsMediaHubSharedLinkCreatedDetails | EventDetailsMediaHubSharedLinkDownloadSettingChangedDetails | EventDetailsMediaHubSharedLinkRevokedDetails | EventDetailsNoteAclInviteOnlyDetails | EventDetailsNoteAclLinkDetails | EventDetailsNoteAclTeamLinkDetails | EventDetailsNoteSharedDetails | EventDetailsNoteShareReceiveDetails | EventDetailsOpenNoteSharedDetails | EventDetailsReplayFileSharedLinkCreatedDetails | EventDetailsReplayFileSharedLinkModifiedDetails | EventDetailsReplayProjectTeamAddDetails | EventDetailsReplayProjectTeamDeleteDetails | EventDetailsSendAndTrackFileAddedDetails | EventDetailsSendAndTrackFileRenamedDetails | EventDetailsSendAndTrackFileUpdatedDetails | EventDetailsSendAndTrackLinkCreatedDetails | EventDetailsSendAndTrackLinkDeletedDetails | EventDetailsSendAndTrackLinkUpdatedDetails | EventDetailsSendAndTrackLinkViewedDetails | EventDetailsSendAndTrackRemovedFileAndAssociatedLinksDetails | EventDetailsSfAddGroupDetails | EventDetailsSfAllowNonMembersToViewSharedLinksDetails | EventDetailsSfExternalInviteWarnDetails | EventDetailsSfFbInviteDetails | EventDetailsSfFbInviteChangeRoleDetails | EventDetailsSfFbUninviteDetails | EventDetailsSfInviteGroupDetails | EventDetailsSfTeamGrantAccessDetails | EventDetailsSfTeamInviteDetails | EventDetailsSfTeamInviteChangeRoleDetails | EventDetailsSfTeamJoinDetails | EventDetailsSfTeamJoinFromOobLinkDetails | EventDetailsSfTeamUninviteDetails | EventDetailsSharedContentAddInviteesDetails | EventDetailsSharedContentAddLinkExpiryDetails | EventDetailsSharedContentAddLinkPasswordDetails | EventDetailsSharedContentAddMemberDetails | EventDetailsSharedContentChangeDownloadsPolicyDetails | EventDetailsSharedContentChangeInviteeRoleDetails | EventDetailsSharedContentChangeLinkAudienceDetails | EventDetailsSharedContentChangeLinkExpiryDetails | EventDetailsSharedContentChangeLinkPasswordDetails | EventDetailsSharedContentChangeMemberRoleDetails | EventDetailsSharedContentChangeViewerInfoPolicyDetails | EventDetailsSharedContentClaimInvitationDetails | EventDetailsSharedContentCopyDetails | EventDetailsSharedContentDownloadDetails | EventDetailsSharedContentRelinquishMembershipDetails | EventDetailsSharedContentRemoveInviteesDetails | EventDetailsSharedContentRemoveLinkExpiryDetails | EventDetailsSharedContentRemoveLinkPasswordDetails | EventDetailsSharedContentRemoveMemberDetails | EventDetailsSharedContentRequestAccessDetails | EventDetailsSharedContentRestoreInviteesDetails | EventDetailsSharedContentRestoreMemberDetails | EventDetailsSharedContentUnshareDetails | EventDetailsSharedContentViewDetails | EventDetailsSharedFolderChangeLinkPolicyDetails | EventDetailsSharedFolderChangeMembersInheritancePolicyDetails | EventDetailsSharedFolderChangeMembersManagementPolicyDetails | EventDetailsSharedFolderChangeMembersPolicyDetails | EventDetailsSharedFolderCreateDetails | EventDetailsSharedFolderDeclineInvitationDetails | EventDetailsSharedFolderMountDetails | EventDetailsSharedFolderNestDetails | EventDetailsSharedFolderTransferOwnershipDetails | EventDetailsSharedFolderUnmountDetails | EventDetailsSharedLinkAddExpiryDetails | EventDetailsSharedLinkChangeExpiryDetails | EventDetailsSharedLinkChangeVisibilityDetails | EventDetailsSharedLinkCopyDetails | EventDetailsSharedLinkCreateDetails | EventDetailsSharedLinkDisableDetails | EventDetailsSharedLinkDownloadDetails | EventDetailsSharedLinkRemoveExpiryDetails | EventDetailsSharedLinkRemoveVisitorDetails | EventDetailsSharedLinkSettingsAddExpirationDetails | EventDetailsSharedLinkSettingsAddPasswordDetails | EventDetailsSharedLinkSettingsAllowDownloadDisabledDetails | EventDetailsSharedLinkSettingsAllowDownloadEnabledDetails | EventDetailsSharedLinkSettingsChangeAudienceDetails | EventDetailsSharedLinkSettingsChangeExpirationDetails | EventDetailsSharedLinkSettingsChangePasswordDetails | EventDetailsSharedLinkSettingsRemoveExpirationDetails | EventDetailsSharedLinkSettingsRemovePasswordDetails | EventDetailsSharedLinkShareDetails | EventDetailsSharedLinkViewDetails | EventDetailsSharedNoteOpenedDetails | EventDetailsShmodelDisableDownloadsDetails | EventDetailsShmodelEnableDownloadsDetails | EventDetailsShmodelGroupShareDetails | EventDetailsShowcaseAccessGrantedDetails | EventDetailsShowcaseAddMemberDetails | EventDetailsShowcaseArchivedDetails | EventDetailsShowcaseCreatedDetails | EventDetailsShowcaseDeleteCommentDetails | EventDetailsShowcaseEditedDetails | EventDetailsShowcaseEditCommentDetails | EventDetailsShowcaseFileAddedDetails | EventDetailsShowcaseFileDownloadDetails | EventDetailsShowcaseFileRemovedDetails | EventDetailsShowcaseFileViewDetails | EventDetailsShowcasePermanentlyDeletedDetails | EventDetailsShowcasePostCommentDetails | EventDetailsShowcaseRemoveMemberDetails | EventDetailsShowcaseRenamedDetails | EventDetailsShowcaseRequestAccessDetails | EventDetailsShowcaseResolveCommentDetails | EventDetailsShowcaseRestoredDetails | EventDetailsShowcaseTrashedDetails | EventDetailsShowcaseTrashedDeprecatedDetails | EventDetailsShowcaseUnresolveCommentDetails | EventDetailsShowcaseUntrashedDetails | EventDetailsShowcaseUntrashedDeprecatedDetails | EventDetailsShowcaseViewDetails | EventDetailsSignSignatureRequestCanceledDetails | EventDetailsSignSignatureRequestCompletedDetails | EventDetailsSignSignatureRequestDeclinedDetails | EventDetailsSignSignatureRequestOpenedDetails | EventDetailsSignSignatureRequestReminderSentDetails | EventDetailsSignSignatureRequestSentDetails | EventDetailsSignTemplateCreatedDetails | EventDetailsSignTemplateSharedDetails | EventDetailsRiscSecurityEventDetails | EventDetailsSsoAddCertDetails | EventDetailsSsoAddLoginUrlDetails | EventDetailsSsoAddLogoutUrlDetails | EventDetailsSsoChangeCertDetails | EventDetailsSsoChangeLoginUrlDetails | EventDetailsSsoChangeLogoutUrlDetails | EventDetailsSsoChangeSamlIdentityModeDetails | EventDetailsSsoRemoveCertDetails | EventDetailsSsoRemoveLoginUrlDetails | EventDetailsSsoRemoveLogoutUrlDetails | EventDetailsTeamFolderChangeStatusDetails | EventDetailsTeamFolderCreateDetails | EventDetailsTeamFolderDowngradeDetails | EventDetailsTeamFolderPermanentlyDeleteDetails | EventDetailsTeamFolderRenameDetails | EventDetailsTeamFolderSpaceLimitsChangeCapsTypeDetails | EventDetailsTeamFolderSpaceLimitsChangeLimitDetails | EventDetailsTeamFolderSpaceLimitsChangeNotificationTargetDetails | EventDetailsTeamSelectiveSyncSettingsChangedDetails | EventDetailsAccountCaptureChangePolicyDetails | EventDetailsAdminEmailRemindersChangedDetails | EventDetailsAiThirdPartySharingDropboxBasePolicyChangedDetails | EventDetailsAllowDownloadDisabledDetails | EventDetailsAllowDownloadEnabledDetails | EventDetailsAppleLoginChangePolicyDetails | EventDetailsAppPermissionsChangedDetails | EventDetailsCameraUploadsPolicyChangedDetails | EventDetailsCaptureTeamSpacePolicyChangedDetails | EventDetailsCaptureTranscriptPolicyChangedDetails | EventDetailsClassificationChangePolicyDetails | EventDetailsComputerBackupPolicyChangedDetails | EventDetailsContentAdministrationPolicyChangedDetails | EventDetailsContentDeletionProtectionChangePolicyDetails | EventDetailsDashExternalSharingPolicyChangedDetails | EventDetailsDataPlacementRestrictionChangePolicyDetails | EventDetailsDataPlacementRestrictionSatisfyPolicyDetails | EventDetailsDeviceApprovalsAddExceptionDetails | EventDetailsDeviceApprovalsChangeDesktopPolicyDetails | EventDetailsDeviceApprovalsChangeMobilePolicyDetails | EventDetailsDeviceApprovalsChangeOverageActionDetails | EventDetailsDeviceApprovalsChangeUnlinkActionDetails | EventDetailsDeviceApprovalsRemoveExceptionDetails | EventDetailsDirectoryRestrictionsAddMembersDetails | EventDetailsDirectoryRestrictionsRemoveMembersDetails | EventDetailsDropboxPasswordsPolicyChangedDetails | EventDetailsEmailIngestPolicyChangedDetails | EventDetailsEmmAddExceptionDetails | EventDetailsEmmChangePolicyDetails | EventDetailsEmmRemoveExceptionDetails | EventDetailsExtendedVersionHistoryChangePolicyDetails | EventDetailsExternalDriveBackupPolicyChangedDetails | EventDetailsFileCommentsChangePolicyDetails | EventDetailsFileLockingPolicyChangedDetails | EventDetailsFileProviderMigrationPolicyChangedDetails | EventDetailsFileRequestsChangePolicyDetails | EventDetailsFileRequestsEmailsEnabledDetails | EventDetailsFileRequestsEmailsRestrictedToTeamOnlyDetails | EventDetailsFileTransfersPolicyChangedDetails | EventDetailsFlexibleFileNamesPolicyChangedDetails | EventDetailsFolderLinkRestrictionPolicyChangedDetails | EventDetailsGoogleSsoChangePolicyDetails | EventDetailsGroupUserManagementChangePolicyDetails | EventDetailsIntegrationPolicyChangedDetails | EventDetailsInviteAcceptanceEmailPolicyChangedDetails | EventDetailsMediaHubAddingPeoplePolicyChangedDetails | EventDetailsMediaHubDownloadPolicyChangedDetails | EventDetailsMediaHubLinkSharingPolicyChangedDetails | EventDetailsMemberRequestsChangePolicyDetails | EventDetailsMemberSendInvitePolicyChangedDetails | EventDetailsMemberSpaceLimitsAddExceptionDetails | EventDetailsMemberSpaceLimitsChangeCapsTypePolicyDetails | EventDetailsMemberSpaceLimitsChangePolicyDetails | EventDetailsMemberSpaceLimitsRemoveExceptionDetails | EventDetailsMemberSuggestionsChangePolicyDetails | EventDetailsMicrosoftLoginChangePolicyDetails | EventDetailsMicrosoftOfficeAddinChangePolicyDetails | EventDetailsMultiTeamIdentityPolicyChangedDetails | EventDetailsNetworkControlChangePolicyDetails | EventDetailsPaperChangeDeploymentPolicyDetails | EventDetailsPaperChangeMemberLinkPolicyDetails | EventDetailsPaperChangeMemberPolicyDetails | EventDetailsPaperChangePolicyDetails | EventDetailsPaperDefaultFolderPolicyChangedDetails | EventDetailsPaperDesktopPolicyChangedDetails | EventDetailsPaperEnabledUsersGroupAdditionDetails | EventDetailsPaperEnabledUsersGroupRemovalDetails | EventDetailsPasskeyLoginPolicyChangedDetails | EventDetailsPasswordStrengthRequirementsChangePolicyDetails | EventDetailsPermanentDeleteChangePolicyDetails | EventDetailsPreviewsAiPolicyChangedDetails | EventDetailsReplayAddingPeoplePolicyChangedDetails | EventDetailsReplaySharingPolicyChangedDetails | EventDetailsResellerSupportChangePolicyDetails | EventDetailsRewindPolicyChangedDetails | EventDetailsSendAndTrackPolicyChangedDetails | EventDetailsSendExternalSharingPolicyChangedDetails | EventDetailsSendForSignaturePolicyChangedDetails | EventDetailsSharedLinkDefaultPermissionsPolicyChangedDetails | EventDetailsSharingChangeFolderJoinPolicyDetails | EventDetailsSharingChangeLinkAllowChangeExpirationPolicyDetails | EventDetailsSharingChangeLinkDefaultExpirationPolicyDetails | EventDetailsSharingChangeLinkEnforcePasswordPolicyDetails | EventDetailsSharingChangeLinkPolicyDetails | EventDetailsSharingChangeMemberPolicyDetails | EventDetailsShowcaseChangeDownloadPolicyDetails | EventDetailsShowcaseChangeEnabledPolicyDetails | EventDetailsShowcaseChangeExternalSharingPolicyDetails | EventDetailsSignExternalSharingPolicyChangedDetails | EventDetailsSignTemplateCreationPermissionChangedDetails | EventDetailsSmarterSmartSyncPolicyChangedDetails | EventDetailsSmartSyncChangePolicyDetails | EventDetailsSmartSyncNotOptOutDetails | EventDetailsSmartSyncOptOutDetails | EventDetailsSsoChangePolicyDetails | EventDetailsStackCrossTeamAccessPolicyChangedDetails | EventDetailsTeamBrandingPolicyChangedDetails | EventDetailsTeamExtensionsPolicyChangedDetails | EventDetailsTeamMemberStorageRequestPolicyChangedDetails | EventDetailsTeamSelectiveSyncPolicyChangedDetails | EventDetailsTeamSharingWhitelistSubjectsChangedDetails | EventDetailsTfaAddExceptionDetails | EventDetailsTfaChangePolicyDetails | EventDetailsTfaRemoveExceptionDetails | EventDetailsTopLevelContentPolicyChangedDetails | EventDetailsTwoAccountChangePolicyDetails | EventDetailsViewerInfoPolicyChangedDetails | EventDetailsWatermarkingPolicyChangedDetails | EventDetailsWebSessionsChangeActiveSessionLimitDetails | EventDetailsWebSessionsChangeFixedLengthPolicyDetails | EventDetailsWebSessionsChangeIdleLengthPolicyDetails | EventDetailsDataResidencyMigrationRequestSuccessfulDetails | EventDetailsDataResidencyMigrationRequestUnsuccessfulDetails | EventDetailsTeamMergeFromDetails | EventDetailsTeamMergeToDetails | EventDetailsTeamProfileAddBackgroundDetails | EventDetailsTeamProfileAddLogoDetails | EventDetailsTeamProfileChangeBackgroundDetails | EventDetailsTeamProfileChangeDefaultLanguageDetails | EventDetailsTeamProfileChangeLogoDetails | EventDetailsTeamProfileChangeNameDetails | EventDetailsTeamProfileRemoveBackgroundDetails | EventDetailsTeamProfileRemoveLogoDetails | EventDetailsPasskeyAddDetails | EventDetailsPasskeyRemoveDetails | EventDetailsTfaAddBackupPhoneDetails | EventDetailsTfaAddSecurityKeyDetails | EventDetailsTfaChangeBackupPhoneDetails | EventDetailsTfaChangeStatusDetails | EventDetailsTfaRemoveBackupPhoneDetails | EventDetailsTfaRemoveSecurityKeyDetails | EventDetailsTfaResetDetails | EventDetailsChangedEnterpriseAdminRoleDetails | EventDetailsChangedEnterpriseConnectedTeamStatusDetails | EventDetailsEndedEnterpriseAdminSessionDetails | EventDetailsEndedEnterpriseAdminSessionDeprecatedDetails | EventDetailsEnterpriseSettingsLockingDetails | EventDetailsGuestAdminChangeStatusDetails | EventDetailsStartedEnterpriseAdminSessionDetails | EventDetailsTeamMergeRequestAcceptedDetails | EventDetailsTeamMergeRequestAcceptedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestAcceptedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestAutoCanceledDetails | EventDetailsTeamMergeRequestCanceledDetails | EventDetailsTeamMergeRequestCanceledShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestCanceledShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestExpiredDetails | EventDetailsTeamMergeRequestExpiredShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestExpiredShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestReminderDetails | EventDetailsTeamMergeRequestReminderShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestReminderShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRevokedDetails | EventDetailsTeamMergeRequestSentShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestSentShownToSecondaryTeamDetails | EventDetailsMissingDetails | EventDetailsOther;
 
     /**
      * (admin_alerting) Changed an alert state
@@ -25529,7 +25250,7 @@
     }
 
     /**
-     * (file_operations) Downloaded files in Replay
+     * (file_operations) Downloaded files in Media Hub
      */
     export interface EventTypeMediaHubFileDownloaded extends MediaHubFileDownloadedType {
       '.tag': 'media_hub_file_downloaded';
@@ -25970,13 +25691,6 @@
      */
     export interface EventTypeMemberDeleteProfilePhoto extends MemberDeleteProfilePhotoType {
       '.tag': 'member_delete_profile_photo';
-    }
-
-    /**
-     * (members) Admin browsed a team member's folder contents
-     */
-    export interface EventTypeMemberFolderContentsAccessed extends MemberFolderContentsAccessedType {
-      '.tag': 'member_folder_contents_accessed';
     }
 
     /**
@@ -26457,87 +26171,10 @@
     }
 
     /**
-     * (protect) Added collaborators via Dropbox Protect
-     */
-    export interface EventTypeProtectActionAddCollaborator extends ProtectActionAddCollaboratorType {
-      '.tag': 'protect_action_add_collaborator';
-    }
-
-    /**
-     * (protect) Added a link via Dropbox Protect
-     */
-    export interface EventTypeProtectActionAddLink extends ProtectActionAddLinkType {
-      '.tag': 'protect_action_add_link';
-    }
-
-    /**
-     * (protect) Deleted content via Dropbox Protect
-     */
-    export interface EventTypeProtectActionDelete extends ProtectActionDeleteType {
-      '.tag': 'protect_action_delete';
-    }
-
-    /**
-     * (protect) Exported content via Dropbox Protect
-     */
-    export interface EventTypeProtectActionExport extends ProtectActionExportType {
-      '.tag': 'protect_action_export';
-    }
-
-    /**
-     * (protect) Removed collaborators via Dropbox Protect
-     */
-    export interface EventTypeProtectActionRemoveCollaborator extends ProtectActionRemoveCollaboratorType {
-      '.tag': 'protect_action_remove_collaborator';
-    }
-
-    /**
-     * (protect) Removed a link via Dropbox Protect
-     */
-    export interface EventTypeProtectActionRemoveLink extends ProtectActionRemoveLinkType {
-      '.tag': 'protect_action_remove_link';
-    }
-
-    /**
-     * (protect) Stopped sharing content via Dropbox Protect
-     */
-    export interface EventTypeProtectActionStopSharing extends ProtectActionStopSharingType {
-      '.tag': 'protect_action_stop_sharing';
-    }
-
-    /**
      * (protect) Modified Protect internal domains list
      */
     export interface EventTypeProtectInternalDomainsChanged extends ProtectInternalDomainsChangedType {
       '.tag': 'protect_internal_domains_changed';
-    }
-
-    /**
-     * (protect) Activated a Dropbox Protect policy
-     */
-    export interface EventTypeProtectPolicyActivated extends ProtectPolicyActivatedType {
-      '.tag': 'protect_policy_activated';
-    }
-
-    /**
-     * (protect) Deactivated a Dropbox Protect policy
-     */
-    export interface EventTypeProtectPolicyDeactivated extends ProtectPolicyDeactivatedType {
-      '.tag': 'protect_policy_deactivated';
-    }
-
-    /**
-     * (protect) Scheduled a Dropbox Protect policy
-     */
-    export interface EventTypeProtectPolicyScheduled extends ProtectPolicyScheduledType {
-      '.tag': 'protect_policy_scheduled';
-    }
-
-    /**
-     * (protect) Updated a Dropbox Protect policy
-     */
-    export interface EventTypeProtectPolicyUpdated extends ProtectPolicyUpdatedType {
-      '.tag': 'protect_policy_updated';
     }
 
     /**
@@ -26793,49 +26430,49 @@
     }
 
     /**
-     * (sharing) Added member to Replay project
+     * (sharing) Added member to Media Hub project
      */
     export interface EventTypeMediaHubProjectTeamAdd extends MediaHubProjectTeamAddType {
       '.tag': 'media_hub_project_team_add';
     }
 
     /**
-     * (sharing) Removed member from Replay project
+     * (sharing) Removed member from Media Hub project
      */
     export interface EventTypeMediaHubProjectTeamDelete extends MediaHubProjectTeamDeleteType {
       '.tag': 'media_hub_project_team_delete';
     }
 
     /**
-     * (sharing) Changed member role in Replay project
+     * (sharing) Changed member role in Media Hub project
      */
     export interface EventTypeMediaHubProjectTeamRoleChanged extends MediaHubProjectTeamRoleChangedType {
       '.tag': 'media_hub_project_team_role_changed';
     }
 
     /**
-     * (sharing) Changed Replay shared link audience
+     * (sharing) Changed Media Hub shared link audience
      */
     export interface EventTypeMediaHubSharedLinkAudienceChanged extends MediaHubSharedLinkAudienceChangedType {
       '.tag': 'media_hub_shared_link_audience_changed';
     }
 
     /**
-     * (sharing) Created Replay shared link
+     * (sharing) Created Media Hub shared link
      */
     export interface EventTypeMediaHubSharedLinkCreated extends MediaHubSharedLinkCreatedType {
       '.tag': 'media_hub_shared_link_created';
     }
 
     /**
-     * (sharing) Changed Replay shared link download setting
+     * (sharing) Changed Media Hub shared link download setting
      */
     export interface EventTypeMediaHubSharedLinkDownloadSettingChanged extends MediaHubSharedLinkDownloadSettingChangedType {
       '.tag': 'media_hub_shared_link_download_setting_changed';
     }
 
     /**
-     * (sharing) Revoked Replay shared link
+     * (sharing) Revoked Media Hub shared link
      */
     export interface EventTypeMediaHubSharedLinkRevoked extends MediaHubSharedLinkRevokedType {
       '.tag': 'media_hub_shared_link_revoked';
@@ -28180,21 +27817,21 @@
     }
 
     /**
-     * (team_policies) Changed the policy for adding people to Replay content
+     * (team_policies) Changed the policy for adding people to Media Hub content
      */
     export interface EventTypeMediaHubAddingPeoplePolicyChanged extends MediaHubAddingPeoplePolicyChangedType {
       '.tag': 'media_hub_adding_people_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for downloading Replay content
+     * (team_policies) Changed the policy for downloading Media Hub content
      */
     export interface EventTypeMediaHubDownloadPolicyChanged extends MediaHubDownloadPolicyChangedType {
       '.tag': 'media_hub_download_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for sharing Replay content
+     * (team_policies) Changed the policy for sharing Media Hub content
      */
     export interface EventTypeMediaHubLinkSharingPolicyChanged extends MediaHubLinkSharingPolicyChangedType {
       '.tag': 'media_hub_link_sharing_policy_changed';
@@ -29000,7 +28637,7 @@
     /**
      * The type of the event with description.
      */
-    export type EventType = EventTypeAdminAlertingAlertStateChanged | EventTypeAdminAlertingChangedAlertConfig | EventTypeAdminAlertingTriggeredAlert | EventTypeRansomwareRestoreProcessCompleted | EventTypeRansomwareRestoreProcessStarted | EventTypeAppBlockedByPermissions | EventTypeAppLinkTeam | EventTypeAppLinkUser | EventTypeAppUnlinkTeam | EventTypeAppUnlinkUser | EventTypeIntegrationConnected | EventTypeIntegrationDisconnected | EventTypeFileAddComment | EventTypeFileChangeCommentSubscription | EventTypeFileDeleteComment | EventTypeFileEditComment | EventTypeFileLikeComment | EventTypeFileResolveComment | EventTypeFileUnlikeComment | EventTypeFileUnresolveComment | EventTypeDashAddedCommentToStack | EventTypeDashAddedConnector | EventTypeDashAddedLinkToStack | EventTypeDashAddedTeamEmailDomainAllowlist | EventTypeDashAdminAddedOrgWideConnector | EventTypeDashAdminDisabledConnector | EventTypeDashAdminEnabledConnector | EventTypeDashAdminRemovedOrgWideConnector | EventTypeDashArchivedStack | EventTypeDashChangedAudienceOfSharedLinkToStack | EventTypeDashClonedStack | EventTypeDashConnectorToolsCall | EventTypeDashCreatedStack | EventTypeDashDeletedCommentFromStack | EventTypeDashDeletedStack | EventTypeDashEditedCommentInStack | EventTypeDashExternalUserOpenedStack | EventTypeDashFirstLaunchedDesktop | EventTypeDashFirstLaunchedExtension | EventTypeDashFirstLaunchedWebStartPage | EventTypeDashOpenedSharedLinkToStack | EventTypeDashOpenedStack | EventTypeDashPreviewOptOutStatusChanged | EventTypeDashRemovedConnector | EventTypeDashRemovedLinkFromStack | EventTypeDashRemovedSharedLinkToStack | EventTypeDashRemovedTeamEmailDomainAllowlist | EventTypeDashRenamedStack | EventTypeDashSharedLinkToStack | EventTypeDashUnarchivedStack | EventTypeDashViewedCompanyStack | EventTypeDashViewedExternalAiActivityReport | EventTypeGovernancePolicyAddFolders | EventTypeGovernancePolicyAddFolderFailed | EventTypeGovernancePolicyContentDisposed | EventTypeGovernancePolicyCreate | EventTypeGovernancePolicyDelete | EventTypeGovernancePolicyEditDetails | EventTypeGovernancePolicyEditDuration | EventTypeGovernancePolicyExportCreated | EventTypeGovernancePolicyExportRemoved | EventTypeGovernancePolicyRemoveFolders | EventTypeGovernancePolicyReportCreated | EventTypeGovernancePolicyZipPartDownloaded | EventTypeLegalHoldsActivateAHold | EventTypeLegalHoldsAddMembers | EventTypeLegalHoldsChangeHoldDetails | EventTypeLegalHoldsChangeHoldName | EventTypeLegalHoldsExportAHold | EventTypeLegalHoldsExportCancelled | EventTypeLegalHoldsExportDownloaded | EventTypeLegalHoldsExportRemoved | EventTypeLegalHoldsReleaseAHold | EventTypeLegalHoldsRemoveMembers | EventTypeLegalHoldsReportAHold | EventTypeDeviceChangeIpDesktop | EventTypeDeviceChangeIpMobile | EventTypeDeviceChangeIpWeb | EventTypeDeviceDeleteOnUnlinkFail | EventTypeDeviceDeleteOnUnlinkSuccess | EventTypeDeviceLinkFail | EventTypeDeviceLinkSuccess | EventTypeDeviceManagementDisabled | EventTypeDeviceManagementEnabled | EventTypeDeviceSyncBackupStatusChanged | EventTypeDeviceUnlink | EventTypeDropboxPasswordsExported | EventTypeDropboxPasswordsNewDeviceEnrolled | EventTypeEmmRefreshAuthToken | EventTypeExternalDriveBackupEligibilityStatusChecked | EventTypeExternalDriveBackupStatusChanged | EventTypeAccountCaptureChangeAvailability | EventTypeAccountCaptureMigrateAccount | EventTypeAccountCaptureNotificationEmailsSent | EventTypeAccountCaptureRelinquishAccount | EventTypeDisabledDomainInvites | EventTypeDomainInvitesApproveRequestToJoinTeam | EventTypeDomainInvitesDeclineRequestToJoinTeam | EventTypeDomainInvitesEmailExistingUsers | EventTypeDomainInvitesRequestToJoinTeam | EventTypeDomainInvitesSetInviteNewUserPrefToNo | EventTypeDomainInvitesSetInviteNewUserPrefToYes | EventTypeDomainVerificationAddDomainFail | EventTypeDomainVerificationAddDomainSuccess | EventTypeDomainVerificationRemoveDomain | EventTypeEnabledDomainInvites | EventTypeEncryptedFolderCancelTeamKeyRotation | EventTypeEncryptedFolderEnrollBackupKey | EventTypeEncryptedFolderEnrollClient | EventTypeEncryptedFolderEnrollTeam | EventTypeEncryptedFolderFinishTeamUnenrollment | EventTypeEncryptedFolderInitTeamKeyRotation | EventTypeEncryptedFolderInitTeamUnenrollment | EventTypeEncryptedFolderRemoveBackupKey | EventTypeEncryptedFolderRotateTeamKey | EventTypeEncryptedFolderUnenrollClient | EventTypeTeamEncryptionKeyActivateKey | EventTypeTeamEncryptionKeyCancelKeyDeletion | EventTypeTeamEncryptionKeyCreateKey | EventTypeTeamEncryptionKeyDeactivateKey | EventTypeTeamEncryptionKeyDeleteKey | EventTypeTeamEncryptionKeyDisableKey | EventTypeTeamEncryptionKeyEnableKey | EventTypeTeamEncryptionKeyRotateKey | EventTypeTeamEncryptionKeyScheduleKeyDeletion | EventTypeApplyNamingConvention | EventTypeCreateFolder | EventTypeFileAdd | EventTypeFileAddFromAutomation | EventTypeFileCopy | EventTypeFileDelete | EventTypeFileDownload | EventTypeFileEdit | EventTypeFileGetCopyReference | EventTypeFileLockingLockStatusChanged | EventTypeFileMove | EventTypeFilePermanentlyDelete | EventTypeFilePreview | EventTypeFileRename | EventTypeFileRestore | EventTypeFileRevert | EventTypeFileRollbackChanges | EventTypeFileSaveCopyReference | EventTypeFolderOverviewDescriptionChanged | EventTypeFolderOverviewItemPinned | EventTypeFolderOverviewItemUnpinned | EventTypeMediaHubFileDownloaded | EventTypeObjectLabelAdded | EventTypeObjectLabelRemoved | EventTypeObjectLabelUpdatedValue | EventTypeOrganizeFolderWithTidy | EventTypeReplayFileDelete | EventTypeReplayFileDownloaded | EventTypeReplayTeamProjectCreated | EventTypeRewindFolder | EventTypeUndoNamingConvention | EventTypeUndoOrganizeFolderWithTidy | EventTypeUserTagsAdded | EventTypeUserTagsRemoved | EventTypeEmailIngestReceiveFile | EventTypeFileRequestAutoClose | EventTypeFileRequestChange | EventTypeFileRequestClose | EventTypeFileRequestCreate | EventTypeFileRequestDelete | EventTypeFileRequestReceiveFile | EventTypeGroupAddExternalId | EventTypeGroupAddMember | EventTypeGroupChangeExternalId | EventTypeGroupChangeManagementType | EventTypeGroupChangeMemberRole | EventTypeGroupCreate | EventTypeGroupDelete | EventTypeGroupDescriptionUpdated | EventTypeGroupExternalSharingSettingOverrideChanged | EventTypeGroupJoinPolicyUpdated | EventTypeGroupMoved | EventTypeGroupRemoveExternalId | EventTypeGroupRemoveMember | EventTypeGroupRename | EventTypeAccountLockOrUnlocked | EventTypeEmmError | EventTypeGuestAdminSignedInViaTrustedTeams | EventTypeGuestAdminSignedOutViaTrustedTeams | EventTypeLoginFail | EventTypeLoginSuccess | EventTypeLogout | EventTypeResellerSupportSessionEnd | EventTypeResellerSupportSessionStart | EventTypeSignInAsSessionEnd | EventTypeSignInAsSessionStart | EventTypeSsoError | EventTypeAddonAssigned | EventTypeAddonRemoved | EventTypeBackupAdminInvitationSent | EventTypeBackupInvitationOpened | EventTypeCreateTeamInviteLink | EventTypeDeleteTeamInviteLink | EventTypeMemberAddExternalId | EventTypeMemberAddName | EventTypeMemberChangeAdminRole | EventTypeMemberChangeEmail | EventTypeMemberChangeExternalId | EventTypeMemberChangeMembershipType | EventTypeMemberChangeName | EventTypeMemberChangeResellerRole | EventTypeMemberChangeStatus | EventTypeMemberDeleteManualContacts | EventTypeMemberDeleteProfilePhoto | EventTypeMemberFolderContentsAccessed | EventTypeMemberPermanentlyDeleteAccountContents | EventTypeMemberRemoveExternalId | EventTypeMemberSetProfilePhoto | EventTypeMemberSpaceLimitsAddCustomQuota | EventTypeMemberSpaceLimitsChangeCustomQuota | EventTypeMemberSpaceLimitsChangeStatus | EventTypeMemberSpaceLimitsRemoveCustomQuota | EventTypeMemberSuggest | EventTypeMemberTransferAccountContents | EventTypePendingSecondaryEmailAdded | EventTypeProductAssignedToMember | EventTypeProductRemovedFromMember | EventTypeSecondaryEmailDeleted | EventTypeSecondaryEmailVerified | EventTypeSecondaryMailsPolicyChanged | EventTypeBinderAddPage | EventTypeBinderAddSection | EventTypeBinderRemovePage | EventTypeBinderRemoveSection | EventTypeBinderRenamePage | EventTypeBinderRenameSection | EventTypeBinderReorderPage | EventTypeBinderReorderSection | EventTypePaperContentAddMember | EventTypePaperContentAddToFolder | EventTypePaperContentArchive | EventTypePaperContentCreate | EventTypePaperContentPermanentlyDelete | EventTypePaperContentRemoveFromFolder | EventTypePaperContentRemoveMember | EventTypePaperContentRename | EventTypePaperContentRestore | EventTypePaperDocAddComment | EventTypePaperDocChangeMemberRole | EventTypePaperDocChangeSharingPolicy | EventTypePaperDocChangeSubscription | EventTypePaperDocDeleted | EventTypePaperDocDeleteComment | EventTypePaperDocDownload | EventTypePaperDocEdit | EventTypePaperDocEditComment | EventTypePaperDocFollowed | EventTypePaperDocMention | EventTypePaperDocOwnershipChanged | EventTypePaperDocRequestAccess | EventTypePaperDocResolveComment | EventTypePaperDocRevert | EventTypePaperDocSlackShare | EventTypePaperDocTeamInvite | EventTypePaperDocTrashed | EventTypePaperDocUnresolveComment | EventTypePaperDocUntrashed | EventTypePaperDocView | EventTypePaperExternalViewAllow | EventTypePaperExternalViewDefaultTeam | EventTypePaperExternalViewForbid | EventTypePaperFolderChangeSubscription | EventTypePaperFolderDeleted | EventTypePaperFolderFollowed | EventTypePaperFolderTeamInvite | EventTypePaperPublishedLinkChangePermission | EventTypePaperPublishedLinkCreate | EventTypePaperPublishedLinkDisabled | EventTypePaperPublishedLinkView | EventTypePasswordChange | EventTypePasswordReset | EventTypePasswordResetAll | EventTypeProtectActionAddCollaborator | EventTypeProtectActionAddLink | EventTypeProtectActionDelete | EventTypeProtectActionExport | EventTypeProtectActionRemoveCollaborator | EventTypeProtectActionRemoveLink | EventTypeProtectActionStopSharing | EventTypeProtectInternalDomainsChanged | EventTypeProtectPolicyActivated | EventTypeProtectPolicyDeactivated | EventTypeProtectPolicyScheduled | EventTypeProtectPolicyUpdated | EventTypeClassificationCreateReport | EventTypeClassificationCreateReportFail | EventTypeEmmCreateExceptionsReport | EventTypeEmmCreateUsageReport | EventTypeExportMembersReport | EventTypeExportMembersReportFail | EventTypeExternalSharingCreateReport | EventTypeExternalSharingReportFailed | EventTypeMemberAccessDetailsCreateReport | EventTypeMemberAccessDetailsCreateReportFailed | EventTypeNoExpirationLinkGenCreateReport | EventTypeNoExpirationLinkGenReportFailed | EventTypeNoPasswordLinkGenCreateReport | EventTypeNoPasswordLinkGenReportFailed | EventTypeNoPasswordLinkViewCreateReport | EventTypeNoPasswordLinkViewReportFailed | EventTypeOutdatedLinkViewCreateReport | EventTypeOutdatedLinkViewReportFailed | EventTypePaperAdminExportStart | EventTypeRansomwareAlertCreateReport | EventTypeRansomwareAlertCreateReportFailed | EventTypeSharedFoldersCreateReport | EventTypeSharedFoldersCreateReportFailed | EventTypeSmartSyncCreateAdminPrivilegeReport | EventTypeTeamActivityCreateReport | EventTypeTeamActivityCreateReportFail | EventTypeTeamFoldersCreateReport | EventTypeTeamFoldersCreateReportFailed | EventTypeTeamStorageCreateReport | EventTypeTeamStorageCreateReportFailed | EventTypeCollectionShare | EventTypeFileTransfersFileAdd | EventTypeFileTransfersTransferDelete | EventTypeFileTransfersTransferDownload | EventTypeFileTransfersTransferSend | EventTypeFileTransfersTransferView | EventTypeMediaHubProjectTeamAdd | EventTypeMediaHubProjectTeamDelete | EventTypeMediaHubProjectTeamRoleChanged | EventTypeMediaHubSharedLinkAudienceChanged | EventTypeMediaHubSharedLinkCreated | EventTypeMediaHubSharedLinkDownloadSettingChanged | EventTypeMediaHubSharedLinkRevoked | EventTypeNoteAclInviteOnly | EventTypeNoteAclLink | EventTypeNoteAclTeamLink | EventTypeNoteShared | EventTypeNoteShareReceive | EventTypeOpenNoteShared | EventTypeReplayFileSharedLinkCreated | EventTypeReplayFileSharedLinkModified | EventTypeReplayProjectTeamAdd | EventTypeReplayProjectTeamDelete | EventTypeSendAndTrackFileAdded | EventTypeSendAndTrackFileRenamed | EventTypeSendAndTrackFileUpdated | EventTypeSendAndTrackLinkCreated | EventTypeSendAndTrackLinkDeleted | EventTypeSendAndTrackLinkUpdated | EventTypeSendAndTrackLinkViewed | EventTypeSendAndTrackRemovedFileAndAssociatedLinks | EventTypeSfAddGroup | EventTypeSfAllowNonMembersToViewSharedLinks | EventTypeSfExternalInviteWarn | EventTypeSfFbInvite | EventTypeSfFbInviteChangeRole | EventTypeSfFbUninvite | EventTypeSfInviteGroup | EventTypeSfTeamGrantAccess | EventTypeSfTeamInvite | EventTypeSfTeamInviteChangeRole | EventTypeSfTeamJoin | EventTypeSfTeamJoinFromOobLink | EventTypeSfTeamUninvite | EventTypeSharedContentAddInvitees | EventTypeSharedContentAddLinkExpiry | EventTypeSharedContentAddLinkPassword | EventTypeSharedContentAddMember | EventTypeSharedContentChangeDownloadsPolicy | EventTypeSharedContentChangeInviteeRole | EventTypeSharedContentChangeLinkAudience | EventTypeSharedContentChangeLinkExpiry | EventTypeSharedContentChangeLinkPassword | EventTypeSharedContentChangeMemberRole | EventTypeSharedContentChangeViewerInfoPolicy | EventTypeSharedContentClaimInvitation | EventTypeSharedContentCopy | EventTypeSharedContentDownload | EventTypeSharedContentRelinquishMembership | EventTypeSharedContentRemoveInvitees | EventTypeSharedContentRemoveLinkExpiry | EventTypeSharedContentRemoveLinkPassword | EventTypeSharedContentRemoveMember | EventTypeSharedContentRequestAccess | EventTypeSharedContentRestoreInvitees | EventTypeSharedContentRestoreMember | EventTypeSharedContentUnshare | EventTypeSharedContentView | EventTypeSharedFolderChangeLinkPolicy | EventTypeSharedFolderChangeMembersInheritancePolicy | EventTypeSharedFolderChangeMembersManagementPolicy | EventTypeSharedFolderChangeMembersPolicy | EventTypeSharedFolderCreate | EventTypeSharedFolderDeclineInvitation | EventTypeSharedFolderMount | EventTypeSharedFolderNest | EventTypeSharedFolderTransferOwnership | EventTypeSharedFolderUnmount | EventTypeSharedLinkAddExpiry | EventTypeSharedLinkChangeExpiry | EventTypeSharedLinkChangeVisibility | EventTypeSharedLinkCopy | EventTypeSharedLinkCreate | EventTypeSharedLinkDisable | EventTypeSharedLinkDownload | EventTypeSharedLinkRemoveExpiry | EventTypeSharedLinkRemoveVisitor | EventTypeSharedLinkSettingsAddExpiration | EventTypeSharedLinkSettingsAddPassword | EventTypeSharedLinkSettingsAllowDownloadDisabled | EventTypeSharedLinkSettingsAllowDownloadEnabled | EventTypeSharedLinkSettingsChangeAudience | EventTypeSharedLinkSettingsChangeExpiration | EventTypeSharedLinkSettingsChangePassword | EventTypeSharedLinkSettingsRemoveExpiration | EventTypeSharedLinkSettingsRemovePassword | EventTypeSharedLinkShare | EventTypeSharedLinkView | EventTypeSharedNoteOpened | EventTypeShmodelDisableDownloads | EventTypeShmodelEnableDownloads | EventTypeShmodelGroupShare | EventTypeShowcaseAccessGranted | EventTypeShowcaseAddMember | EventTypeShowcaseArchived | EventTypeShowcaseCreated | EventTypeShowcaseDeleteComment | EventTypeShowcaseEdited | EventTypeShowcaseEditComment | EventTypeShowcaseFileAdded | EventTypeShowcaseFileDownload | EventTypeShowcaseFileRemoved | EventTypeShowcaseFileView | EventTypeShowcasePermanentlyDeleted | EventTypeShowcasePostComment | EventTypeShowcaseRemoveMember | EventTypeShowcaseRenamed | EventTypeShowcaseRequestAccess | EventTypeShowcaseResolveComment | EventTypeShowcaseRestored | EventTypeShowcaseTrashed | EventTypeShowcaseTrashedDeprecated | EventTypeShowcaseUnresolveComment | EventTypeShowcaseUntrashed | EventTypeShowcaseUntrashedDeprecated | EventTypeShowcaseView | EventTypeSignSignatureRequestCanceled | EventTypeSignSignatureRequestCompleted | EventTypeSignSignatureRequestDeclined | EventTypeSignSignatureRequestOpened | EventTypeSignSignatureRequestReminderSent | EventTypeSignSignatureRequestSent | EventTypeSignTemplateCreated | EventTypeSignTemplateShared | EventTypeRiscSecurityEvent | EventTypeSsoAddCert | EventTypeSsoAddLoginUrl | EventTypeSsoAddLogoutUrl | EventTypeSsoChangeCert | EventTypeSsoChangeLoginUrl | EventTypeSsoChangeLogoutUrl | EventTypeSsoChangeSamlIdentityMode | EventTypeSsoRemoveCert | EventTypeSsoRemoveLoginUrl | EventTypeSsoRemoveLogoutUrl | EventTypeTeamFolderChangeStatus | EventTypeTeamFolderCreate | EventTypeTeamFolderDowngrade | EventTypeTeamFolderPermanentlyDelete | EventTypeTeamFolderRename | EventTypeTeamFolderSpaceLimitsChangeCapsType | EventTypeTeamFolderSpaceLimitsChangeLimit | EventTypeTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeTeamSelectiveSyncSettingsChanged | EventTypeAccountCaptureChangePolicy | EventTypeAdminEmailRemindersChanged | EventTypeAiThirdPartySharingDropboxBasePolicyChanged | EventTypeAllowDownloadDisabled | EventTypeAllowDownloadEnabled | EventTypeAppleLoginChangePolicy | EventTypeAppPermissionsChanged | EventTypeCameraUploadsPolicyChanged | EventTypeCaptureTeamSpacePolicyChanged | EventTypeCaptureTranscriptPolicyChanged | EventTypeClassificationChangePolicy | EventTypeComputerBackupPolicyChanged | EventTypeContentAdministrationPolicyChanged | EventTypeContentDeletionProtectionChangePolicy | EventTypeDashExternalSharingPolicyChanged | EventTypeDataPlacementRestrictionChangePolicy | EventTypeDataPlacementRestrictionSatisfyPolicy | EventTypeDeviceApprovalsAddException | EventTypeDeviceApprovalsChangeDesktopPolicy | EventTypeDeviceApprovalsChangeMobilePolicy | EventTypeDeviceApprovalsChangeOverageAction | EventTypeDeviceApprovalsChangeUnlinkAction | EventTypeDeviceApprovalsRemoveException | EventTypeDirectoryRestrictionsAddMembers | EventTypeDirectoryRestrictionsRemoveMembers | EventTypeDropboxPasswordsPolicyChanged | EventTypeEmailIngestPolicyChanged | EventTypeEmmAddException | EventTypeEmmChangePolicy | EventTypeEmmRemoveException | EventTypeExtendedVersionHistoryChangePolicy | EventTypeExternalDriveBackupPolicyChanged | EventTypeFileCommentsChangePolicy | EventTypeFileLockingPolicyChanged | EventTypeFileProviderMigrationPolicyChanged | EventTypeFileRequestsChangePolicy | EventTypeFileRequestsEmailsEnabled | EventTypeFileRequestsEmailsRestrictedToTeamOnly | EventTypeFileTransfersPolicyChanged | EventTypeFlexibleFileNamesPolicyChanged | EventTypeFolderLinkRestrictionPolicyChanged | EventTypeGoogleSsoChangePolicy | EventTypeGroupUserManagementChangePolicy | EventTypeIntegrationPolicyChanged | EventTypeInviteAcceptanceEmailPolicyChanged | EventTypeMediaHubAddingPeoplePolicyChanged | EventTypeMediaHubDownloadPolicyChanged | EventTypeMediaHubLinkSharingPolicyChanged | EventTypeMemberRequestsChangePolicy | EventTypeMemberSendInvitePolicyChanged | EventTypeMemberSpaceLimitsAddException | EventTypeMemberSpaceLimitsChangeCapsTypePolicy | EventTypeMemberSpaceLimitsChangePolicy | EventTypeMemberSpaceLimitsRemoveException | EventTypeMemberSuggestionsChangePolicy | EventTypeMicrosoftLoginChangePolicy | EventTypeMicrosoftOfficeAddinChangePolicy | EventTypeMultiTeamIdentityPolicyChanged | EventTypeNetworkControlChangePolicy | EventTypePaperChangeDeploymentPolicy | EventTypePaperChangeMemberLinkPolicy | EventTypePaperChangeMemberPolicy | EventTypePaperChangePolicy | EventTypePaperDefaultFolderPolicyChanged | EventTypePaperDesktopPolicyChanged | EventTypePaperEnabledUsersGroupAddition | EventTypePaperEnabledUsersGroupRemoval | EventTypePasskeyLoginPolicyChanged | EventTypePasswordStrengthRequirementsChangePolicy | EventTypePermanentDeleteChangePolicy | EventTypePreviewsAiPolicyChanged | EventTypeReplayAddingPeoplePolicyChanged | EventTypeReplaySharingPolicyChanged | EventTypeResellerSupportChangePolicy | EventTypeRewindPolicyChanged | EventTypeSendAndTrackPolicyChanged | EventTypeSendExternalSharingPolicyChanged | EventTypeSendForSignaturePolicyChanged | EventTypeSharedLinkDefaultPermissionsPolicyChanged | EventTypeSharingChangeFolderJoinPolicy | EventTypeSharingChangeLinkAllowChangeExpirationPolicy | EventTypeSharingChangeLinkDefaultExpirationPolicy | EventTypeSharingChangeLinkEnforcePasswordPolicy | EventTypeSharingChangeLinkPolicy | EventTypeSharingChangeMemberPolicy | EventTypeShowcaseChangeDownloadPolicy | EventTypeShowcaseChangeEnabledPolicy | EventTypeShowcaseChangeExternalSharingPolicy | EventTypeSignExternalSharingPolicyChanged | EventTypeSignTemplateCreationPermissionChanged | EventTypeSmarterSmartSyncPolicyChanged | EventTypeSmartSyncChangePolicy | EventTypeSmartSyncNotOptOut | EventTypeSmartSyncOptOut | EventTypeSsoChangePolicy | EventTypeStackCrossTeamAccessPolicyChanged | EventTypeTeamBrandingPolicyChanged | EventTypeTeamExtensionsPolicyChanged | EventTypeTeamMemberStorageRequestPolicyChanged | EventTypeTeamSelectiveSyncPolicyChanged | EventTypeTeamSharingWhitelistSubjectsChanged | EventTypeTfaAddException | EventTypeTfaChangePolicy | EventTypeTfaRemoveException | EventTypeTopLevelContentPolicyChanged | EventTypeTwoAccountChangePolicy | EventTypeViewerInfoPolicyChanged | EventTypeWatermarkingPolicyChanged | EventTypeWebSessionsChangeActiveSessionLimit | EventTypeWebSessionsChangeFixedLengthPolicy | EventTypeWebSessionsChangeIdleLengthPolicy | EventTypeDataResidencyMigrationRequestSuccessful | EventTypeDataResidencyMigrationRequestUnsuccessful | EventTypeTeamMergeFrom | EventTypeTeamMergeTo | EventTypeTeamProfileAddBackground | EventTypeTeamProfileAddLogo | EventTypeTeamProfileChangeBackground | EventTypeTeamProfileChangeDefaultLanguage | EventTypeTeamProfileChangeLogo | EventTypeTeamProfileChangeName | EventTypeTeamProfileRemoveBackground | EventTypeTeamProfileRemoveLogo | EventTypePasskeyAdd | EventTypePasskeyRemove | EventTypeTfaAddBackupPhone | EventTypeTfaAddSecurityKey | EventTypeTfaChangeBackupPhone | EventTypeTfaChangeStatus | EventTypeTfaRemoveBackupPhone | EventTypeTfaRemoveSecurityKey | EventTypeTfaReset | EventTypeChangedEnterpriseAdminRole | EventTypeChangedEnterpriseConnectedTeamStatus | EventTypeEndedEnterpriseAdminSession | EventTypeEndedEnterpriseAdminSessionDeprecated | EventTypeEnterpriseSettingsLocking | EventTypeGuestAdminChangeStatus | EventTypeStartedEnterpriseAdminSession | EventTypeTeamMergeRequestAccepted | EventTypeTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeTeamMergeRequestAutoCanceled | EventTypeTeamMergeRequestCanceled | EventTypeTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeTeamMergeRequestExpired | EventTypeTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeTeamMergeRequestReminder | EventTypeTeamMergeRequestReminderShownToPrimaryTeam | EventTypeTeamMergeRequestReminderShownToSecondaryTeam | EventTypeTeamMergeRequestRevoked | EventTypeTeamMergeRequestSentShownToPrimaryTeam | EventTypeTeamMergeRequestSentShownToSecondaryTeam | EventTypeOther;
+    export type EventType = EventTypeAdminAlertingAlertStateChanged | EventTypeAdminAlertingChangedAlertConfig | EventTypeAdminAlertingTriggeredAlert | EventTypeRansomwareRestoreProcessCompleted | EventTypeRansomwareRestoreProcessStarted | EventTypeAppBlockedByPermissions | EventTypeAppLinkTeam | EventTypeAppLinkUser | EventTypeAppUnlinkTeam | EventTypeAppUnlinkUser | EventTypeIntegrationConnected | EventTypeIntegrationDisconnected | EventTypeFileAddComment | EventTypeFileChangeCommentSubscription | EventTypeFileDeleteComment | EventTypeFileEditComment | EventTypeFileLikeComment | EventTypeFileResolveComment | EventTypeFileUnlikeComment | EventTypeFileUnresolveComment | EventTypeDashAddedCommentToStack | EventTypeDashAddedConnector | EventTypeDashAddedLinkToStack | EventTypeDashAddedTeamEmailDomainAllowlist | EventTypeDashAdminAddedOrgWideConnector | EventTypeDashAdminDisabledConnector | EventTypeDashAdminEnabledConnector | EventTypeDashAdminRemovedOrgWideConnector | EventTypeDashArchivedStack | EventTypeDashChangedAudienceOfSharedLinkToStack | EventTypeDashClonedStack | EventTypeDashConnectorToolsCall | EventTypeDashCreatedStack | EventTypeDashDeletedCommentFromStack | EventTypeDashDeletedStack | EventTypeDashEditedCommentInStack | EventTypeDashExternalUserOpenedStack | EventTypeDashFirstLaunchedDesktop | EventTypeDashFirstLaunchedExtension | EventTypeDashFirstLaunchedWebStartPage | EventTypeDashOpenedSharedLinkToStack | EventTypeDashOpenedStack | EventTypeDashPreviewOptOutStatusChanged | EventTypeDashRemovedConnector | EventTypeDashRemovedLinkFromStack | EventTypeDashRemovedSharedLinkToStack | EventTypeDashRemovedTeamEmailDomainAllowlist | EventTypeDashRenamedStack | EventTypeDashSharedLinkToStack | EventTypeDashUnarchivedStack | EventTypeDashViewedCompanyStack | EventTypeDashViewedExternalAiActivityReport | EventTypeGovernancePolicyAddFolders | EventTypeGovernancePolicyAddFolderFailed | EventTypeGovernancePolicyContentDisposed | EventTypeGovernancePolicyCreate | EventTypeGovernancePolicyDelete | EventTypeGovernancePolicyEditDetails | EventTypeGovernancePolicyEditDuration | EventTypeGovernancePolicyExportCreated | EventTypeGovernancePolicyExportRemoved | EventTypeGovernancePolicyRemoveFolders | EventTypeGovernancePolicyReportCreated | EventTypeGovernancePolicyZipPartDownloaded | EventTypeLegalHoldsActivateAHold | EventTypeLegalHoldsAddMembers | EventTypeLegalHoldsChangeHoldDetails | EventTypeLegalHoldsChangeHoldName | EventTypeLegalHoldsExportAHold | EventTypeLegalHoldsExportCancelled | EventTypeLegalHoldsExportDownloaded | EventTypeLegalHoldsExportRemoved | EventTypeLegalHoldsReleaseAHold | EventTypeLegalHoldsRemoveMembers | EventTypeLegalHoldsReportAHold | EventTypeDeviceChangeIpDesktop | EventTypeDeviceChangeIpMobile | EventTypeDeviceChangeIpWeb | EventTypeDeviceDeleteOnUnlinkFail | EventTypeDeviceDeleteOnUnlinkSuccess | EventTypeDeviceLinkFail | EventTypeDeviceLinkSuccess | EventTypeDeviceManagementDisabled | EventTypeDeviceManagementEnabled | EventTypeDeviceSyncBackupStatusChanged | EventTypeDeviceUnlink | EventTypeDropboxPasswordsExported | EventTypeDropboxPasswordsNewDeviceEnrolled | EventTypeEmmRefreshAuthToken | EventTypeExternalDriveBackupEligibilityStatusChecked | EventTypeExternalDriveBackupStatusChanged | EventTypeAccountCaptureChangeAvailability | EventTypeAccountCaptureMigrateAccount | EventTypeAccountCaptureNotificationEmailsSent | EventTypeAccountCaptureRelinquishAccount | EventTypeDisabledDomainInvites | EventTypeDomainInvitesApproveRequestToJoinTeam | EventTypeDomainInvitesDeclineRequestToJoinTeam | EventTypeDomainInvitesEmailExistingUsers | EventTypeDomainInvitesRequestToJoinTeam | EventTypeDomainInvitesSetInviteNewUserPrefToNo | EventTypeDomainInvitesSetInviteNewUserPrefToYes | EventTypeDomainVerificationAddDomainFail | EventTypeDomainVerificationAddDomainSuccess | EventTypeDomainVerificationRemoveDomain | EventTypeEnabledDomainInvites | EventTypeEncryptedFolderCancelTeamKeyRotation | EventTypeEncryptedFolderEnrollBackupKey | EventTypeEncryptedFolderEnrollClient | EventTypeEncryptedFolderEnrollTeam | EventTypeEncryptedFolderFinishTeamUnenrollment | EventTypeEncryptedFolderInitTeamKeyRotation | EventTypeEncryptedFolderInitTeamUnenrollment | EventTypeEncryptedFolderRemoveBackupKey | EventTypeEncryptedFolderRotateTeamKey | EventTypeEncryptedFolderUnenrollClient | EventTypeTeamEncryptionKeyActivateKey | EventTypeTeamEncryptionKeyCancelKeyDeletion | EventTypeTeamEncryptionKeyCreateKey | EventTypeTeamEncryptionKeyDeactivateKey | EventTypeTeamEncryptionKeyDeleteKey | EventTypeTeamEncryptionKeyDisableKey | EventTypeTeamEncryptionKeyEnableKey | EventTypeTeamEncryptionKeyRotateKey | EventTypeTeamEncryptionKeyScheduleKeyDeletion | EventTypeApplyNamingConvention | EventTypeCreateFolder | EventTypeFileAdd | EventTypeFileAddFromAutomation | EventTypeFileCopy | EventTypeFileDelete | EventTypeFileDownload | EventTypeFileEdit | EventTypeFileGetCopyReference | EventTypeFileLockingLockStatusChanged | EventTypeFileMove | EventTypeFilePermanentlyDelete | EventTypeFilePreview | EventTypeFileRename | EventTypeFileRestore | EventTypeFileRevert | EventTypeFileRollbackChanges | EventTypeFileSaveCopyReference | EventTypeFolderOverviewDescriptionChanged | EventTypeFolderOverviewItemPinned | EventTypeFolderOverviewItemUnpinned | EventTypeMediaHubFileDownloaded | EventTypeObjectLabelAdded | EventTypeObjectLabelRemoved | EventTypeObjectLabelUpdatedValue | EventTypeOrganizeFolderWithTidy | EventTypeReplayFileDelete | EventTypeReplayFileDownloaded | EventTypeReplayTeamProjectCreated | EventTypeRewindFolder | EventTypeUndoNamingConvention | EventTypeUndoOrganizeFolderWithTidy | EventTypeUserTagsAdded | EventTypeUserTagsRemoved | EventTypeEmailIngestReceiveFile | EventTypeFileRequestAutoClose | EventTypeFileRequestChange | EventTypeFileRequestClose | EventTypeFileRequestCreate | EventTypeFileRequestDelete | EventTypeFileRequestReceiveFile | EventTypeGroupAddExternalId | EventTypeGroupAddMember | EventTypeGroupChangeExternalId | EventTypeGroupChangeManagementType | EventTypeGroupChangeMemberRole | EventTypeGroupCreate | EventTypeGroupDelete | EventTypeGroupDescriptionUpdated | EventTypeGroupExternalSharingSettingOverrideChanged | EventTypeGroupJoinPolicyUpdated | EventTypeGroupMoved | EventTypeGroupRemoveExternalId | EventTypeGroupRemoveMember | EventTypeGroupRename | EventTypeAccountLockOrUnlocked | EventTypeEmmError | EventTypeGuestAdminSignedInViaTrustedTeams | EventTypeGuestAdminSignedOutViaTrustedTeams | EventTypeLoginFail | EventTypeLoginSuccess | EventTypeLogout | EventTypeResellerSupportSessionEnd | EventTypeResellerSupportSessionStart | EventTypeSignInAsSessionEnd | EventTypeSignInAsSessionStart | EventTypeSsoError | EventTypeAddonAssigned | EventTypeAddonRemoved | EventTypeBackupAdminInvitationSent | EventTypeBackupInvitationOpened | EventTypeCreateTeamInviteLink | EventTypeDeleteTeamInviteLink | EventTypeMemberAddExternalId | EventTypeMemberAddName | EventTypeMemberChangeAdminRole | EventTypeMemberChangeEmail | EventTypeMemberChangeExternalId | EventTypeMemberChangeMembershipType | EventTypeMemberChangeName | EventTypeMemberChangeResellerRole | EventTypeMemberChangeStatus | EventTypeMemberDeleteManualContacts | EventTypeMemberDeleteProfilePhoto | EventTypeMemberPermanentlyDeleteAccountContents | EventTypeMemberRemoveExternalId | EventTypeMemberSetProfilePhoto | EventTypeMemberSpaceLimitsAddCustomQuota | EventTypeMemberSpaceLimitsChangeCustomQuota | EventTypeMemberSpaceLimitsChangeStatus | EventTypeMemberSpaceLimitsRemoveCustomQuota | EventTypeMemberSuggest | EventTypeMemberTransferAccountContents | EventTypePendingSecondaryEmailAdded | EventTypeProductAssignedToMember | EventTypeProductRemovedFromMember | EventTypeSecondaryEmailDeleted | EventTypeSecondaryEmailVerified | EventTypeSecondaryMailsPolicyChanged | EventTypeBinderAddPage | EventTypeBinderAddSection | EventTypeBinderRemovePage | EventTypeBinderRemoveSection | EventTypeBinderRenamePage | EventTypeBinderRenameSection | EventTypeBinderReorderPage | EventTypeBinderReorderSection | EventTypePaperContentAddMember | EventTypePaperContentAddToFolder | EventTypePaperContentArchive | EventTypePaperContentCreate | EventTypePaperContentPermanentlyDelete | EventTypePaperContentRemoveFromFolder | EventTypePaperContentRemoveMember | EventTypePaperContentRename | EventTypePaperContentRestore | EventTypePaperDocAddComment | EventTypePaperDocChangeMemberRole | EventTypePaperDocChangeSharingPolicy | EventTypePaperDocChangeSubscription | EventTypePaperDocDeleted | EventTypePaperDocDeleteComment | EventTypePaperDocDownload | EventTypePaperDocEdit | EventTypePaperDocEditComment | EventTypePaperDocFollowed | EventTypePaperDocMention | EventTypePaperDocOwnershipChanged | EventTypePaperDocRequestAccess | EventTypePaperDocResolveComment | EventTypePaperDocRevert | EventTypePaperDocSlackShare | EventTypePaperDocTeamInvite | EventTypePaperDocTrashed | EventTypePaperDocUnresolveComment | EventTypePaperDocUntrashed | EventTypePaperDocView | EventTypePaperExternalViewAllow | EventTypePaperExternalViewDefaultTeam | EventTypePaperExternalViewForbid | EventTypePaperFolderChangeSubscription | EventTypePaperFolderDeleted | EventTypePaperFolderFollowed | EventTypePaperFolderTeamInvite | EventTypePaperPublishedLinkChangePermission | EventTypePaperPublishedLinkCreate | EventTypePaperPublishedLinkDisabled | EventTypePaperPublishedLinkView | EventTypePasswordChange | EventTypePasswordReset | EventTypePasswordResetAll | EventTypeProtectInternalDomainsChanged | EventTypeClassificationCreateReport | EventTypeClassificationCreateReportFail | EventTypeEmmCreateExceptionsReport | EventTypeEmmCreateUsageReport | EventTypeExportMembersReport | EventTypeExportMembersReportFail | EventTypeExternalSharingCreateReport | EventTypeExternalSharingReportFailed | EventTypeMemberAccessDetailsCreateReport | EventTypeMemberAccessDetailsCreateReportFailed | EventTypeNoExpirationLinkGenCreateReport | EventTypeNoExpirationLinkGenReportFailed | EventTypeNoPasswordLinkGenCreateReport | EventTypeNoPasswordLinkGenReportFailed | EventTypeNoPasswordLinkViewCreateReport | EventTypeNoPasswordLinkViewReportFailed | EventTypeOutdatedLinkViewCreateReport | EventTypeOutdatedLinkViewReportFailed | EventTypePaperAdminExportStart | EventTypeRansomwareAlertCreateReport | EventTypeRansomwareAlertCreateReportFailed | EventTypeSharedFoldersCreateReport | EventTypeSharedFoldersCreateReportFailed | EventTypeSmartSyncCreateAdminPrivilegeReport | EventTypeTeamActivityCreateReport | EventTypeTeamActivityCreateReportFail | EventTypeTeamFoldersCreateReport | EventTypeTeamFoldersCreateReportFailed | EventTypeTeamStorageCreateReport | EventTypeTeamStorageCreateReportFailed | EventTypeCollectionShare | EventTypeFileTransfersFileAdd | EventTypeFileTransfersTransferDelete | EventTypeFileTransfersTransferDownload | EventTypeFileTransfersTransferSend | EventTypeFileTransfersTransferView | EventTypeMediaHubProjectTeamAdd | EventTypeMediaHubProjectTeamDelete | EventTypeMediaHubProjectTeamRoleChanged | EventTypeMediaHubSharedLinkAudienceChanged | EventTypeMediaHubSharedLinkCreated | EventTypeMediaHubSharedLinkDownloadSettingChanged | EventTypeMediaHubSharedLinkRevoked | EventTypeNoteAclInviteOnly | EventTypeNoteAclLink | EventTypeNoteAclTeamLink | EventTypeNoteShared | EventTypeNoteShareReceive | EventTypeOpenNoteShared | EventTypeReplayFileSharedLinkCreated | EventTypeReplayFileSharedLinkModified | EventTypeReplayProjectTeamAdd | EventTypeReplayProjectTeamDelete | EventTypeSendAndTrackFileAdded | EventTypeSendAndTrackFileRenamed | EventTypeSendAndTrackFileUpdated | EventTypeSendAndTrackLinkCreated | EventTypeSendAndTrackLinkDeleted | EventTypeSendAndTrackLinkUpdated | EventTypeSendAndTrackLinkViewed | EventTypeSendAndTrackRemovedFileAndAssociatedLinks | EventTypeSfAddGroup | EventTypeSfAllowNonMembersToViewSharedLinks | EventTypeSfExternalInviteWarn | EventTypeSfFbInvite | EventTypeSfFbInviteChangeRole | EventTypeSfFbUninvite | EventTypeSfInviteGroup | EventTypeSfTeamGrantAccess | EventTypeSfTeamInvite | EventTypeSfTeamInviteChangeRole | EventTypeSfTeamJoin | EventTypeSfTeamJoinFromOobLink | EventTypeSfTeamUninvite | EventTypeSharedContentAddInvitees | EventTypeSharedContentAddLinkExpiry | EventTypeSharedContentAddLinkPassword | EventTypeSharedContentAddMember | EventTypeSharedContentChangeDownloadsPolicy | EventTypeSharedContentChangeInviteeRole | EventTypeSharedContentChangeLinkAudience | EventTypeSharedContentChangeLinkExpiry | EventTypeSharedContentChangeLinkPassword | EventTypeSharedContentChangeMemberRole | EventTypeSharedContentChangeViewerInfoPolicy | EventTypeSharedContentClaimInvitation | EventTypeSharedContentCopy | EventTypeSharedContentDownload | EventTypeSharedContentRelinquishMembership | EventTypeSharedContentRemoveInvitees | EventTypeSharedContentRemoveLinkExpiry | EventTypeSharedContentRemoveLinkPassword | EventTypeSharedContentRemoveMember | EventTypeSharedContentRequestAccess | EventTypeSharedContentRestoreInvitees | EventTypeSharedContentRestoreMember | EventTypeSharedContentUnshare | EventTypeSharedContentView | EventTypeSharedFolderChangeLinkPolicy | EventTypeSharedFolderChangeMembersInheritancePolicy | EventTypeSharedFolderChangeMembersManagementPolicy | EventTypeSharedFolderChangeMembersPolicy | EventTypeSharedFolderCreate | EventTypeSharedFolderDeclineInvitation | EventTypeSharedFolderMount | EventTypeSharedFolderNest | EventTypeSharedFolderTransferOwnership | EventTypeSharedFolderUnmount | EventTypeSharedLinkAddExpiry | EventTypeSharedLinkChangeExpiry | EventTypeSharedLinkChangeVisibility | EventTypeSharedLinkCopy | EventTypeSharedLinkCreate | EventTypeSharedLinkDisable | EventTypeSharedLinkDownload | EventTypeSharedLinkRemoveExpiry | EventTypeSharedLinkRemoveVisitor | EventTypeSharedLinkSettingsAddExpiration | EventTypeSharedLinkSettingsAddPassword | EventTypeSharedLinkSettingsAllowDownloadDisabled | EventTypeSharedLinkSettingsAllowDownloadEnabled | EventTypeSharedLinkSettingsChangeAudience | EventTypeSharedLinkSettingsChangeExpiration | EventTypeSharedLinkSettingsChangePassword | EventTypeSharedLinkSettingsRemoveExpiration | EventTypeSharedLinkSettingsRemovePassword | EventTypeSharedLinkShare | EventTypeSharedLinkView | EventTypeSharedNoteOpened | EventTypeShmodelDisableDownloads | EventTypeShmodelEnableDownloads | EventTypeShmodelGroupShare | EventTypeShowcaseAccessGranted | EventTypeShowcaseAddMember | EventTypeShowcaseArchived | EventTypeShowcaseCreated | EventTypeShowcaseDeleteComment | EventTypeShowcaseEdited | EventTypeShowcaseEditComment | EventTypeShowcaseFileAdded | EventTypeShowcaseFileDownload | EventTypeShowcaseFileRemoved | EventTypeShowcaseFileView | EventTypeShowcasePermanentlyDeleted | EventTypeShowcasePostComment | EventTypeShowcaseRemoveMember | EventTypeShowcaseRenamed | EventTypeShowcaseRequestAccess | EventTypeShowcaseResolveComment | EventTypeShowcaseRestored | EventTypeShowcaseTrashed | EventTypeShowcaseTrashedDeprecated | EventTypeShowcaseUnresolveComment | EventTypeShowcaseUntrashed | EventTypeShowcaseUntrashedDeprecated | EventTypeShowcaseView | EventTypeSignSignatureRequestCanceled | EventTypeSignSignatureRequestCompleted | EventTypeSignSignatureRequestDeclined | EventTypeSignSignatureRequestOpened | EventTypeSignSignatureRequestReminderSent | EventTypeSignSignatureRequestSent | EventTypeSignTemplateCreated | EventTypeSignTemplateShared | EventTypeRiscSecurityEvent | EventTypeSsoAddCert | EventTypeSsoAddLoginUrl | EventTypeSsoAddLogoutUrl | EventTypeSsoChangeCert | EventTypeSsoChangeLoginUrl | EventTypeSsoChangeLogoutUrl | EventTypeSsoChangeSamlIdentityMode | EventTypeSsoRemoveCert | EventTypeSsoRemoveLoginUrl | EventTypeSsoRemoveLogoutUrl | EventTypeTeamFolderChangeStatus | EventTypeTeamFolderCreate | EventTypeTeamFolderDowngrade | EventTypeTeamFolderPermanentlyDelete | EventTypeTeamFolderRename | EventTypeTeamFolderSpaceLimitsChangeCapsType | EventTypeTeamFolderSpaceLimitsChangeLimit | EventTypeTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeTeamSelectiveSyncSettingsChanged | EventTypeAccountCaptureChangePolicy | EventTypeAdminEmailRemindersChanged | EventTypeAiThirdPartySharingDropboxBasePolicyChanged | EventTypeAllowDownloadDisabled | EventTypeAllowDownloadEnabled | EventTypeAppleLoginChangePolicy | EventTypeAppPermissionsChanged | EventTypeCameraUploadsPolicyChanged | EventTypeCaptureTeamSpacePolicyChanged | EventTypeCaptureTranscriptPolicyChanged | EventTypeClassificationChangePolicy | EventTypeComputerBackupPolicyChanged | EventTypeContentAdministrationPolicyChanged | EventTypeContentDeletionProtectionChangePolicy | EventTypeDashExternalSharingPolicyChanged | EventTypeDataPlacementRestrictionChangePolicy | EventTypeDataPlacementRestrictionSatisfyPolicy | EventTypeDeviceApprovalsAddException | EventTypeDeviceApprovalsChangeDesktopPolicy | EventTypeDeviceApprovalsChangeMobilePolicy | EventTypeDeviceApprovalsChangeOverageAction | EventTypeDeviceApprovalsChangeUnlinkAction | EventTypeDeviceApprovalsRemoveException | EventTypeDirectoryRestrictionsAddMembers | EventTypeDirectoryRestrictionsRemoveMembers | EventTypeDropboxPasswordsPolicyChanged | EventTypeEmailIngestPolicyChanged | EventTypeEmmAddException | EventTypeEmmChangePolicy | EventTypeEmmRemoveException | EventTypeExtendedVersionHistoryChangePolicy | EventTypeExternalDriveBackupPolicyChanged | EventTypeFileCommentsChangePolicy | EventTypeFileLockingPolicyChanged | EventTypeFileProviderMigrationPolicyChanged | EventTypeFileRequestsChangePolicy | EventTypeFileRequestsEmailsEnabled | EventTypeFileRequestsEmailsRestrictedToTeamOnly | EventTypeFileTransfersPolicyChanged | EventTypeFlexibleFileNamesPolicyChanged | EventTypeFolderLinkRestrictionPolicyChanged | EventTypeGoogleSsoChangePolicy | EventTypeGroupUserManagementChangePolicy | EventTypeIntegrationPolicyChanged | EventTypeInviteAcceptanceEmailPolicyChanged | EventTypeMediaHubAddingPeoplePolicyChanged | EventTypeMediaHubDownloadPolicyChanged | EventTypeMediaHubLinkSharingPolicyChanged | EventTypeMemberRequestsChangePolicy | EventTypeMemberSendInvitePolicyChanged | EventTypeMemberSpaceLimitsAddException | EventTypeMemberSpaceLimitsChangeCapsTypePolicy | EventTypeMemberSpaceLimitsChangePolicy | EventTypeMemberSpaceLimitsRemoveException | EventTypeMemberSuggestionsChangePolicy | EventTypeMicrosoftLoginChangePolicy | EventTypeMicrosoftOfficeAddinChangePolicy | EventTypeMultiTeamIdentityPolicyChanged | EventTypeNetworkControlChangePolicy | EventTypePaperChangeDeploymentPolicy | EventTypePaperChangeMemberLinkPolicy | EventTypePaperChangeMemberPolicy | EventTypePaperChangePolicy | EventTypePaperDefaultFolderPolicyChanged | EventTypePaperDesktopPolicyChanged | EventTypePaperEnabledUsersGroupAddition | EventTypePaperEnabledUsersGroupRemoval | EventTypePasskeyLoginPolicyChanged | EventTypePasswordStrengthRequirementsChangePolicy | EventTypePermanentDeleteChangePolicy | EventTypePreviewsAiPolicyChanged | EventTypeReplayAddingPeoplePolicyChanged | EventTypeReplaySharingPolicyChanged | EventTypeResellerSupportChangePolicy | EventTypeRewindPolicyChanged | EventTypeSendAndTrackPolicyChanged | EventTypeSendExternalSharingPolicyChanged | EventTypeSendForSignaturePolicyChanged | EventTypeSharedLinkDefaultPermissionsPolicyChanged | EventTypeSharingChangeFolderJoinPolicy | EventTypeSharingChangeLinkAllowChangeExpirationPolicy | EventTypeSharingChangeLinkDefaultExpirationPolicy | EventTypeSharingChangeLinkEnforcePasswordPolicy | EventTypeSharingChangeLinkPolicy | EventTypeSharingChangeMemberPolicy | EventTypeShowcaseChangeDownloadPolicy | EventTypeShowcaseChangeEnabledPolicy | EventTypeShowcaseChangeExternalSharingPolicy | EventTypeSignExternalSharingPolicyChanged | EventTypeSignTemplateCreationPermissionChanged | EventTypeSmarterSmartSyncPolicyChanged | EventTypeSmartSyncChangePolicy | EventTypeSmartSyncNotOptOut | EventTypeSmartSyncOptOut | EventTypeSsoChangePolicy | EventTypeStackCrossTeamAccessPolicyChanged | EventTypeTeamBrandingPolicyChanged | EventTypeTeamExtensionsPolicyChanged | EventTypeTeamMemberStorageRequestPolicyChanged | EventTypeTeamSelectiveSyncPolicyChanged | EventTypeTeamSharingWhitelistSubjectsChanged | EventTypeTfaAddException | EventTypeTfaChangePolicy | EventTypeTfaRemoveException | EventTypeTopLevelContentPolicyChanged | EventTypeTwoAccountChangePolicy | EventTypeViewerInfoPolicyChanged | EventTypeWatermarkingPolicyChanged | EventTypeWebSessionsChangeActiveSessionLimit | EventTypeWebSessionsChangeFixedLengthPolicy | EventTypeWebSessionsChangeIdleLengthPolicy | EventTypeDataResidencyMigrationRequestSuccessful | EventTypeDataResidencyMigrationRequestUnsuccessful | EventTypeTeamMergeFrom | EventTypeTeamMergeTo | EventTypeTeamProfileAddBackground | EventTypeTeamProfileAddLogo | EventTypeTeamProfileChangeBackground | EventTypeTeamProfileChangeDefaultLanguage | EventTypeTeamProfileChangeLogo | EventTypeTeamProfileChangeName | EventTypeTeamProfileRemoveBackground | EventTypeTeamProfileRemoveLogo | EventTypePasskeyAdd | EventTypePasskeyRemove | EventTypeTfaAddBackupPhone | EventTypeTfaAddSecurityKey | EventTypeTfaChangeBackupPhone | EventTypeTfaChangeStatus | EventTypeTfaRemoveBackupPhone | EventTypeTfaRemoveSecurityKey | EventTypeTfaReset | EventTypeChangedEnterpriseAdminRole | EventTypeChangedEnterpriseConnectedTeamStatus | EventTypeEndedEnterpriseAdminSession | EventTypeEndedEnterpriseAdminSessionDeprecated | EventTypeEnterpriseSettingsLocking | EventTypeGuestAdminChangeStatus | EventTypeStartedEnterpriseAdminSession | EventTypeTeamMergeRequestAccepted | EventTypeTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeTeamMergeRequestAutoCanceled | EventTypeTeamMergeRequestCanceled | EventTypeTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeTeamMergeRequestExpired | EventTypeTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeTeamMergeRequestReminder | EventTypeTeamMergeRequestReminderShownToPrimaryTeam | EventTypeTeamMergeRequestReminderShownToSecondaryTeam | EventTypeTeamMergeRequestRevoked | EventTypeTeamMergeRequestSentShownToPrimaryTeam | EventTypeTeamMergeRequestSentShownToSecondaryTeam | EventTypeOther;
 
     /**
      * (admin_alerting) Changed an alert state
@@ -30030,7 +29667,7 @@
     }
 
     /**
-     * (file_operations) Downloaded files in Replay
+     * (file_operations) Downloaded files in Media Hub
      */
     export interface EventTypeArgMediaHubFileDownloaded {
       '.tag': 'media_hub_file_downloaded';
@@ -30471,13 +30108,6 @@
      */
     export interface EventTypeArgMemberDeleteProfilePhoto {
       '.tag': 'member_delete_profile_photo';
-    }
-
-    /**
-     * (members) Admin browsed a team member's folder contents
-     */
-    export interface EventTypeArgMemberFolderContentsAccessed {
-      '.tag': 'member_folder_contents_accessed';
     }
 
     /**
@@ -30958,87 +30588,10 @@
     }
 
     /**
-     * (protect) Added collaborators via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionAddCollaborator {
-      '.tag': 'protect_action_add_collaborator';
-    }
-
-    /**
-     * (protect) Added a link via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionAddLink {
-      '.tag': 'protect_action_add_link';
-    }
-
-    /**
-     * (protect) Deleted content via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionDelete {
-      '.tag': 'protect_action_delete';
-    }
-
-    /**
-     * (protect) Exported content via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionExport {
-      '.tag': 'protect_action_export';
-    }
-
-    /**
-     * (protect) Removed collaborators via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionRemoveCollaborator {
-      '.tag': 'protect_action_remove_collaborator';
-    }
-
-    /**
-     * (protect) Removed a link via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionRemoveLink {
-      '.tag': 'protect_action_remove_link';
-    }
-
-    /**
-     * (protect) Stopped sharing content via Dropbox Protect
-     */
-    export interface EventTypeArgProtectActionStopSharing {
-      '.tag': 'protect_action_stop_sharing';
-    }
-
-    /**
      * (protect) Modified Protect internal domains list
      */
     export interface EventTypeArgProtectInternalDomainsChanged {
       '.tag': 'protect_internal_domains_changed';
-    }
-
-    /**
-     * (protect) Activated a Dropbox Protect policy
-     */
-    export interface EventTypeArgProtectPolicyActivated {
-      '.tag': 'protect_policy_activated';
-    }
-
-    /**
-     * (protect) Deactivated a Dropbox Protect policy
-     */
-    export interface EventTypeArgProtectPolicyDeactivated {
-      '.tag': 'protect_policy_deactivated';
-    }
-
-    /**
-     * (protect) Scheduled a Dropbox Protect policy
-     */
-    export interface EventTypeArgProtectPolicyScheduled {
-      '.tag': 'protect_policy_scheduled';
-    }
-
-    /**
-     * (protect) Updated a Dropbox Protect policy
-     */
-    export interface EventTypeArgProtectPolicyUpdated {
-      '.tag': 'protect_policy_updated';
     }
 
     /**
@@ -31294,49 +30847,49 @@
     }
 
     /**
-     * (sharing) Added member to Replay project
+     * (sharing) Added member to Media Hub project
      */
     export interface EventTypeArgMediaHubProjectTeamAdd {
       '.tag': 'media_hub_project_team_add';
     }
 
     /**
-     * (sharing) Removed member from Replay project
+     * (sharing) Removed member from Media Hub project
      */
     export interface EventTypeArgMediaHubProjectTeamDelete {
       '.tag': 'media_hub_project_team_delete';
     }
 
     /**
-     * (sharing) Changed member role in Replay project
+     * (sharing) Changed member role in Media Hub project
      */
     export interface EventTypeArgMediaHubProjectTeamRoleChanged {
       '.tag': 'media_hub_project_team_role_changed';
     }
 
     /**
-     * (sharing) Changed Replay shared link audience
+     * (sharing) Changed Media Hub shared link audience
      */
     export interface EventTypeArgMediaHubSharedLinkAudienceChanged {
       '.tag': 'media_hub_shared_link_audience_changed';
     }
 
     /**
-     * (sharing) Created Replay shared link
+     * (sharing) Created Media Hub shared link
      */
     export interface EventTypeArgMediaHubSharedLinkCreated {
       '.tag': 'media_hub_shared_link_created';
     }
 
     /**
-     * (sharing) Changed Replay shared link download setting
+     * (sharing) Changed Media Hub shared link download setting
      */
     export interface EventTypeArgMediaHubSharedLinkDownloadSettingChanged {
       '.tag': 'media_hub_shared_link_download_setting_changed';
     }
 
     /**
-     * (sharing) Revoked Replay shared link
+     * (sharing) Revoked Media Hub shared link
      */
     export interface EventTypeArgMediaHubSharedLinkRevoked {
       '.tag': 'media_hub_shared_link_revoked';
@@ -32681,21 +32234,21 @@
     }
 
     /**
-     * (team_policies) Changed the policy for adding people to Replay content
+     * (team_policies) Changed the policy for adding people to Media Hub content
      */
     export interface EventTypeArgMediaHubAddingPeoplePolicyChanged {
       '.tag': 'media_hub_adding_people_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for downloading Replay content
+     * (team_policies) Changed the policy for downloading Media Hub content
      */
     export interface EventTypeArgMediaHubDownloadPolicyChanged {
       '.tag': 'media_hub_download_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for sharing Replay content
+     * (team_policies) Changed the policy for sharing Media Hub content
      */
     export interface EventTypeArgMediaHubLinkSharingPolicyChanged {
       '.tag': 'media_hub_link_sharing_policy_changed';
@@ -33501,7 +33054,7 @@
     /**
      * The type of the event.
      */
-    export type EventTypeArg = EventTypeArgAdminAlertingAlertStateChanged | EventTypeArgAdminAlertingChangedAlertConfig | EventTypeArgAdminAlertingTriggeredAlert | EventTypeArgRansomwareRestoreProcessCompleted | EventTypeArgRansomwareRestoreProcessStarted | EventTypeArgAppBlockedByPermissions | EventTypeArgAppLinkTeam | EventTypeArgAppLinkUser | EventTypeArgAppUnlinkTeam | EventTypeArgAppUnlinkUser | EventTypeArgIntegrationConnected | EventTypeArgIntegrationDisconnected | EventTypeArgFileAddComment | EventTypeArgFileChangeCommentSubscription | EventTypeArgFileDeleteComment | EventTypeArgFileEditComment | EventTypeArgFileLikeComment | EventTypeArgFileResolveComment | EventTypeArgFileUnlikeComment | EventTypeArgFileUnresolveComment | EventTypeArgDashAddedCommentToStack | EventTypeArgDashAddedConnector | EventTypeArgDashAddedLinkToStack | EventTypeArgDashAddedTeamEmailDomainAllowlist | EventTypeArgDashAdminAddedOrgWideConnector | EventTypeArgDashAdminDisabledConnector | EventTypeArgDashAdminEnabledConnector | EventTypeArgDashAdminRemovedOrgWideConnector | EventTypeArgDashArchivedStack | EventTypeArgDashChangedAudienceOfSharedLinkToStack | EventTypeArgDashClonedStack | EventTypeArgDashConnectorToolsCall | EventTypeArgDashCreatedStack | EventTypeArgDashDeletedCommentFromStack | EventTypeArgDashDeletedStack | EventTypeArgDashEditedCommentInStack | EventTypeArgDashExternalUserOpenedStack | EventTypeArgDashFirstLaunchedDesktop | EventTypeArgDashFirstLaunchedExtension | EventTypeArgDashFirstLaunchedWebStartPage | EventTypeArgDashOpenedSharedLinkToStack | EventTypeArgDashOpenedStack | EventTypeArgDashPreviewOptOutStatusChanged | EventTypeArgDashRemovedConnector | EventTypeArgDashRemovedLinkFromStack | EventTypeArgDashRemovedSharedLinkToStack | EventTypeArgDashRemovedTeamEmailDomainAllowlist | EventTypeArgDashRenamedStack | EventTypeArgDashSharedLinkToStack | EventTypeArgDashUnarchivedStack | EventTypeArgDashViewedCompanyStack | EventTypeArgDashViewedExternalAiActivityReport | EventTypeArgGovernancePolicyAddFolders | EventTypeArgGovernancePolicyAddFolderFailed | EventTypeArgGovernancePolicyContentDisposed | EventTypeArgGovernancePolicyCreate | EventTypeArgGovernancePolicyDelete | EventTypeArgGovernancePolicyEditDetails | EventTypeArgGovernancePolicyEditDuration | EventTypeArgGovernancePolicyExportCreated | EventTypeArgGovernancePolicyExportRemoved | EventTypeArgGovernancePolicyRemoveFolders | EventTypeArgGovernancePolicyReportCreated | EventTypeArgGovernancePolicyZipPartDownloaded | EventTypeArgLegalHoldsActivateAHold | EventTypeArgLegalHoldsAddMembers | EventTypeArgLegalHoldsChangeHoldDetails | EventTypeArgLegalHoldsChangeHoldName | EventTypeArgLegalHoldsExportAHold | EventTypeArgLegalHoldsExportCancelled | EventTypeArgLegalHoldsExportDownloaded | EventTypeArgLegalHoldsExportRemoved | EventTypeArgLegalHoldsReleaseAHold | EventTypeArgLegalHoldsRemoveMembers | EventTypeArgLegalHoldsReportAHold | EventTypeArgDeviceChangeIpDesktop | EventTypeArgDeviceChangeIpMobile | EventTypeArgDeviceChangeIpWeb | EventTypeArgDeviceDeleteOnUnlinkFail | EventTypeArgDeviceDeleteOnUnlinkSuccess | EventTypeArgDeviceLinkFail | EventTypeArgDeviceLinkSuccess | EventTypeArgDeviceManagementDisabled | EventTypeArgDeviceManagementEnabled | EventTypeArgDeviceSyncBackupStatusChanged | EventTypeArgDeviceUnlink | EventTypeArgDropboxPasswordsExported | EventTypeArgDropboxPasswordsNewDeviceEnrolled | EventTypeArgEmmRefreshAuthToken | EventTypeArgExternalDriveBackupEligibilityStatusChecked | EventTypeArgExternalDriveBackupStatusChanged | EventTypeArgAccountCaptureChangeAvailability | EventTypeArgAccountCaptureMigrateAccount | EventTypeArgAccountCaptureNotificationEmailsSent | EventTypeArgAccountCaptureRelinquishAccount | EventTypeArgDisabledDomainInvites | EventTypeArgDomainInvitesApproveRequestToJoinTeam | EventTypeArgDomainInvitesDeclineRequestToJoinTeam | EventTypeArgDomainInvitesEmailExistingUsers | EventTypeArgDomainInvitesRequestToJoinTeam | EventTypeArgDomainInvitesSetInviteNewUserPrefToNo | EventTypeArgDomainInvitesSetInviteNewUserPrefToYes | EventTypeArgDomainVerificationAddDomainFail | EventTypeArgDomainVerificationAddDomainSuccess | EventTypeArgDomainVerificationRemoveDomain | EventTypeArgEnabledDomainInvites | EventTypeArgEncryptedFolderCancelTeamKeyRotation | EventTypeArgEncryptedFolderEnrollBackupKey | EventTypeArgEncryptedFolderEnrollClient | EventTypeArgEncryptedFolderEnrollTeam | EventTypeArgEncryptedFolderFinishTeamUnenrollment | EventTypeArgEncryptedFolderInitTeamKeyRotation | EventTypeArgEncryptedFolderInitTeamUnenrollment | EventTypeArgEncryptedFolderRemoveBackupKey | EventTypeArgEncryptedFolderRotateTeamKey | EventTypeArgEncryptedFolderUnenrollClient | EventTypeArgTeamEncryptionKeyActivateKey | EventTypeArgTeamEncryptionKeyCancelKeyDeletion | EventTypeArgTeamEncryptionKeyCreateKey | EventTypeArgTeamEncryptionKeyDeactivateKey | EventTypeArgTeamEncryptionKeyDeleteKey | EventTypeArgTeamEncryptionKeyDisableKey | EventTypeArgTeamEncryptionKeyEnableKey | EventTypeArgTeamEncryptionKeyRotateKey | EventTypeArgTeamEncryptionKeyScheduleKeyDeletion | EventTypeArgApplyNamingConvention | EventTypeArgCreateFolder | EventTypeArgFileAdd | EventTypeArgFileAddFromAutomation | EventTypeArgFileCopy | EventTypeArgFileDelete | EventTypeArgFileDownload | EventTypeArgFileEdit | EventTypeArgFileGetCopyReference | EventTypeArgFileLockingLockStatusChanged | EventTypeArgFileMove | EventTypeArgFilePermanentlyDelete | EventTypeArgFilePreview | EventTypeArgFileRename | EventTypeArgFileRestore | EventTypeArgFileRevert | EventTypeArgFileRollbackChanges | EventTypeArgFileSaveCopyReference | EventTypeArgFolderOverviewDescriptionChanged | EventTypeArgFolderOverviewItemPinned | EventTypeArgFolderOverviewItemUnpinned | EventTypeArgMediaHubFileDownloaded | EventTypeArgObjectLabelAdded | EventTypeArgObjectLabelRemoved | EventTypeArgObjectLabelUpdatedValue | EventTypeArgOrganizeFolderWithTidy | EventTypeArgReplayFileDelete | EventTypeArgReplayFileDownloaded | EventTypeArgReplayTeamProjectCreated | EventTypeArgRewindFolder | EventTypeArgUndoNamingConvention | EventTypeArgUndoOrganizeFolderWithTidy | EventTypeArgUserTagsAdded | EventTypeArgUserTagsRemoved | EventTypeArgEmailIngestReceiveFile | EventTypeArgFileRequestAutoClose | EventTypeArgFileRequestChange | EventTypeArgFileRequestClose | EventTypeArgFileRequestCreate | EventTypeArgFileRequestDelete | EventTypeArgFileRequestReceiveFile | EventTypeArgGroupAddExternalId | EventTypeArgGroupAddMember | EventTypeArgGroupChangeExternalId | EventTypeArgGroupChangeManagementType | EventTypeArgGroupChangeMemberRole | EventTypeArgGroupCreate | EventTypeArgGroupDelete | EventTypeArgGroupDescriptionUpdated | EventTypeArgGroupExternalSharingSettingOverrideChanged | EventTypeArgGroupJoinPolicyUpdated | EventTypeArgGroupMoved | EventTypeArgGroupRemoveExternalId | EventTypeArgGroupRemoveMember | EventTypeArgGroupRename | EventTypeArgAccountLockOrUnlocked | EventTypeArgEmmError | EventTypeArgGuestAdminSignedInViaTrustedTeams | EventTypeArgGuestAdminSignedOutViaTrustedTeams | EventTypeArgLoginFail | EventTypeArgLoginSuccess | EventTypeArgLogout | EventTypeArgResellerSupportSessionEnd | EventTypeArgResellerSupportSessionStart | EventTypeArgSignInAsSessionEnd | EventTypeArgSignInAsSessionStart | EventTypeArgSsoError | EventTypeArgAddonAssigned | EventTypeArgAddonRemoved | EventTypeArgBackupAdminInvitationSent | EventTypeArgBackupInvitationOpened | EventTypeArgCreateTeamInviteLink | EventTypeArgDeleteTeamInviteLink | EventTypeArgMemberAddExternalId | EventTypeArgMemberAddName | EventTypeArgMemberChangeAdminRole | EventTypeArgMemberChangeEmail | EventTypeArgMemberChangeExternalId | EventTypeArgMemberChangeMembershipType | EventTypeArgMemberChangeName | EventTypeArgMemberChangeResellerRole | EventTypeArgMemberChangeStatus | EventTypeArgMemberDeleteManualContacts | EventTypeArgMemberDeleteProfilePhoto | EventTypeArgMemberFolderContentsAccessed | EventTypeArgMemberPermanentlyDeleteAccountContents | EventTypeArgMemberRemoveExternalId | EventTypeArgMemberSetProfilePhoto | EventTypeArgMemberSpaceLimitsAddCustomQuota | EventTypeArgMemberSpaceLimitsChangeCustomQuota | EventTypeArgMemberSpaceLimitsChangeStatus | EventTypeArgMemberSpaceLimitsRemoveCustomQuota | EventTypeArgMemberSuggest | EventTypeArgMemberTransferAccountContents | EventTypeArgPendingSecondaryEmailAdded | EventTypeArgProductAssignedToMember | EventTypeArgProductRemovedFromMember | EventTypeArgSecondaryEmailDeleted | EventTypeArgSecondaryEmailVerified | EventTypeArgSecondaryMailsPolicyChanged | EventTypeArgBinderAddPage | EventTypeArgBinderAddSection | EventTypeArgBinderRemovePage | EventTypeArgBinderRemoveSection | EventTypeArgBinderRenamePage | EventTypeArgBinderRenameSection | EventTypeArgBinderReorderPage | EventTypeArgBinderReorderSection | EventTypeArgPaperContentAddMember | EventTypeArgPaperContentAddToFolder | EventTypeArgPaperContentArchive | EventTypeArgPaperContentCreate | EventTypeArgPaperContentPermanentlyDelete | EventTypeArgPaperContentRemoveFromFolder | EventTypeArgPaperContentRemoveMember | EventTypeArgPaperContentRename | EventTypeArgPaperContentRestore | EventTypeArgPaperDocAddComment | EventTypeArgPaperDocChangeMemberRole | EventTypeArgPaperDocChangeSharingPolicy | EventTypeArgPaperDocChangeSubscription | EventTypeArgPaperDocDeleted | EventTypeArgPaperDocDeleteComment | EventTypeArgPaperDocDownload | EventTypeArgPaperDocEdit | EventTypeArgPaperDocEditComment | EventTypeArgPaperDocFollowed | EventTypeArgPaperDocMention | EventTypeArgPaperDocOwnershipChanged | EventTypeArgPaperDocRequestAccess | EventTypeArgPaperDocResolveComment | EventTypeArgPaperDocRevert | EventTypeArgPaperDocSlackShare | EventTypeArgPaperDocTeamInvite | EventTypeArgPaperDocTrashed | EventTypeArgPaperDocUnresolveComment | EventTypeArgPaperDocUntrashed | EventTypeArgPaperDocView | EventTypeArgPaperExternalViewAllow | EventTypeArgPaperExternalViewDefaultTeam | EventTypeArgPaperExternalViewForbid | EventTypeArgPaperFolderChangeSubscription | EventTypeArgPaperFolderDeleted | EventTypeArgPaperFolderFollowed | EventTypeArgPaperFolderTeamInvite | EventTypeArgPaperPublishedLinkChangePermission | EventTypeArgPaperPublishedLinkCreate | EventTypeArgPaperPublishedLinkDisabled | EventTypeArgPaperPublishedLinkView | EventTypeArgPasswordChange | EventTypeArgPasswordReset | EventTypeArgPasswordResetAll | EventTypeArgProtectActionAddCollaborator | EventTypeArgProtectActionAddLink | EventTypeArgProtectActionDelete | EventTypeArgProtectActionExport | EventTypeArgProtectActionRemoveCollaborator | EventTypeArgProtectActionRemoveLink | EventTypeArgProtectActionStopSharing | EventTypeArgProtectInternalDomainsChanged | EventTypeArgProtectPolicyActivated | EventTypeArgProtectPolicyDeactivated | EventTypeArgProtectPolicyScheduled | EventTypeArgProtectPolicyUpdated | EventTypeArgClassificationCreateReport | EventTypeArgClassificationCreateReportFail | EventTypeArgEmmCreateExceptionsReport | EventTypeArgEmmCreateUsageReport | EventTypeArgExportMembersReport | EventTypeArgExportMembersReportFail | EventTypeArgExternalSharingCreateReport | EventTypeArgExternalSharingReportFailed | EventTypeArgMemberAccessDetailsCreateReport | EventTypeArgMemberAccessDetailsCreateReportFailed | EventTypeArgNoExpirationLinkGenCreateReport | EventTypeArgNoExpirationLinkGenReportFailed | EventTypeArgNoPasswordLinkGenCreateReport | EventTypeArgNoPasswordLinkGenReportFailed | EventTypeArgNoPasswordLinkViewCreateReport | EventTypeArgNoPasswordLinkViewReportFailed | EventTypeArgOutdatedLinkViewCreateReport | EventTypeArgOutdatedLinkViewReportFailed | EventTypeArgPaperAdminExportStart | EventTypeArgRansomwareAlertCreateReport | EventTypeArgRansomwareAlertCreateReportFailed | EventTypeArgSharedFoldersCreateReport | EventTypeArgSharedFoldersCreateReportFailed | EventTypeArgSmartSyncCreateAdminPrivilegeReport | EventTypeArgTeamActivityCreateReport | EventTypeArgTeamActivityCreateReportFail | EventTypeArgTeamFoldersCreateReport | EventTypeArgTeamFoldersCreateReportFailed | EventTypeArgTeamStorageCreateReport | EventTypeArgTeamStorageCreateReportFailed | EventTypeArgCollectionShare | EventTypeArgFileTransfersFileAdd | EventTypeArgFileTransfersTransferDelete | EventTypeArgFileTransfersTransferDownload | EventTypeArgFileTransfersTransferSend | EventTypeArgFileTransfersTransferView | EventTypeArgMediaHubProjectTeamAdd | EventTypeArgMediaHubProjectTeamDelete | EventTypeArgMediaHubProjectTeamRoleChanged | EventTypeArgMediaHubSharedLinkAudienceChanged | EventTypeArgMediaHubSharedLinkCreated | EventTypeArgMediaHubSharedLinkDownloadSettingChanged | EventTypeArgMediaHubSharedLinkRevoked | EventTypeArgNoteAclInviteOnly | EventTypeArgNoteAclLink | EventTypeArgNoteAclTeamLink | EventTypeArgNoteShared | EventTypeArgNoteShareReceive | EventTypeArgOpenNoteShared | EventTypeArgReplayFileSharedLinkCreated | EventTypeArgReplayFileSharedLinkModified | EventTypeArgReplayProjectTeamAdd | EventTypeArgReplayProjectTeamDelete | EventTypeArgSendAndTrackFileAdded | EventTypeArgSendAndTrackFileRenamed | EventTypeArgSendAndTrackFileUpdated | EventTypeArgSendAndTrackLinkCreated | EventTypeArgSendAndTrackLinkDeleted | EventTypeArgSendAndTrackLinkUpdated | EventTypeArgSendAndTrackLinkViewed | EventTypeArgSendAndTrackRemovedFileAndAssociatedLinks | EventTypeArgSfAddGroup | EventTypeArgSfAllowNonMembersToViewSharedLinks | EventTypeArgSfExternalInviteWarn | EventTypeArgSfFbInvite | EventTypeArgSfFbInviteChangeRole | EventTypeArgSfFbUninvite | EventTypeArgSfInviteGroup | EventTypeArgSfTeamGrantAccess | EventTypeArgSfTeamInvite | EventTypeArgSfTeamInviteChangeRole | EventTypeArgSfTeamJoin | EventTypeArgSfTeamJoinFromOobLink | EventTypeArgSfTeamUninvite | EventTypeArgSharedContentAddInvitees | EventTypeArgSharedContentAddLinkExpiry | EventTypeArgSharedContentAddLinkPassword | EventTypeArgSharedContentAddMember | EventTypeArgSharedContentChangeDownloadsPolicy | EventTypeArgSharedContentChangeInviteeRole | EventTypeArgSharedContentChangeLinkAudience | EventTypeArgSharedContentChangeLinkExpiry | EventTypeArgSharedContentChangeLinkPassword | EventTypeArgSharedContentChangeMemberRole | EventTypeArgSharedContentChangeViewerInfoPolicy | EventTypeArgSharedContentClaimInvitation | EventTypeArgSharedContentCopy | EventTypeArgSharedContentDownload | EventTypeArgSharedContentRelinquishMembership | EventTypeArgSharedContentRemoveInvitees | EventTypeArgSharedContentRemoveLinkExpiry | EventTypeArgSharedContentRemoveLinkPassword | EventTypeArgSharedContentRemoveMember | EventTypeArgSharedContentRequestAccess | EventTypeArgSharedContentRestoreInvitees | EventTypeArgSharedContentRestoreMember | EventTypeArgSharedContentUnshare | EventTypeArgSharedContentView | EventTypeArgSharedFolderChangeLinkPolicy | EventTypeArgSharedFolderChangeMembersInheritancePolicy | EventTypeArgSharedFolderChangeMembersManagementPolicy | EventTypeArgSharedFolderChangeMembersPolicy | EventTypeArgSharedFolderCreate | EventTypeArgSharedFolderDeclineInvitation | EventTypeArgSharedFolderMount | EventTypeArgSharedFolderNest | EventTypeArgSharedFolderTransferOwnership | EventTypeArgSharedFolderUnmount | EventTypeArgSharedLinkAddExpiry | EventTypeArgSharedLinkChangeExpiry | EventTypeArgSharedLinkChangeVisibility | EventTypeArgSharedLinkCopy | EventTypeArgSharedLinkCreate | EventTypeArgSharedLinkDisable | EventTypeArgSharedLinkDownload | EventTypeArgSharedLinkRemoveExpiry | EventTypeArgSharedLinkRemoveVisitor | EventTypeArgSharedLinkSettingsAddExpiration | EventTypeArgSharedLinkSettingsAddPassword | EventTypeArgSharedLinkSettingsAllowDownloadDisabled | EventTypeArgSharedLinkSettingsAllowDownloadEnabled | EventTypeArgSharedLinkSettingsChangeAudience | EventTypeArgSharedLinkSettingsChangeExpiration | EventTypeArgSharedLinkSettingsChangePassword | EventTypeArgSharedLinkSettingsRemoveExpiration | EventTypeArgSharedLinkSettingsRemovePassword | EventTypeArgSharedLinkShare | EventTypeArgSharedLinkView | EventTypeArgSharedNoteOpened | EventTypeArgShmodelDisableDownloads | EventTypeArgShmodelEnableDownloads | EventTypeArgShmodelGroupShare | EventTypeArgShowcaseAccessGranted | EventTypeArgShowcaseAddMember | EventTypeArgShowcaseArchived | EventTypeArgShowcaseCreated | EventTypeArgShowcaseDeleteComment | EventTypeArgShowcaseEdited | EventTypeArgShowcaseEditComment | EventTypeArgShowcaseFileAdded | EventTypeArgShowcaseFileDownload | EventTypeArgShowcaseFileRemoved | EventTypeArgShowcaseFileView | EventTypeArgShowcasePermanentlyDeleted | EventTypeArgShowcasePostComment | EventTypeArgShowcaseRemoveMember | EventTypeArgShowcaseRenamed | EventTypeArgShowcaseRequestAccess | EventTypeArgShowcaseResolveComment | EventTypeArgShowcaseRestored | EventTypeArgShowcaseTrashed | EventTypeArgShowcaseTrashedDeprecated | EventTypeArgShowcaseUnresolveComment | EventTypeArgShowcaseUntrashed | EventTypeArgShowcaseUntrashedDeprecated | EventTypeArgShowcaseView | EventTypeArgSignSignatureRequestCanceled | EventTypeArgSignSignatureRequestCompleted | EventTypeArgSignSignatureRequestDeclined | EventTypeArgSignSignatureRequestOpened | EventTypeArgSignSignatureRequestReminderSent | EventTypeArgSignSignatureRequestSent | EventTypeArgSignTemplateCreated | EventTypeArgSignTemplateShared | EventTypeArgRiscSecurityEvent | EventTypeArgSsoAddCert | EventTypeArgSsoAddLoginUrl | EventTypeArgSsoAddLogoutUrl | EventTypeArgSsoChangeCert | EventTypeArgSsoChangeLoginUrl | EventTypeArgSsoChangeLogoutUrl | EventTypeArgSsoChangeSamlIdentityMode | EventTypeArgSsoRemoveCert | EventTypeArgSsoRemoveLoginUrl | EventTypeArgSsoRemoveLogoutUrl | EventTypeArgTeamFolderChangeStatus | EventTypeArgTeamFolderCreate | EventTypeArgTeamFolderDowngrade | EventTypeArgTeamFolderPermanentlyDelete | EventTypeArgTeamFolderRename | EventTypeArgTeamFolderSpaceLimitsChangeCapsType | EventTypeArgTeamFolderSpaceLimitsChangeLimit | EventTypeArgTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeArgTeamSelectiveSyncSettingsChanged | EventTypeArgAccountCaptureChangePolicy | EventTypeArgAdminEmailRemindersChanged | EventTypeArgAiThirdPartySharingDropboxBasePolicyChanged | EventTypeArgAllowDownloadDisabled | EventTypeArgAllowDownloadEnabled | EventTypeArgAppleLoginChangePolicy | EventTypeArgAppPermissionsChanged | EventTypeArgCameraUploadsPolicyChanged | EventTypeArgCaptureTeamSpacePolicyChanged | EventTypeArgCaptureTranscriptPolicyChanged | EventTypeArgClassificationChangePolicy | EventTypeArgComputerBackupPolicyChanged | EventTypeArgContentAdministrationPolicyChanged | EventTypeArgContentDeletionProtectionChangePolicy | EventTypeArgDashExternalSharingPolicyChanged | EventTypeArgDataPlacementRestrictionChangePolicy | EventTypeArgDataPlacementRestrictionSatisfyPolicy | EventTypeArgDeviceApprovalsAddException | EventTypeArgDeviceApprovalsChangeDesktopPolicy | EventTypeArgDeviceApprovalsChangeMobilePolicy | EventTypeArgDeviceApprovalsChangeOverageAction | EventTypeArgDeviceApprovalsChangeUnlinkAction | EventTypeArgDeviceApprovalsRemoveException | EventTypeArgDirectoryRestrictionsAddMembers | EventTypeArgDirectoryRestrictionsRemoveMembers | EventTypeArgDropboxPasswordsPolicyChanged | EventTypeArgEmailIngestPolicyChanged | EventTypeArgEmmAddException | EventTypeArgEmmChangePolicy | EventTypeArgEmmRemoveException | EventTypeArgExtendedVersionHistoryChangePolicy | EventTypeArgExternalDriveBackupPolicyChanged | EventTypeArgFileCommentsChangePolicy | EventTypeArgFileLockingPolicyChanged | EventTypeArgFileProviderMigrationPolicyChanged | EventTypeArgFileRequestsChangePolicy | EventTypeArgFileRequestsEmailsEnabled | EventTypeArgFileRequestsEmailsRestrictedToTeamOnly | EventTypeArgFileTransfersPolicyChanged | EventTypeArgFlexibleFileNamesPolicyChanged | EventTypeArgFolderLinkRestrictionPolicyChanged | EventTypeArgGoogleSsoChangePolicy | EventTypeArgGroupUserManagementChangePolicy | EventTypeArgIntegrationPolicyChanged | EventTypeArgInviteAcceptanceEmailPolicyChanged | EventTypeArgMediaHubAddingPeoplePolicyChanged | EventTypeArgMediaHubDownloadPolicyChanged | EventTypeArgMediaHubLinkSharingPolicyChanged | EventTypeArgMemberRequestsChangePolicy | EventTypeArgMemberSendInvitePolicyChanged | EventTypeArgMemberSpaceLimitsAddException | EventTypeArgMemberSpaceLimitsChangeCapsTypePolicy | EventTypeArgMemberSpaceLimitsChangePolicy | EventTypeArgMemberSpaceLimitsRemoveException | EventTypeArgMemberSuggestionsChangePolicy | EventTypeArgMicrosoftLoginChangePolicy | EventTypeArgMicrosoftOfficeAddinChangePolicy | EventTypeArgMultiTeamIdentityPolicyChanged | EventTypeArgNetworkControlChangePolicy | EventTypeArgPaperChangeDeploymentPolicy | EventTypeArgPaperChangeMemberLinkPolicy | EventTypeArgPaperChangeMemberPolicy | EventTypeArgPaperChangePolicy | EventTypeArgPaperDefaultFolderPolicyChanged | EventTypeArgPaperDesktopPolicyChanged | EventTypeArgPaperEnabledUsersGroupAddition | EventTypeArgPaperEnabledUsersGroupRemoval | EventTypeArgPasskeyLoginPolicyChanged | EventTypeArgPasswordStrengthRequirementsChangePolicy | EventTypeArgPermanentDeleteChangePolicy | EventTypeArgPreviewsAiPolicyChanged | EventTypeArgReplayAddingPeoplePolicyChanged | EventTypeArgReplaySharingPolicyChanged | EventTypeArgResellerSupportChangePolicy | EventTypeArgRewindPolicyChanged | EventTypeArgSendAndTrackPolicyChanged | EventTypeArgSendExternalSharingPolicyChanged | EventTypeArgSendForSignaturePolicyChanged | EventTypeArgSharedLinkDefaultPermissionsPolicyChanged | EventTypeArgSharingChangeFolderJoinPolicy | EventTypeArgSharingChangeLinkAllowChangeExpirationPolicy | EventTypeArgSharingChangeLinkDefaultExpirationPolicy | EventTypeArgSharingChangeLinkEnforcePasswordPolicy | EventTypeArgSharingChangeLinkPolicy | EventTypeArgSharingChangeMemberPolicy | EventTypeArgShowcaseChangeDownloadPolicy | EventTypeArgShowcaseChangeEnabledPolicy | EventTypeArgShowcaseChangeExternalSharingPolicy | EventTypeArgSignExternalSharingPolicyChanged | EventTypeArgSignTemplateCreationPermissionChanged | EventTypeArgSmarterSmartSyncPolicyChanged | EventTypeArgSmartSyncChangePolicy | EventTypeArgSmartSyncNotOptOut | EventTypeArgSmartSyncOptOut | EventTypeArgSsoChangePolicy | EventTypeArgStackCrossTeamAccessPolicyChanged | EventTypeArgTeamBrandingPolicyChanged | EventTypeArgTeamExtensionsPolicyChanged | EventTypeArgTeamMemberStorageRequestPolicyChanged | EventTypeArgTeamSelectiveSyncPolicyChanged | EventTypeArgTeamSharingWhitelistSubjectsChanged | EventTypeArgTfaAddException | EventTypeArgTfaChangePolicy | EventTypeArgTfaRemoveException | EventTypeArgTopLevelContentPolicyChanged | EventTypeArgTwoAccountChangePolicy | EventTypeArgViewerInfoPolicyChanged | EventTypeArgWatermarkingPolicyChanged | EventTypeArgWebSessionsChangeActiveSessionLimit | EventTypeArgWebSessionsChangeFixedLengthPolicy | EventTypeArgWebSessionsChangeIdleLengthPolicy | EventTypeArgDataResidencyMigrationRequestSuccessful | EventTypeArgDataResidencyMigrationRequestUnsuccessful | EventTypeArgTeamMergeFrom | EventTypeArgTeamMergeTo | EventTypeArgTeamProfileAddBackground | EventTypeArgTeamProfileAddLogo | EventTypeArgTeamProfileChangeBackground | EventTypeArgTeamProfileChangeDefaultLanguage | EventTypeArgTeamProfileChangeLogo | EventTypeArgTeamProfileChangeName | EventTypeArgTeamProfileRemoveBackground | EventTypeArgTeamProfileRemoveLogo | EventTypeArgPasskeyAdd | EventTypeArgPasskeyRemove | EventTypeArgTfaAddBackupPhone | EventTypeArgTfaAddSecurityKey | EventTypeArgTfaChangeBackupPhone | EventTypeArgTfaChangeStatus | EventTypeArgTfaRemoveBackupPhone | EventTypeArgTfaRemoveSecurityKey | EventTypeArgTfaReset | EventTypeArgChangedEnterpriseAdminRole | EventTypeArgChangedEnterpriseConnectedTeamStatus | EventTypeArgEndedEnterpriseAdminSession | EventTypeArgEndedEnterpriseAdminSessionDeprecated | EventTypeArgEnterpriseSettingsLocking | EventTypeArgGuestAdminChangeStatus | EventTypeArgStartedEnterpriseAdminSession | EventTypeArgTeamMergeRequestAccepted | EventTypeArgTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeArgTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeArgTeamMergeRequestAutoCanceled | EventTypeArgTeamMergeRequestCanceled | EventTypeArgTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeArgTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeArgTeamMergeRequestExpired | EventTypeArgTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeArgTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeArgTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeArgTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeArgTeamMergeRequestReminder | EventTypeArgTeamMergeRequestReminderShownToPrimaryTeam | EventTypeArgTeamMergeRequestReminderShownToSecondaryTeam | EventTypeArgTeamMergeRequestRevoked | EventTypeArgTeamMergeRequestSentShownToPrimaryTeam | EventTypeArgTeamMergeRequestSentShownToSecondaryTeam | EventTypeArgOther;
+    export type EventTypeArg = EventTypeArgAdminAlertingAlertStateChanged | EventTypeArgAdminAlertingChangedAlertConfig | EventTypeArgAdminAlertingTriggeredAlert | EventTypeArgRansomwareRestoreProcessCompleted | EventTypeArgRansomwareRestoreProcessStarted | EventTypeArgAppBlockedByPermissions | EventTypeArgAppLinkTeam | EventTypeArgAppLinkUser | EventTypeArgAppUnlinkTeam | EventTypeArgAppUnlinkUser | EventTypeArgIntegrationConnected | EventTypeArgIntegrationDisconnected | EventTypeArgFileAddComment | EventTypeArgFileChangeCommentSubscription | EventTypeArgFileDeleteComment | EventTypeArgFileEditComment | EventTypeArgFileLikeComment | EventTypeArgFileResolveComment | EventTypeArgFileUnlikeComment | EventTypeArgFileUnresolveComment | EventTypeArgDashAddedCommentToStack | EventTypeArgDashAddedConnector | EventTypeArgDashAddedLinkToStack | EventTypeArgDashAddedTeamEmailDomainAllowlist | EventTypeArgDashAdminAddedOrgWideConnector | EventTypeArgDashAdminDisabledConnector | EventTypeArgDashAdminEnabledConnector | EventTypeArgDashAdminRemovedOrgWideConnector | EventTypeArgDashArchivedStack | EventTypeArgDashChangedAudienceOfSharedLinkToStack | EventTypeArgDashClonedStack | EventTypeArgDashConnectorToolsCall | EventTypeArgDashCreatedStack | EventTypeArgDashDeletedCommentFromStack | EventTypeArgDashDeletedStack | EventTypeArgDashEditedCommentInStack | EventTypeArgDashExternalUserOpenedStack | EventTypeArgDashFirstLaunchedDesktop | EventTypeArgDashFirstLaunchedExtension | EventTypeArgDashFirstLaunchedWebStartPage | EventTypeArgDashOpenedSharedLinkToStack | EventTypeArgDashOpenedStack | EventTypeArgDashPreviewOptOutStatusChanged | EventTypeArgDashRemovedConnector | EventTypeArgDashRemovedLinkFromStack | EventTypeArgDashRemovedSharedLinkToStack | EventTypeArgDashRemovedTeamEmailDomainAllowlist | EventTypeArgDashRenamedStack | EventTypeArgDashSharedLinkToStack | EventTypeArgDashUnarchivedStack | EventTypeArgDashViewedCompanyStack | EventTypeArgDashViewedExternalAiActivityReport | EventTypeArgGovernancePolicyAddFolders | EventTypeArgGovernancePolicyAddFolderFailed | EventTypeArgGovernancePolicyContentDisposed | EventTypeArgGovernancePolicyCreate | EventTypeArgGovernancePolicyDelete | EventTypeArgGovernancePolicyEditDetails | EventTypeArgGovernancePolicyEditDuration | EventTypeArgGovernancePolicyExportCreated | EventTypeArgGovernancePolicyExportRemoved | EventTypeArgGovernancePolicyRemoveFolders | EventTypeArgGovernancePolicyReportCreated | EventTypeArgGovernancePolicyZipPartDownloaded | EventTypeArgLegalHoldsActivateAHold | EventTypeArgLegalHoldsAddMembers | EventTypeArgLegalHoldsChangeHoldDetails | EventTypeArgLegalHoldsChangeHoldName | EventTypeArgLegalHoldsExportAHold | EventTypeArgLegalHoldsExportCancelled | EventTypeArgLegalHoldsExportDownloaded | EventTypeArgLegalHoldsExportRemoved | EventTypeArgLegalHoldsReleaseAHold | EventTypeArgLegalHoldsRemoveMembers | EventTypeArgLegalHoldsReportAHold | EventTypeArgDeviceChangeIpDesktop | EventTypeArgDeviceChangeIpMobile | EventTypeArgDeviceChangeIpWeb | EventTypeArgDeviceDeleteOnUnlinkFail | EventTypeArgDeviceDeleteOnUnlinkSuccess | EventTypeArgDeviceLinkFail | EventTypeArgDeviceLinkSuccess | EventTypeArgDeviceManagementDisabled | EventTypeArgDeviceManagementEnabled | EventTypeArgDeviceSyncBackupStatusChanged | EventTypeArgDeviceUnlink | EventTypeArgDropboxPasswordsExported | EventTypeArgDropboxPasswordsNewDeviceEnrolled | EventTypeArgEmmRefreshAuthToken | EventTypeArgExternalDriveBackupEligibilityStatusChecked | EventTypeArgExternalDriveBackupStatusChanged | EventTypeArgAccountCaptureChangeAvailability | EventTypeArgAccountCaptureMigrateAccount | EventTypeArgAccountCaptureNotificationEmailsSent | EventTypeArgAccountCaptureRelinquishAccount | EventTypeArgDisabledDomainInvites | EventTypeArgDomainInvitesApproveRequestToJoinTeam | EventTypeArgDomainInvitesDeclineRequestToJoinTeam | EventTypeArgDomainInvitesEmailExistingUsers | EventTypeArgDomainInvitesRequestToJoinTeam | EventTypeArgDomainInvitesSetInviteNewUserPrefToNo | EventTypeArgDomainInvitesSetInviteNewUserPrefToYes | EventTypeArgDomainVerificationAddDomainFail | EventTypeArgDomainVerificationAddDomainSuccess | EventTypeArgDomainVerificationRemoveDomain | EventTypeArgEnabledDomainInvites | EventTypeArgEncryptedFolderCancelTeamKeyRotation | EventTypeArgEncryptedFolderEnrollBackupKey | EventTypeArgEncryptedFolderEnrollClient | EventTypeArgEncryptedFolderEnrollTeam | EventTypeArgEncryptedFolderFinishTeamUnenrollment | EventTypeArgEncryptedFolderInitTeamKeyRotation | EventTypeArgEncryptedFolderInitTeamUnenrollment | EventTypeArgEncryptedFolderRemoveBackupKey | EventTypeArgEncryptedFolderRotateTeamKey | EventTypeArgEncryptedFolderUnenrollClient | EventTypeArgTeamEncryptionKeyActivateKey | EventTypeArgTeamEncryptionKeyCancelKeyDeletion | EventTypeArgTeamEncryptionKeyCreateKey | EventTypeArgTeamEncryptionKeyDeactivateKey | EventTypeArgTeamEncryptionKeyDeleteKey | EventTypeArgTeamEncryptionKeyDisableKey | EventTypeArgTeamEncryptionKeyEnableKey | EventTypeArgTeamEncryptionKeyRotateKey | EventTypeArgTeamEncryptionKeyScheduleKeyDeletion | EventTypeArgApplyNamingConvention | EventTypeArgCreateFolder | EventTypeArgFileAdd | EventTypeArgFileAddFromAutomation | EventTypeArgFileCopy | EventTypeArgFileDelete | EventTypeArgFileDownload | EventTypeArgFileEdit | EventTypeArgFileGetCopyReference | EventTypeArgFileLockingLockStatusChanged | EventTypeArgFileMove | EventTypeArgFilePermanentlyDelete | EventTypeArgFilePreview | EventTypeArgFileRename | EventTypeArgFileRestore | EventTypeArgFileRevert | EventTypeArgFileRollbackChanges | EventTypeArgFileSaveCopyReference | EventTypeArgFolderOverviewDescriptionChanged | EventTypeArgFolderOverviewItemPinned | EventTypeArgFolderOverviewItemUnpinned | EventTypeArgMediaHubFileDownloaded | EventTypeArgObjectLabelAdded | EventTypeArgObjectLabelRemoved | EventTypeArgObjectLabelUpdatedValue | EventTypeArgOrganizeFolderWithTidy | EventTypeArgReplayFileDelete | EventTypeArgReplayFileDownloaded | EventTypeArgReplayTeamProjectCreated | EventTypeArgRewindFolder | EventTypeArgUndoNamingConvention | EventTypeArgUndoOrganizeFolderWithTidy | EventTypeArgUserTagsAdded | EventTypeArgUserTagsRemoved | EventTypeArgEmailIngestReceiveFile | EventTypeArgFileRequestAutoClose | EventTypeArgFileRequestChange | EventTypeArgFileRequestClose | EventTypeArgFileRequestCreate | EventTypeArgFileRequestDelete | EventTypeArgFileRequestReceiveFile | EventTypeArgGroupAddExternalId | EventTypeArgGroupAddMember | EventTypeArgGroupChangeExternalId | EventTypeArgGroupChangeManagementType | EventTypeArgGroupChangeMemberRole | EventTypeArgGroupCreate | EventTypeArgGroupDelete | EventTypeArgGroupDescriptionUpdated | EventTypeArgGroupExternalSharingSettingOverrideChanged | EventTypeArgGroupJoinPolicyUpdated | EventTypeArgGroupMoved | EventTypeArgGroupRemoveExternalId | EventTypeArgGroupRemoveMember | EventTypeArgGroupRename | EventTypeArgAccountLockOrUnlocked | EventTypeArgEmmError | EventTypeArgGuestAdminSignedInViaTrustedTeams | EventTypeArgGuestAdminSignedOutViaTrustedTeams | EventTypeArgLoginFail | EventTypeArgLoginSuccess | EventTypeArgLogout | EventTypeArgResellerSupportSessionEnd | EventTypeArgResellerSupportSessionStart | EventTypeArgSignInAsSessionEnd | EventTypeArgSignInAsSessionStart | EventTypeArgSsoError | EventTypeArgAddonAssigned | EventTypeArgAddonRemoved | EventTypeArgBackupAdminInvitationSent | EventTypeArgBackupInvitationOpened | EventTypeArgCreateTeamInviteLink | EventTypeArgDeleteTeamInviteLink | EventTypeArgMemberAddExternalId | EventTypeArgMemberAddName | EventTypeArgMemberChangeAdminRole | EventTypeArgMemberChangeEmail | EventTypeArgMemberChangeExternalId | EventTypeArgMemberChangeMembershipType | EventTypeArgMemberChangeName | EventTypeArgMemberChangeResellerRole | EventTypeArgMemberChangeStatus | EventTypeArgMemberDeleteManualContacts | EventTypeArgMemberDeleteProfilePhoto | EventTypeArgMemberPermanentlyDeleteAccountContents | EventTypeArgMemberRemoveExternalId | EventTypeArgMemberSetProfilePhoto | EventTypeArgMemberSpaceLimitsAddCustomQuota | EventTypeArgMemberSpaceLimitsChangeCustomQuota | EventTypeArgMemberSpaceLimitsChangeStatus | EventTypeArgMemberSpaceLimitsRemoveCustomQuota | EventTypeArgMemberSuggest | EventTypeArgMemberTransferAccountContents | EventTypeArgPendingSecondaryEmailAdded | EventTypeArgProductAssignedToMember | EventTypeArgProductRemovedFromMember | EventTypeArgSecondaryEmailDeleted | EventTypeArgSecondaryEmailVerified | EventTypeArgSecondaryMailsPolicyChanged | EventTypeArgBinderAddPage | EventTypeArgBinderAddSection | EventTypeArgBinderRemovePage | EventTypeArgBinderRemoveSection | EventTypeArgBinderRenamePage | EventTypeArgBinderRenameSection | EventTypeArgBinderReorderPage | EventTypeArgBinderReorderSection | EventTypeArgPaperContentAddMember | EventTypeArgPaperContentAddToFolder | EventTypeArgPaperContentArchive | EventTypeArgPaperContentCreate | EventTypeArgPaperContentPermanentlyDelete | EventTypeArgPaperContentRemoveFromFolder | EventTypeArgPaperContentRemoveMember | EventTypeArgPaperContentRename | EventTypeArgPaperContentRestore | EventTypeArgPaperDocAddComment | EventTypeArgPaperDocChangeMemberRole | EventTypeArgPaperDocChangeSharingPolicy | EventTypeArgPaperDocChangeSubscription | EventTypeArgPaperDocDeleted | EventTypeArgPaperDocDeleteComment | EventTypeArgPaperDocDownload | EventTypeArgPaperDocEdit | EventTypeArgPaperDocEditComment | EventTypeArgPaperDocFollowed | EventTypeArgPaperDocMention | EventTypeArgPaperDocOwnershipChanged | EventTypeArgPaperDocRequestAccess | EventTypeArgPaperDocResolveComment | EventTypeArgPaperDocRevert | EventTypeArgPaperDocSlackShare | EventTypeArgPaperDocTeamInvite | EventTypeArgPaperDocTrashed | EventTypeArgPaperDocUnresolveComment | EventTypeArgPaperDocUntrashed | EventTypeArgPaperDocView | EventTypeArgPaperExternalViewAllow | EventTypeArgPaperExternalViewDefaultTeam | EventTypeArgPaperExternalViewForbid | EventTypeArgPaperFolderChangeSubscription | EventTypeArgPaperFolderDeleted | EventTypeArgPaperFolderFollowed | EventTypeArgPaperFolderTeamInvite | EventTypeArgPaperPublishedLinkChangePermission | EventTypeArgPaperPublishedLinkCreate | EventTypeArgPaperPublishedLinkDisabled | EventTypeArgPaperPublishedLinkView | EventTypeArgPasswordChange | EventTypeArgPasswordReset | EventTypeArgPasswordResetAll | EventTypeArgProtectInternalDomainsChanged | EventTypeArgClassificationCreateReport | EventTypeArgClassificationCreateReportFail | EventTypeArgEmmCreateExceptionsReport | EventTypeArgEmmCreateUsageReport | EventTypeArgExportMembersReport | EventTypeArgExportMembersReportFail | EventTypeArgExternalSharingCreateReport | EventTypeArgExternalSharingReportFailed | EventTypeArgMemberAccessDetailsCreateReport | EventTypeArgMemberAccessDetailsCreateReportFailed | EventTypeArgNoExpirationLinkGenCreateReport | EventTypeArgNoExpirationLinkGenReportFailed | EventTypeArgNoPasswordLinkGenCreateReport | EventTypeArgNoPasswordLinkGenReportFailed | EventTypeArgNoPasswordLinkViewCreateReport | EventTypeArgNoPasswordLinkViewReportFailed | EventTypeArgOutdatedLinkViewCreateReport | EventTypeArgOutdatedLinkViewReportFailed | EventTypeArgPaperAdminExportStart | EventTypeArgRansomwareAlertCreateReport | EventTypeArgRansomwareAlertCreateReportFailed | EventTypeArgSharedFoldersCreateReport | EventTypeArgSharedFoldersCreateReportFailed | EventTypeArgSmartSyncCreateAdminPrivilegeReport | EventTypeArgTeamActivityCreateReport | EventTypeArgTeamActivityCreateReportFail | EventTypeArgTeamFoldersCreateReport | EventTypeArgTeamFoldersCreateReportFailed | EventTypeArgTeamStorageCreateReport | EventTypeArgTeamStorageCreateReportFailed | EventTypeArgCollectionShare | EventTypeArgFileTransfersFileAdd | EventTypeArgFileTransfersTransferDelete | EventTypeArgFileTransfersTransferDownload | EventTypeArgFileTransfersTransferSend | EventTypeArgFileTransfersTransferView | EventTypeArgMediaHubProjectTeamAdd | EventTypeArgMediaHubProjectTeamDelete | EventTypeArgMediaHubProjectTeamRoleChanged | EventTypeArgMediaHubSharedLinkAudienceChanged | EventTypeArgMediaHubSharedLinkCreated | EventTypeArgMediaHubSharedLinkDownloadSettingChanged | EventTypeArgMediaHubSharedLinkRevoked | EventTypeArgNoteAclInviteOnly | EventTypeArgNoteAclLink | EventTypeArgNoteAclTeamLink | EventTypeArgNoteShared | EventTypeArgNoteShareReceive | EventTypeArgOpenNoteShared | EventTypeArgReplayFileSharedLinkCreated | EventTypeArgReplayFileSharedLinkModified | EventTypeArgReplayProjectTeamAdd | EventTypeArgReplayProjectTeamDelete | EventTypeArgSendAndTrackFileAdded | EventTypeArgSendAndTrackFileRenamed | EventTypeArgSendAndTrackFileUpdated | EventTypeArgSendAndTrackLinkCreated | EventTypeArgSendAndTrackLinkDeleted | EventTypeArgSendAndTrackLinkUpdated | EventTypeArgSendAndTrackLinkViewed | EventTypeArgSendAndTrackRemovedFileAndAssociatedLinks | EventTypeArgSfAddGroup | EventTypeArgSfAllowNonMembersToViewSharedLinks | EventTypeArgSfExternalInviteWarn | EventTypeArgSfFbInvite | EventTypeArgSfFbInviteChangeRole | EventTypeArgSfFbUninvite | EventTypeArgSfInviteGroup | EventTypeArgSfTeamGrantAccess | EventTypeArgSfTeamInvite | EventTypeArgSfTeamInviteChangeRole | EventTypeArgSfTeamJoin | EventTypeArgSfTeamJoinFromOobLink | EventTypeArgSfTeamUninvite | EventTypeArgSharedContentAddInvitees | EventTypeArgSharedContentAddLinkExpiry | EventTypeArgSharedContentAddLinkPassword | EventTypeArgSharedContentAddMember | EventTypeArgSharedContentChangeDownloadsPolicy | EventTypeArgSharedContentChangeInviteeRole | EventTypeArgSharedContentChangeLinkAudience | EventTypeArgSharedContentChangeLinkExpiry | EventTypeArgSharedContentChangeLinkPassword | EventTypeArgSharedContentChangeMemberRole | EventTypeArgSharedContentChangeViewerInfoPolicy | EventTypeArgSharedContentClaimInvitation | EventTypeArgSharedContentCopy | EventTypeArgSharedContentDownload | EventTypeArgSharedContentRelinquishMembership | EventTypeArgSharedContentRemoveInvitees | EventTypeArgSharedContentRemoveLinkExpiry | EventTypeArgSharedContentRemoveLinkPassword | EventTypeArgSharedContentRemoveMember | EventTypeArgSharedContentRequestAccess | EventTypeArgSharedContentRestoreInvitees | EventTypeArgSharedContentRestoreMember | EventTypeArgSharedContentUnshare | EventTypeArgSharedContentView | EventTypeArgSharedFolderChangeLinkPolicy | EventTypeArgSharedFolderChangeMembersInheritancePolicy | EventTypeArgSharedFolderChangeMembersManagementPolicy | EventTypeArgSharedFolderChangeMembersPolicy | EventTypeArgSharedFolderCreate | EventTypeArgSharedFolderDeclineInvitation | EventTypeArgSharedFolderMount | EventTypeArgSharedFolderNest | EventTypeArgSharedFolderTransferOwnership | EventTypeArgSharedFolderUnmount | EventTypeArgSharedLinkAddExpiry | EventTypeArgSharedLinkChangeExpiry | EventTypeArgSharedLinkChangeVisibility | EventTypeArgSharedLinkCopy | EventTypeArgSharedLinkCreate | EventTypeArgSharedLinkDisable | EventTypeArgSharedLinkDownload | EventTypeArgSharedLinkRemoveExpiry | EventTypeArgSharedLinkRemoveVisitor | EventTypeArgSharedLinkSettingsAddExpiration | EventTypeArgSharedLinkSettingsAddPassword | EventTypeArgSharedLinkSettingsAllowDownloadDisabled | EventTypeArgSharedLinkSettingsAllowDownloadEnabled | EventTypeArgSharedLinkSettingsChangeAudience | EventTypeArgSharedLinkSettingsChangeExpiration | EventTypeArgSharedLinkSettingsChangePassword | EventTypeArgSharedLinkSettingsRemoveExpiration | EventTypeArgSharedLinkSettingsRemovePassword | EventTypeArgSharedLinkShare | EventTypeArgSharedLinkView | EventTypeArgSharedNoteOpened | EventTypeArgShmodelDisableDownloads | EventTypeArgShmodelEnableDownloads | EventTypeArgShmodelGroupShare | EventTypeArgShowcaseAccessGranted | EventTypeArgShowcaseAddMember | EventTypeArgShowcaseArchived | EventTypeArgShowcaseCreated | EventTypeArgShowcaseDeleteComment | EventTypeArgShowcaseEdited | EventTypeArgShowcaseEditComment | EventTypeArgShowcaseFileAdded | EventTypeArgShowcaseFileDownload | EventTypeArgShowcaseFileRemoved | EventTypeArgShowcaseFileView | EventTypeArgShowcasePermanentlyDeleted | EventTypeArgShowcasePostComment | EventTypeArgShowcaseRemoveMember | EventTypeArgShowcaseRenamed | EventTypeArgShowcaseRequestAccess | EventTypeArgShowcaseResolveComment | EventTypeArgShowcaseRestored | EventTypeArgShowcaseTrashed | EventTypeArgShowcaseTrashedDeprecated | EventTypeArgShowcaseUnresolveComment | EventTypeArgShowcaseUntrashed | EventTypeArgShowcaseUntrashedDeprecated | EventTypeArgShowcaseView | EventTypeArgSignSignatureRequestCanceled | EventTypeArgSignSignatureRequestCompleted | EventTypeArgSignSignatureRequestDeclined | EventTypeArgSignSignatureRequestOpened | EventTypeArgSignSignatureRequestReminderSent | EventTypeArgSignSignatureRequestSent | EventTypeArgSignTemplateCreated | EventTypeArgSignTemplateShared | EventTypeArgRiscSecurityEvent | EventTypeArgSsoAddCert | EventTypeArgSsoAddLoginUrl | EventTypeArgSsoAddLogoutUrl | EventTypeArgSsoChangeCert | EventTypeArgSsoChangeLoginUrl | EventTypeArgSsoChangeLogoutUrl | EventTypeArgSsoChangeSamlIdentityMode | EventTypeArgSsoRemoveCert | EventTypeArgSsoRemoveLoginUrl | EventTypeArgSsoRemoveLogoutUrl | EventTypeArgTeamFolderChangeStatus | EventTypeArgTeamFolderCreate | EventTypeArgTeamFolderDowngrade | EventTypeArgTeamFolderPermanentlyDelete | EventTypeArgTeamFolderRename | EventTypeArgTeamFolderSpaceLimitsChangeCapsType | EventTypeArgTeamFolderSpaceLimitsChangeLimit | EventTypeArgTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeArgTeamSelectiveSyncSettingsChanged | EventTypeArgAccountCaptureChangePolicy | EventTypeArgAdminEmailRemindersChanged | EventTypeArgAiThirdPartySharingDropboxBasePolicyChanged | EventTypeArgAllowDownloadDisabled | EventTypeArgAllowDownloadEnabled | EventTypeArgAppleLoginChangePolicy | EventTypeArgAppPermissionsChanged | EventTypeArgCameraUploadsPolicyChanged | EventTypeArgCaptureTeamSpacePolicyChanged | EventTypeArgCaptureTranscriptPolicyChanged | EventTypeArgClassificationChangePolicy | EventTypeArgComputerBackupPolicyChanged | EventTypeArgContentAdministrationPolicyChanged | EventTypeArgContentDeletionProtectionChangePolicy | EventTypeArgDashExternalSharingPolicyChanged | EventTypeArgDataPlacementRestrictionChangePolicy | EventTypeArgDataPlacementRestrictionSatisfyPolicy | EventTypeArgDeviceApprovalsAddException | EventTypeArgDeviceApprovalsChangeDesktopPolicy | EventTypeArgDeviceApprovalsChangeMobilePolicy | EventTypeArgDeviceApprovalsChangeOverageAction | EventTypeArgDeviceApprovalsChangeUnlinkAction | EventTypeArgDeviceApprovalsRemoveException | EventTypeArgDirectoryRestrictionsAddMembers | EventTypeArgDirectoryRestrictionsRemoveMembers | EventTypeArgDropboxPasswordsPolicyChanged | EventTypeArgEmailIngestPolicyChanged | EventTypeArgEmmAddException | EventTypeArgEmmChangePolicy | EventTypeArgEmmRemoveException | EventTypeArgExtendedVersionHistoryChangePolicy | EventTypeArgExternalDriveBackupPolicyChanged | EventTypeArgFileCommentsChangePolicy | EventTypeArgFileLockingPolicyChanged | EventTypeArgFileProviderMigrationPolicyChanged | EventTypeArgFileRequestsChangePolicy | EventTypeArgFileRequestsEmailsEnabled | EventTypeArgFileRequestsEmailsRestrictedToTeamOnly | EventTypeArgFileTransfersPolicyChanged | EventTypeArgFlexibleFileNamesPolicyChanged | EventTypeArgFolderLinkRestrictionPolicyChanged | EventTypeArgGoogleSsoChangePolicy | EventTypeArgGroupUserManagementChangePolicy | EventTypeArgIntegrationPolicyChanged | EventTypeArgInviteAcceptanceEmailPolicyChanged | EventTypeArgMediaHubAddingPeoplePolicyChanged | EventTypeArgMediaHubDownloadPolicyChanged | EventTypeArgMediaHubLinkSharingPolicyChanged | EventTypeArgMemberRequestsChangePolicy | EventTypeArgMemberSendInvitePolicyChanged | EventTypeArgMemberSpaceLimitsAddException | EventTypeArgMemberSpaceLimitsChangeCapsTypePolicy | EventTypeArgMemberSpaceLimitsChangePolicy | EventTypeArgMemberSpaceLimitsRemoveException | EventTypeArgMemberSuggestionsChangePolicy | EventTypeArgMicrosoftLoginChangePolicy | EventTypeArgMicrosoftOfficeAddinChangePolicy | EventTypeArgMultiTeamIdentityPolicyChanged | EventTypeArgNetworkControlChangePolicy | EventTypeArgPaperChangeDeploymentPolicy | EventTypeArgPaperChangeMemberLinkPolicy | EventTypeArgPaperChangeMemberPolicy | EventTypeArgPaperChangePolicy | EventTypeArgPaperDefaultFolderPolicyChanged | EventTypeArgPaperDesktopPolicyChanged | EventTypeArgPaperEnabledUsersGroupAddition | EventTypeArgPaperEnabledUsersGroupRemoval | EventTypeArgPasskeyLoginPolicyChanged | EventTypeArgPasswordStrengthRequirementsChangePolicy | EventTypeArgPermanentDeleteChangePolicy | EventTypeArgPreviewsAiPolicyChanged | EventTypeArgReplayAddingPeoplePolicyChanged | EventTypeArgReplaySharingPolicyChanged | EventTypeArgResellerSupportChangePolicy | EventTypeArgRewindPolicyChanged | EventTypeArgSendAndTrackPolicyChanged | EventTypeArgSendExternalSharingPolicyChanged | EventTypeArgSendForSignaturePolicyChanged | EventTypeArgSharedLinkDefaultPermissionsPolicyChanged | EventTypeArgSharingChangeFolderJoinPolicy | EventTypeArgSharingChangeLinkAllowChangeExpirationPolicy | EventTypeArgSharingChangeLinkDefaultExpirationPolicy | EventTypeArgSharingChangeLinkEnforcePasswordPolicy | EventTypeArgSharingChangeLinkPolicy | EventTypeArgSharingChangeMemberPolicy | EventTypeArgShowcaseChangeDownloadPolicy | EventTypeArgShowcaseChangeEnabledPolicy | EventTypeArgShowcaseChangeExternalSharingPolicy | EventTypeArgSignExternalSharingPolicyChanged | EventTypeArgSignTemplateCreationPermissionChanged | EventTypeArgSmarterSmartSyncPolicyChanged | EventTypeArgSmartSyncChangePolicy | EventTypeArgSmartSyncNotOptOut | EventTypeArgSmartSyncOptOut | EventTypeArgSsoChangePolicy | EventTypeArgStackCrossTeamAccessPolicyChanged | EventTypeArgTeamBrandingPolicyChanged | EventTypeArgTeamExtensionsPolicyChanged | EventTypeArgTeamMemberStorageRequestPolicyChanged | EventTypeArgTeamSelectiveSyncPolicyChanged | EventTypeArgTeamSharingWhitelistSubjectsChanged | EventTypeArgTfaAddException | EventTypeArgTfaChangePolicy | EventTypeArgTfaRemoveException | EventTypeArgTopLevelContentPolicyChanged | EventTypeArgTwoAccountChangePolicy | EventTypeArgViewerInfoPolicyChanged | EventTypeArgWatermarkingPolicyChanged | EventTypeArgWebSessionsChangeActiveSessionLimit | EventTypeArgWebSessionsChangeFixedLengthPolicy | EventTypeArgWebSessionsChangeIdleLengthPolicy | EventTypeArgDataResidencyMigrationRequestSuccessful | EventTypeArgDataResidencyMigrationRequestUnsuccessful | EventTypeArgTeamMergeFrom | EventTypeArgTeamMergeTo | EventTypeArgTeamProfileAddBackground | EventTypeArgTeamProfileAddLogo | EventTypeArgTeamProfileChangeBackground | EventTypeArgTeamProfileChangeDefaultLanguage | EventTypeArgTeamProfileChangeLogo | EventTypeArgTeamProfileChangeName | EventTypeArgTeamProfileRemoveBackground | EventTypeArgTeamProfileRemoveLogo | EventTypeArgPasskeyAdd | EventTypeArgPasskeyRemove | EventTypeArgTfaAddBackupPhone | EventTypeArgTfaAddSecurityKey | EventTypeArgTfaChangeBackupPhone | EventTypeArgTfaChangeStatus | EventTypeArgTfaRemoveBackupPhone | EventTypeArgTfaRemoveSecurityKey | EventTypeArgTfaReset | EventTypeArgChangedEnterpriseAdminRole | EventTypeArgChangedEnterpriseConnectedTeamStatus | EventTypeArgEndedEnterpriseAdminSession | EventTypeArgEndedEnterpriseAdminSessionDeprecated | EventTypeArgEnterpriseSettingsLocking | EventTypeArgGuestAdminChangeStatus | EventTypeArgStartedEnterpriseAdminSession | EventTypeArgTeamMergeRequestAccepted | EventTypeArgTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeArgTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeArgTeamMergeRequestAutoCanceled | EventTypeArgTeamMergeRequestCanceled | EventTypeArgTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeArgTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeArgTeamMergeRequestExpired | EventTypeArgTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeArgTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeArgTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeArgTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeArgTeamMergeRequestReminder | EventTypeArgTeamMergeRequestReminderShownToPrimaryTeam | EventTypeArgTeamMergeRequestReminderShownToSecondaryTeam | EventTypeArgTeamMergeRequestRevoked | EventTypeArgTeamMergeRequestSentShownToPrimaryTeam | EventTypeArgTeamMergeRequestSentShownToSecondaryTeam | EventTypeArgOther;
 
     /**
      * Created member data report.
@@ -36349,7 +35902,7 @@
     export type MediaHubAddingPeoplePolicy = MediaHubAddingPeoplePolicyAnyone | MediaHubAddingPeoplePolicyTeamOnly | MediaHubAddingPeoplePolicyOther;
 
     /**
-     * Changed the policy for adding people to Replay content.
+     * Changed the policy for adding people to Media Hub content.
      */
     export interface MediaHubAddingPeoplePolicyChangedDetails {
       /**
@@ -36384,7 +35937,7 @@
     export type MediaHubDownloadPolicy = MediaHubDownloadPolicyDisabled | MediaHubDownloadPolicyEnabled | MediaHubDownloadPolicyOther;
 
     /**
-     * Changed the policy for downloading Replay content.
+     * Changed the policy for downloading Media Hub content.
      */
     export interface MediaHubDownloadPolicyChangedDetails {
       /**
@@ -36402,7 +35955,7 @@
     }
 
     /**
-     * Downloaded files in Replay.
+     * Downloaded files in Media Hub.
      */
     export interface MediaHubFileDownloadedDetails {
     }
@@ -36434,7 +35987,7 @@
     export type MediaHubLinkSharingPolicy = MediaHubLinkSharingPolicyNoOne | MediaHubLinkSharingPolicyPublic | MediaHubLinkSharingPolicyTeamOnly | MediaHubLinkSharingPolicyOther;
 
     /**
-     * Changed the policy for sharing Replay content.
+     * Changed the policy for sharing Media Hub content.
      */
     export interface MediaHubLinkSharingPolicyChangedDetails {
       /**
@@ -36449,20 +36002,6 @@
 
     export interface MediaHubLinkSharingPolicyChangedType {
       description: string;
-    }
-
-    /**
-     * Replay project
-     */
-    export interface MediaHubProjectLogInfo {
-      /**
-       * Replay project name.
-       */
-      project_name: string;
-      /**
-       * Replay project ID.
-       */
-      project_id?: string;
     }
 
     export interface MediaHubProjectRoleEditor {
@@ -36487,13 +36026,9 @@
     export type MediaHubProjectRole = MediaHubProjectRoleEditor | MediaHubProjectRoleOwner | MediaHubProjectRoleReviewer | MediaHubProjectRoleOther;
 
     /**
-     * Added member to Replay project.
+     * Added member to Media Hub project.
      */
     export interface MediaHubProjectTeamAddDetails {
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamAddType {
@@ -36501,13 +36036,9 @@
     }
 
     /**
-     * Removed member from Replay project.
+     * Removed member from Media Hub project.
      */
     export interface MediaHubProjectTeamDeleteDetails {
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamDeleteType {
@@ -36515,7 +36046,7 @@
     }
 
     /**
-     * Changed member role in Replay project.
+     * Changed member role in Media Hub project.
      */
     export interface MediaHubProjectTeamRoleChangedDetails {
       /**
@@ -36526,10 +36057,6 @@
        * New Media Hub project role.
        */
       new_role: MediaHubProjectRole;
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamRoleChangedType {
@@ -36558,7 +36085,7 @@
     export type MediaHubSharedLinkAudience = MediaHubSharedLinkAudienceNoOne | MediaHubSharedLinkAudiencePublic | MediaHubSharedLinkAudienceTeamOnly | MediaHubSharedLinkAudienceOther;
 
     /**
-     * Changed Replay shared link audience.
+     * Changed Media Hub shared link audience.
      */
     export interface MediaHubSharedLinkAudienceChangedDetails {
       /**
@@ -36573,10 +36100,6 @@
        * New Media Hub shared link audience.
        */
       new_value: MediaHubSharedLinkAudience;
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkAudienceChangedType {
@@ -36584,7 +36107,7 @@
     }
 
     /**
-     * Created Replay shared link.
+     * Created Media Hub shared link.
      */
     export interface MediaHubSharedLinkCreatedDetails {
       /**
@@ -36595,10 +36118,6 @@
        * Media Hub shared link audience.
        */
       audience: MediaHubSharedLinkAudience;
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkCreatedType {
@@ -36623,7 +36142,7 @@
     export type MediaHubSharedLinkDownloadSetting = MediaHubSharedLinkDownloadSettingDisabled | MediaHubSharedLinkDownloadSettingEnabled | MediaHubSharedLinkDownloadSettingOther;
 
     /**
-     * Changed Replay shared link download setting.
+     * Changed Media Hub shared link download setting.
      */
     export interface MediaHubSharedLinkDownloadSettingChangedDetails {
       /**
@@ -36638,10 +36157,6 @@
        * New Media Hub shared link download setting.
        */
       new_value: MediaHubSharedLinkDownloadSetting;
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkDownloadSettingChangedType {
@@ -36649,17 +36164,13 @@
     }
 
     /**
-     * Revoked Replay shared link.
+     * Revoked Media Hub shared link.
      */
     export interface MediaHubSharedLinkRevokedDetails {
       /**
        * Media Hub shared link target type.
        */
       target_type: MediaHubSharedLinkTargetType;
-      /**
-       * Replay project.
-       */
-      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkRevokedType {
@@ -36897,16 +36408,6 @@
     }
 
     export interface MemberDeleteProfilePhotoType {
-      description: string;
-    }
-
-    /**
-     * Admin browsed a team member's folder contents.
-     */
-    export interface MemberFolderContentsAccessedDetails {
-    }
-
-    export interface MemberFolderContentsAccessedType {
       description: string;
     }
 
@@ -39119,104 +38620,6 @@
     }
 
     /**
-     * Added collaborators via Dropbox Protect.
-     */
-    export interface ProtectActionAddCollaboratorDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionAddCollaboratorType {
-      description: string;
-    }
-
-    /**
-     * Added a link via Dropbox Protect.
-     */
-    export interface ProtectActionAddLinkDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionAddLinkType {
-      description: string;
-    }
-
-    /**
-     * Deleted content via Dropbox Protect.
-     */
-    export interface ProtectActionDeleteDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionDeleteType {
-      description: string;
-    }
-
-    /**
-     * Exported content via Dropbox Protect.
-     */
-    export interface ProtectActionExportDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionExportType {
-      description: string;
-    }
-
-    /**
-     * Removed collaborators via Dropbox Protect.
-     */
-    export interface ProtectActionRemoveCollaboratorDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionRemoveCollaboratorType {
-      description: string;
-    }
-
-    /**
-     * Removed a link via Dropbox Protect.
-     */
-    export interface ProtectActionRemoveLinkDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionRemoveLinkType {
-      description: string;
-    }
-
-    /**
-     * Stopped sharing content via Dropbox Protect.
-     */
-    export interface ProtectActionStopSharingDetails {
-      /**
-       * Action ID.
-       */
-      action_id: string;
-    }
-
-    export interface ProtectActionStopSharingType {
-      description: string;
-    }
-
-    /**
      * Modified Protect internal domains list.
      */
     export interface ProtectInternalDomainsChangedDetails {
@@ -39231,62 +38634,6 @@
     }
 
     export interface ProtectInternalDomainsChangedType {
-      description: string;
-    }
-
-    /**
-     * Activated a Dropbox Protect policy.
-     */
-    export interface ProtectPolicyActivatedDetails {
-      /**
-       * Policy ID.
-       */
-      policy_id: string;
-    }
-
-    export interface ProtectPolicyActivatedType {
-      description: string;
-    }
-
-    /**
-     * Deactivated a Dropbox Protect policy.
-     */
-    export interface ProtectPolicyDeactivatedDetails {
-      /**
-       * Policy ID.
-       */
-      policy_id: string;
-    }
-
-    export interface ProtectPolicyDeactivatedType {
-      description: string;
-    }
-
-    /**
-     * Scheduled a Dropbox Protect policy.
-     */
-    export interface ProtectPolicyScheduledDetails {
-      /**
-       * Policy ID.
-       */
-      policy_id: string;
-    }
-
-    export interface ProtectPolicyScheduledType {
-      description: string;
-    }
-
-    /**
-     * Updated a Dropbox Protect policy.
-     */
-    export interface ProtectPolicyUpdatedDetails {
-      /**
-       * Policy ID.
-       */
-      policy_id: string;
-    }
-
-    export interface ProtectPolicyUpdatedType {
       description: string;
     }
 

--- a/types/dropbox_types.d.ts
+++ b/types/dropbox_types.d.ts
@@ -7421,11 +7421,20 @@
       end_time?: number;
     }
 
+    /**
+     * An unexpected, typically transient, server-side failure. The string is a
+     * human-readable message; retrying with backoff may succeed.
+     */
     export interface ContentApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
+    /**
+     * The request could not be processed as supplied (a problem with the
+     * caller's input). The string is a human-readable message; retrying the
+     * same request will not help.
+     */
     export interface ContentApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7469,63 +7478,44 @@
       '.tag': 'other';
     }
 
+    /**
+     * Reason a transcript job failed. Returned in the `failed` variant of
+     * `GetTranscriptAsyncCheckResult`. This is a semantic error union: the HTTP
+     * status of the poll request itself is unaffected (a poll that surfaces a
+     * failed job is still a normal successful poll response). Callers should
+     * branch on the variant.
+     */
     export type ContentApiV2Error = ContentApiV2ErrorServerError | ContentApiV2ErrorUserError | ContentApiV2ErrorMediaDurationError | ContentApiV2ErrorNoAudioError | ContentApiV2ErrorLinkDownloadDisabledError | ContentApiV2ErrorSharedLinkPasswordProtected | ContentApiV2ErrorLimitExceededError | ContentApiV2ErrorNotFoundError | ContentApiV2ErrorIsAFolderError | ContentApiV2ErrorOther;
 
-    export interface ErrorCodeUnknownError {
-      '.tag': 'unknown_error';
-    }
-
     /**
-     * 400
+     * A Dropbox-issued file id (format: "id:<id>") for a file the authenticated
+     * user has access to.
      */
-    export interface ErrorCodeBadRequest {
-      '.tag': 'bad_request';
-    }
-
-    /**
-     * 409
-     */
-    export interface ErrorCodeApiError {
-      '.tag': 'api_error';
-    }
-
-    /**
-     * 403
-     */
-    export interface ErrorCodeAccessError {
-      '.tag': 'access_error';
-    }
-
-    /**
-     * 429
-     */
-    export interface ErrorCodeRatelimitError {
-      '.tag': 'ratelimit_error';
-    }
-
-    /**
-     * 503
-     */
-    export interface ErrorCodeUnavailable {
-      '.tag': 'unavailable';
-    }
-
-    export interface ErrorCodeOther {
-      '.tag': 'other';
-    }
-
-    export type ErrorCode = ErrorCodeUnknownError | ErrorCodeBadRequest | ErrorCodeApiError | ErrorCodeAccessError | ErrorCodeRatelimitError | ErrorCodeUnavailable | ErrorCodeOther;
-
     export interface FileIdOrUrlFileId {
       '.tag': 'file_id';
       file_id: string;
     }
 
+    /**
+     * Either a Dropbox shared link (www.dropbox.com) or an external HTTP or
+     * HTTPS URL pointing to a supported file. - Dropbox shared links are
+     * resolved internally using the caller's authenticated identity and the
+     * link's visibility / download settings. They therefore require an
+     * authenticated user context (anonymous `url` requests against Dropbox
+     * links are rejected with an `access_error`). Links protected by a password
+     * are rejected with `shared_link_password_protected`; links with downloads
+     * disabled are rejected with `link_download_disabled_error`. - External
+     * URLs are fetched through the backend's egress proxy and must point at a
+     * supported file extension.
+     */
     export interface FileIdOrUrlUrl {
       '.tag': 'url';
       url: string;
     }
 
+    /**
+     * An absolute Dropbox path, e.g. "/folder/example.pdf".
+     */
     export interface FileIdOrUrlPath {
       '.tag': 'path';
       path: string;
@@ -7545,21 +7535,9 @@
     export interface GetMarkdownArgs {
       /**
        * Identifier of the document to convert. Callers must set exactly one of
-       * the oneof variants: - file_id: a Dropbox-issued file id (format:
-       * "id:<id>") for a file the authenticated user has access to. - path: an
-       * absolute Dropbox path, e.g. "/folder/report.docx". - url: either a
-       * Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
-       * to a supported document file. - Dropbox shared links are resolved
-       * internally using the caller's authenticated identity and the link's
-       * visibility / download settings. They therefore require an authenticated
-       * user context (anonymous `url` requests against Dropbox links are
-       * rejected with an `ACCESS_ERROR`). Links protected by a password are
-       * rejected with `shared_link_password_protected`; links with downloads
-       * disabled are rejected with `link_download_disabled_error`. - External
-       * URLs are fetched over HTTPS through the backend's egress proxy and must
-       * point at a supported document file extension. The referenced file must
-       * be a document in a supported format; requests against unsupported
-       * formats return `unsupported_format_error`.
+       * the `FileIdOrUrl` variants. The referenced file must be a document in a
+       * supported format (see the route description for the list); requests
+       * against unsupported formats return `unsupported_format_error`.
        */
       file_id_or_url?: FileIdOrUrl;
       /**
@@ -7580,8 +7558,9 @@
       '.tag': 'complete';
     }
 
-    export interface GetMarkdownAsyncCheckResultFailed extends GetMarkdownAsyncError {
+    export interface GetMarkdownAsyncCheckResultFailed {
       '.tag': 'failed';
+      failed: MarkdownConversionApiV2Error;
     }
 
     export interface GetMarkdownAsyncCheckResultOther {
@@ -7592,19 +7571,6 @@
      * Result type for EventBus async check
      */
     export type GetMarkdownAsyncCheckResult = GetMarkdownAsyncCheckResultInProgress | GetMarkdownAsyncCheckResultComplete | GetMarkdownAsyncCheckResultFailed | GetMarkdownAsyncCheckResultOther;
-
-    export interface GetMarkdownAsyncError {
-      /**
-       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
-       * Void, False, None), UnionField('bad_request', Void, False, None),
-       * UnionField('api_error', Void, False, None), UnionField('access_error',
-       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
-       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
-       * True, None)]), 'unknown_error').
-       */
-      error_code?: ErrorCode;
-      error_details?: MarkdownConversionApiV2Error;
-    }
 
     export interface GetMarkdownResult {
       /**
@@ -7621,22 +7587,11 @@
     export interface GetMetadataArgs {
       /**
        * Identifier of the file to extract metadata from. Callers must set
-       * exactly one of the oneof variants: - file_id: a Dropbox-issued file id
-       * (format: "id:<id>") for a file the authenticated user has access to. -
-       * path: an absolute Dropbox path, e.g. "/folder/photo.jpg". - url: either
-       * a Dropbox shared link (www.dropbox.com) or an external HTTPS URL
-       * pointing to a supported file. - Dropbox shared links are resolved
-       * internally using the caller's authenticated identity and the link's
-       * visibility / download settings. They therefore require an authenticated
-       * user context (anonymous `url` requests against Dropbox links are
-       * rejected with an `ACCESS_ERROR`). Links protected by a password are
-       * rejected with `shared_link_password_protected`; links with downloads
-       * disabled are rejected with `link_download_disabled_error`. - External
-       * URLs are fetched over HTTPS through the backend's egress proxy and must
-       * point at a supported file extension. The kind of metadata returned is
-       * determined by the file type: image files return EXIF metadata,
-       * audio/video files return media metadata, PDFs return PDF metadata, and
-       * MS Office documents (docx, pptx, xlsx) return Office metadata. Requests
+       * exactly one of the `FileIdOrUrl` variants. The kind of metadata
+       * returned is determined by the file type: image files return EXIF
+       * metadata, audio/video files return media metadata, PDFs return PDF
+       * metadata, and MS Office documents (docx, pptx, xlsx) return Office
+       * metadata. See the route description for the supported formats. Requests
        * against unsupported formats return `unsupported_format_error`.
        */
       file_id_or_url?: FileIdOrUrl;
@@ -7650,8 +7605,9 @@
       '.tag': 'complete';
     }
 
-    export interface GetMetadataAsyncCheckResultFailed extends GetMetadataAsyncError {
+    export interface GetMetadataAsyncCheckResultFailed {
       '.tag': 'failed';
+      failed: MetadataExtractionApiV2Error;
     }
 
     export interface GetMetadataAsyncCheckResultOther {
@@ -7662,19 +7618,6 @@
      * Result type for EventBus async check - must end in "CheckResult"
      */
     export type GetMetadataAsyncCheckResult = GetMetadataAsyncCheckResultInProgress | GetMetadataAsyncCheckResultComplete | GetMetadataAsyncCheckResultFailed | GetMetadataAsyncCheckResultOther;
-
-    export interface GetMetadataAsyncError {
-      /**
-       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
-       * Void, False, None), UnionField('bad_request', Void, False, None),
-       * UnionField('api_error', Void, False, None), UnionField('access_error',
-       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
-       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
-       * True, None)]), 'unknown_error').
-       */
-      error_code?: ErrorCode;
-      error_details?: MetadataExtractionApiV2Error;
-    }
 
     export interface GetMetadataResult {
       /**
@@ -7691,6 +7634,55 @@
     }
 
     /**
+     * Arguments for the asynchronous `get_text_async` route. Exactly one of
+     * `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
+     * identify the document whose plain-text content should be extracted.
+     */
+    export interface GetTextArgs {
+      /**
+       * Identifier of the document to extract text from. Callers must set
+       * exactly one of the `FileIdOrUrl` variants. Text extraction is supported
+       * for common document formats (Word, PowerPoint, Excel, PDF, RTF, and
+       * Dropbox document types); see the route description for the supported
+       * formats. Requests against unsupported formats return
+       * `unsupported_format_error`. NOTE: for the `url` variant, only Dropbox
+       * shared links (www.dropbox.com) are supported. External (non-Dropbox)
+       * URLs are not supported and return `unsupported_format_error`; import
+       * the file into Dropbox and reference it by `file_id` or `path` instead.
+       */
+      file_id_or_url?: FileIdOrUrl;
+    }
+
+    export interface GetTextAsyncCheckResultInProgress {
+      '.tag': 'in_progress';
+    }
+
+    export interface GetTextAsyncCheckResultComplete extends GetTextResult {
+      '.tag': 'complete';
+    }
+
+    export interface GetTextAsyncCheckResultFailed {
+      '.tag': 'failed';
+      failed: TextExtractionApiV2Error;
+    }
+
+    export interface GetTextAsyncCheckResultOther {
+      '.tag': 'other';
+    }
+
+    /**
+     * Result type for EventBus async check - must end in "CheckResult"
+     */
+    export type GetTextAsyncCheckResult = GetTextAsyncCheckResultInProgress | GetTextAsyncCheckResultComplete | GetTextAsyncCheckResultFailed | GetTextAsyncCheckResultOther;
+
+    export interface GetTextResult {
+      /**
+       * Defaults to .
+       */
+      text?: string;
+    }
+
+    /**
      * Arguments for the asynchronous `get_transcript_async` route. Exactly one
      * of `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
      * identify the audio or video asset to transcribe.
@@ -7698,28 +7690,16 @@
     export interface GetTranscriptArgs {
       /**
        * Identifier of the media asset to transcribe. Callers must set exactly
-       * one of the oneof variants: - file_id: a Dropbox-issued file id (format:
-       * "id:<id>") for a file the authenticated user has access to. - path: an
-       * absolute Dropbox path, e.g. "/folder/recording.mp4". - url: either a
-       * Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
-       * to a supported audio/video file. - Dropbox shared links are resolved
-       * internally using the caller's authenticated identity and the link's
-       * visibility / download settings. They therefore require an authenticated
-       * user context (anonymous `url` requests against Dropbox links are
-       * rejected with an `ACCESS_ERROR`). Links protected by a password are
-       * rejected with `shared_link_password_protected`; links with downloads
-       * disabled are rejected with `link_download_disabled_error`. - External
-       * URLs are fetched over HTTPS through the backend's egress proxy and must
-       * point at a supported audio/video file extension. The referenced asset
-       * must be an audio or video file in a supported format; requests against
-       * files with no audio track return a `no_audio_error`.
+       * one of the `FileIdOrUrl` variants. The referenced asset must be an
+       * audio or video file in a supported format (see the route description
+       * for the list); requests against files with no audio track return a
+       * `no_audio_error`.
        */
       file_id_or_url?: FileIdOrUrl;
       /**
-       * Defaults to TagRef(Union('TimestampLevel', [UnionField('unknown', Void,
-       * False, None), UnionField('sentence', Void, False, None),
-       * UnionField('word', Void, False, None), UnionField('other', Void, True,
-       * None)]), 'unknown').
+       * Defaults to TagRef(Union('TimestampLevel', [UnionField('sentence',
+       * Void, False, None), UnionField('word', Void, False, None),
+       * UnionField('other', Void, True, None)]), 'sentence').
        */
       timestamp_level?: TimestampLevel;
       /**
@@ -7740,8 +7720,9 @@
       '.tag': 'complete';
     }
 
-    export interface GetTranscriptAsyncCheckResultFailed extends GetTranscriptAsyncError {
+    export interface GetTranscriptAsyncCheckResultFailed {
       '.tag': 'failed';
+      failed: ContentApiV2Error;
     }
 
     export interface GetTranscriptAsyncCheckResultOther {
@@ -7753,19 +7734,6 @@
      */
     export type GetTranscriptAsyncCheckResult = GetTranscriptAsyncCheckResultInProgress | GetTranscriptAsyncCheckResultComplete | GetTranscriptAsyncCheckResultFailed | GetTranscriptAsyncCheckResultOther;
 
-    export interface GetTranscriptAsyncError {
-      /**
-       * Defaults to TagRef(Union('ErrorCode', [UnionField('unknown_error',
-       * Void, False, None), UnionField('bad_request', Void, False, None),
-       * UnionField('api_error', Void, False, None), UnionField('access_error',
-       * Void, False, None), UnionField('ratelimit_error', Void, False, None),
-       * UnionField('unavailable', Void, False, None), UnionField('other', Void,
-       * True, None)]), 'unknown_error').
-       */
-      error_code?: ErrorCode;
-      error_details?: ContentApiV2Error;
-    }
-
     export interface GetTranscriptResult {
       /**
        * The structured transcript produced for the requested media asset, with
@@ -7775,11 +7743,20 @@
       structured_transcript?: ApiStructuredTranscript;
     }
 
+    /**
+     * An unexpected, typically transient, server-side failure. The string is a
+     * human-readable message; retrying with backoff may succeed.
+     */
     export interface MarkdownConversionApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
+    /**
+     * The request could not be processed as supplied (a problem with the
+     * caller's input). The string is a human-readable message; retrying the
+     * same request will not help.
+     */
     export interface MarkdownConversionApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7823,6 +7800,13 @@
       '.tag': 'other';
     }
 
+    /**
+     * Reason a markdown conversion job failed. Returned in the `failed` variant
+     * of `GetMarkdownAsyncCheckResult`. This is a semantic error union: the
+     * HTTP status of the poll request itself is unaffected (a poll that
+     * surfaces a failed job is still a normal successful poll response).
+     * Callers should branch on the variant.
+     */
     export type MarkdownConversionApiV2Error = MarkdownConversionApiV2ErrorServerError | MarkdownConversionApiV2ErrorUserError | MarkdownConversionApiV2ErrorUnsupportedFormatError | MarkdownConversionApiV2ErrorLinkDownloadDisabledError | MarkdownConversionApiV2ErrorSharedLinkPasswordProtected | MarkdownConversionApiV2ErrorLimitExceededError | MarkdownConversionApiV2ErrorConversionFailureError | MarkdownConversionApiV2ErrorNotFoundError | MarkdownConversionApiV2ErrorIsAFolderError | MarkdownConversionApiV2ErrorOther;
 
     export interface MediaDurationError {
@@ -7832,11 +7816,20 @@
       limit?: number;
     }
 
+    /**
+     * An unexpected, typically transient, server-side failure. The string is a
+     * human-readable message; retrying with backoff may succeed.
+     */
     export interface MetadataExtractionApiV2ErrorServerError {
       '.tag': 'server_error';
       server_error: string;
     }
 
+    /**
+     * The request could not be processed as supplied (a problem with the
+     * caller's input). The string is a human-readable message; retrying the
+     * same request will not help.
+     */
     export interface MetadataExtractionApiV2ErrorUserError {
       '.tag': 'user_error';
       user_error: string;
@@ -7880,6 +7873,13 @@
       '.tag': 'other';
     }
 
+    /**
+     * Reason a metadata extraction job failed. Returned in the `failed` variant
+     * of `GetMetadataAsyncCheckResult`. This is a semantic error union: the
+     * HTTP status of the poll request itself is unaffected (a poll that
+     * surfaces a failed job is still a normal successful poll response).
+     * Callers should branch on the variant.
+     */
     export type MetadataExtractionApiV2Error = MetadataExtractionApiV2ErrorServerError | MetadataExtractionApiV2ErrorUserError | MetadataExtractionApiV2ErrorUnsupportedFormatError | MetadataExtractionApiV2ErrorLinkDownloadDisabledError | MetadataExtractionApiV2ErrorSharedLinkPasswordProtected | MetadataExtractionApiV2ErrorLimitExceededError | MetadataExtractionApiV2ErrorConversionFailureError | MetadataExtractionApiV2ErrorNotFoundError | MetadataExtractionApiV2ErrorIsAFolderError | MetadataExtractionApiV2ErrorOther;
 
     export interface MetadataTypeMetadataTypeUnknown {
@@ -7938,9 +7938,71 @@
      */
     export type OfficeFileType = OfficeFileTypeOfficeFiletypeUnknown | OfficeFileTypeOfficeFiletypeWord | OfficeFileTypeOfficeFiletypePowerpoint | OfficeFileTypeOfficeFiletypeExcel | OfficeFileTypeOther;
 
-    export interface TimestampLevelUnknown {
-      '.tag': 'unknown';
+    /**
+     * An unexpected, typically transient, server-side failure. The string is a
+     * human-readable message; retrying with backoff may succeed.
+     */
+    export interface TextExtractionApiV2ErrorServerError {
+      '.tag': 'server_error';
+      server_error: string;
     }
+
+    /**
+     * The request could not be processed as supplied (a problem with the
+     * caller's input). The string is a human-readable message; retrying the
+     * same request will not help.
+     */
+    export interface TextExtractionApiV2ErrorUserError {
+      '.tag': 'user_error';
+      user_error: string;
+    }
+
+    export interface TextExtractionApiV2ErrorUnsupportedFormatError {
+      '.tag': 'unsupported_format_error';
+    }
+
+    export interface TextExtractionApiV2ErrorLinkDownloadDisabledError {
+      '.tag': 'link_download_disabled_error';
+    }
+
+    export interface TextExtractionApiV2ErrorSharedLinkPasswordProtected {
+      '.tag': 'shared_link_password_protected';
+    }
+
+    export interface TextExtractionApiV2ErrorLimitExceededError {
+      '.tag': 'limit_exceeded_error';
+    }
+
+    export interface TextExtractionApiV2ErrorConversionFailureError {
+      '.tag': 'conversion_failure_error';
+    }
+
+    /**
+     * The referenced file does not exist or is not accessible.
+     */
+    export interface TextExtractionApiV2ErrorNotFoundError {
+      '.tag': 'not_found_error';
+    }
+
+    /**
+     * The target is a folder, not a file.
+     */
+    export interface TextExtractionApiV2ErrorIsAFolderError {
+      '.tag': 'is_a_folder_error';
+    }
+
+    export interface TextExtractionApiV2ErrorOther {
+      '.tag': 'other';
+    }
+
+    /**
+     * Reason a text extraction job failed. Returned in the `failed` variant of
+     * `GetTextAsyncCheckResult`. This is a semantic error union: the HTTP
+     * status of the poll request itself is unaffected (a poll that surfaces a
+     * failed job is still a normal successful poll response). Callers should
+     * branch on the variant.
+     */
+    export type TextExtractionApiV2Error = TextExtractionApiV2ErrorServerError | TextExtractionApiV2ErrorUserError | TextExtractionApiV2ErrorUnsupportedFormatError | TextExtractionApiV2ErrorLinkDownloadDisabledError | TextExtractionApiV2ErrorSharedLinkPasswordProtected | TextExtractionApiV2ErrorLimitExceededError | TextExtractionApiV2ErrorConversionFailureError | TextExtractionApiV2ErrorNotFoundError | TextExtractionApiV2ErrorIsAFolderError | TextExtractionApiV2ErrorOther;
 
     export interface TimestampLevelSentence {
       '.tag': 'sentence';
@@ -7954,7 +8016,7 @@
       '.tag': 'other';
     }
 
-    export type TimestampLevel = TimestampLevelUnknown | TimestampLevelSentence | TimestampLevelWord | TimestampLevelOther;
+    export type TimestampLevel = TimestampLevelSentence | TimestampLevelWord | TimestampLevelOther;
 
     export interface metadata_unionExif extends ApiExifMetadata {
       '.tag': 'exif';
@@ -12026,7 +12088,7 @@
        * link's access level specified in the `link_access_level` field of
        * `LinkPermissions`. This is used in conjunction with team policies and
        * shared folder policies to determine the final effective audience type
-       * in the `effective_audience` field of `LinkPermissions.
+       * in the `effective_audience` field of `LinkPermissions`.
        */
       audience?: LinkAudience;
       /**
@@ -12998,6 +13060,159 @@
      * Base error that all errors for existing team folders should extend.
      */
     export type BaseTeamFolderError = BaseTeamFolderErrorAccessError | BaseTeamFolderErrorStatusError | BaseTeamFolderErrorTeamSharedDropboxError | BaseTeamFolderErrorOther;
+
+    /**
+     * Launches one action-specific bulk suspend job.
+     */
+    export interface BulkSuspendArg {
+      /**
+       * Must contain between 1 and 500 targets. The launch handler also rejects
+       * duplicate client item IDs and duplicate member selectors.
+       */
+      members: Array<BulkSuspendMemberTarget>;
+    }
+
+    export interface BulkSuspendComplete {
+      requested: number;
+      suspended: number;
+      failed: number;
+      unknown: number;
+      report_delivery: BulkSuspendReportDeliveryStatus;
+    }
+
+    export interface BulkSuspendErrorInvalidRequest {
+      '.tag': 'invalid_request';
+    }
+
+    export interface BulkSuspendErrorTooManyMembers {
+      '.tag': 'too_many_members';
+    }
+
+    export interface BulkSuspendErrorDuplicateClientItemId {
+      '.tag': 'duplicate_client_item_id';
+    }
+
+    export interface BulkSuspendErrorDuplicateTeamMemberId {
+      '.tag': 'duplicate_team_member_id';
+    }
+
+    export interface BulkSuspendErrorActingAdmin {
+      '.tag': 'acting_admin';
+    }
+
+    export interface BulkSuspendErrorLastAdmin {
+      '.tag': 'last_admin';
+    }
+
+    export interface BulkSuspendErrorOther {
+      '.tag': 'other';
+    }
+
+    /**
+     * A typed launch rejection. Authorization failures continue to use the API
+     * v2 authentication/permission error surface.
+     */
+    export type BulkSuspendError = BulkSuspendErrorInvalidRequest | BulkSuspendErrorTooManyMembers | BulkSuspendErrorDuplicateClientItemId | BulkSuspendErrorDuplicateTeamMemberId | BulkSuspendErrorActingAdmin | BulkSuspendErrorLastAdmin | BulkSuspendErrorOther;
+
+    export interface BulkSuspendJobStatusComplete extends BulkSuspendComplete {
+      '.tag': 'complete';
+    }
+
+    export interface BulkSuspendJobStatusFailed {
+      '.tag': 'failed';
+      failed: BulkSuspendTaskFailure;
+    }
+
+    export interface BulkSuspendJobStatusOther {
+      '.tag': 'other';
+    }
+
+    /**
+     * Coarse job state. Live row progress and report contents are intentionally
+     * omitted; callers receive row details in the terminal email report.
+     */
+    export type BulkSuspendJobStatus = async.PollResultBase | BulkSuspendJobStatusComplete | BulkSuspendJobStatusFailed | BulkSuspendJobStatusOther;
+
+    /**
+     * One member selected for suspension. The opaque client item ID correlates
+     * the eventual report row with the caller's input without sending CSV data.
+     */
+    export interface BulkSuspendMemberTarget {
+      client_item_id: string;
+      suspend_arg: MembersDeactivateArg;
+    }
+
+    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusUnspecified {
+      '.tag': 'bulk_suspend_report_delivery_status_unspecified';
+    }
+
+    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusPending {
+      '.tag': 'bulk_suspend_report_delivery_status_pending';
+    }
+
+    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusDelivered {
+      '.tag': 'bulk_suspend_report_delivery_status_delivered';
+    }
+
+    export interface BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusFailed {
+      '.tag': 'bulk_suspend_report_delivery_status_failed';
+    }
+
+    export interface BulkSuspendReportDeliveryStatusOther {
+      '.tag': 'other';
+    }
+
+    export type BulkSuspendReportDeliveryStatus = BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusUnspecified | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusPending | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusDelivered | BulkSuspendReportDeliveryStatusBulkSuspendReportDeliveryStatusFailed | BulkSuspendReportDeliveryStatusOther;
+
+    export interface BulkSuspendRowFailureProtectedActingAdmin {
+      '.tag': 'protected_acting_admin';
+    }
+
+    export interface BulkSuspendRowFailurePermissionChanged {
+      '.tag': 'permission_changed';
+    }
+
+    export interface BulkSuspendRowFailureSuspendFailed {
+      '.tag': 'suspend_failed';
+    }
+
+    /**
+     * Stable machine-readable reasons used by the terminal row report.
+     */
+    export type BulkSuspendRowFailure = MembersSuspendError | BulkSuspendRowFailureProtectedActingAdmin | BulkSuspendRowFailurePermissionChanged | BulkSuspendRowFailureSuspendFailed;
+
+    export interface BulkSuspendRowOutcomeSuspended {
+      '.tag': 'suspended';
+    }
+
+    export interface BulkSuspendRowOutcomeFailed {
+      '.tag': 'failed';
+      failed: BulkSuspendRowFailure;
+    }
+
+    export interface BulkSuspendRowOutcomeUnknown {
+      '.tag': 'unknown';
+    }
+
+    export interface BulkSuspendRowOutcomeOther {
+      '.tag': 'other';
+    }
+
+    /**
+     * The terminal outcome for one requested member. Row outcomes are delivered
+     * in the report rather than embedded in the status response.
+     */
+    export type BulkSuspendRowOutcome = BulkSuspendRowOutcomeSuspended | BulkSuspendRowOutcomeFailed | BulkSuspendRowOutcomeUnknown | BulkSuspendRowOutcomeOther;
+
+    export interface BulkSuspendTaskFailureUnusableResult {
+      '.tag': 'unusable_result';
+    }
+
+    export interface BulkSuspendTaskFailureOther {
+      '.tag': 'other';
+    }
+
+    export type BulkSuspendTaskFailure = BulkSuspendTaskFailureUnusableResult | BulkSuspendTaskFailureOther;
 
     /**
      * A maximum of 1000 users can be set for a single call.
@@ -16872,7 +17087,15 @@
 
     export type TeamFolderAccessError = TeamFolderAccessErrorInvalidTeamFolderId | TeamFolderAccessErrorNoAccess | TeamFolderAccessErrorOther;
 
-    export type TeamFolderActivateError = BaseTeamFolderError;
+    /**
+     * The team has reached the maximum number of team folders allowed by its
+     * plan.
+     */
+    export interface TeamFolderActivateErrorFolderCountLimitExceeded {
+      '.tag': 'folder_count_limit_exceeded';
+    }
+
+    export type TeamFolderActivateError = BaseTeamFolderError | TeamFolderActivateErrorFolderCountLimitExceeded;
 
     export interface TeamFolderArchiveArg extends TeamFolderIdArg {
       /**
@@ -17140,7 +17363,15 @@
 
     export type TeamFolderRenameError = BaseTeamFolderError | TeamFolderRenameErrorInvalidFolderName | TeamFolderRenameErrorFolderNameAlreadyUsed | TeamFolderRenameErrorFolderNameReserved;
 
-    export type TeamFolderRestoreError = BaseTeamFolderError;
+    /**
+     * The team has reached the maximum number of team folders allowed by its
+     * plan.
+     */
+    export interface TeamFolderRestoreErrorFolderCountLimitExceeded {
+      '.tag': 'folder_count_limit_exceeded';
+    }
+
+    export type TeamFolderRestoreError = BaseTeamFolderError | TeamFolderRestoreErrorFolderCountLimitExceeded;
 
     /**
      * The team folder and sub-folders are available to all members.
@@ -22569,6 +22800,10 @@
       '.tag': 'member_delete_profile_photo_details';
     }
 
+    export interface EventDetailsMemberFolderContentsAccessedDetails extends MemberFolderContentsAccessedDetails {
+      '.tag': 'member_folder_contents_accessed_details';
+    }
+
     export interface EventDetailsMemberPermanentlyDeleteAccountContentsDetails extends MemberPermanentlyDeleteAccountContentsDetails {
       '.tag': 'member_permanently_delete_account_contents_details';
     }
@@ -22837,8 +23072,52 @@
       '.tag': 'password_reset_all_details';
     }
 
+    export interface EventDetailsProtectActionAddCollaboratorDetails extends ProtectActionAddCollaboratorDetails {
+      '.tag': 'protect_action_add_collaborator_details';
+    }
+
+    export interface EventDetailsProtectActionAddLinkDetails extends ProtectActionAddLinkDetails {
+      '.tag': 'protect_action_add_link_details';
+    }
+
+    export interface EventDetailsProtectActionDeleteDetails extends ProtectActionDeleteDetails {
+      '.tag': 'protect_action_delete_details';
+    }
+
+    export interface EventDetailsProtectActionExportDetails extends ProtectActionExportDetails {
+      '.tag': 'protect_action_export_details';
+    }
+
+    export interface EventDetailsProtectActionRemoveCollaboratorDetails extends ProtectActionRemoveCollaboratorDetails {
+      '.tag': 'protect_action_remove_collaborator_details';
+    }
+
+    export interface EventDetailsProtectActionRemoveLinkDetails extends ProtectActionRemoveLinkDetails {
+      '.tag': 'protect_action_remove_link_details';
+    }
+
+    export interface EventDetailsProtectActionStopSharingDetails extends ProtectActionStopSharingDetails {
+      '.tag': 'protect_action_stop_sharing_details';
+    }
+
     export interface EventDetailsProtectInternalDomainsChangedDetails extends ProtectInternalDomainsChangedDetails {
       '.tag': 'protect_internal_domains_changed_details';
+    }
+
+    export interface EventDetailsProtectPolicyActivatedDetails extends ProtectPolicyActivatedDetails {
+      '.tag': 'protect_policy_activated_details';
+    }
+
+    export interface EventDetailsProtectPolicyDeactivatedDetails extends ProtectPolicyDeactivatedDetails {
+      '.tag': 'protect_policy_deactivated_details';
+    }
+
+    export interface EventDetailsProtectPolicyScheduledDetails extends ProtectPolicyScheduledDetails {
+      '.tag': 'protect_policy_scheduled_details';
+    }
+
+    export interface EventDetailsProtectPolicyUpdatedDetails extends ProtectPolicyUpdatedDetails {
+      '.tag': 'protect_policy_updated_details';
     }
 
     export interface EventDetailsClassificationCreateReportDetails extends ClassificationCreateReportDetails {
@@ -24220,7 +24499,7 @@
     /**
      * Additional fields depending on the event type.
      */
-    export type EventDetails = EventDetailsAdminAlertingAlertStateChangedDetails | EventDetailsAdminAlertingChangedAlertConfigDetails | EventDetailsAdminAlertingTriggeredAlertDetails | EventDetailsRansomwareRestoreProcessCompletedDetails | EventDetailsRansomwareRestoreProcessStartedDetails | EventDetailsAppBlockedByPermissionsDetails | EventDetailsAppLinkTeamDetails | EventDetailsAppLinkUserDetails | EventDetailsAppUnlinkTeamDetails | EventDetailsAppUnlinkUserDetails | EventDetailsIntegrationConnectedDetails | EventDetailsIntegrationDisconnectedDetails | EventDetailsFileAddCommentDetails | EventDetailsFileChangeCommentSubscriptionDetails | EventDetailsFileDeleteCommentDetails | EventDetailsFileEditCommentDetails | EventDetailsFileLikeCommentDetails | EventDetailsFileResolveCommentDetails | EventDetailsFileUnlikeCommentDetails | EventDetailsFileUnresolveCommentDetails | EventDetailsDashAddedCommentToStackDetails | EventDetailsDashAddedConnectorDetails | EventDetailsDashAddedLinkToStackDetails | EventDetailsDashAddedTeamEmailDomainAllowlistDetails | EventDetailsDashAdminAddedOrgWideConnectorDetails | EventDetailsDashAdminDisabledConnectorDetails | EventDetailsDashAdminEnabledConnectorDetails | EventDetailsDashAdminRemovedOrgWideConnectorDetails | EventDetailsDashArchivedStackDetails | EventDetailsDashChangedAudienceOfSharedLinkToStackDetails | EventDetailsDashClonedStackDetails | EventDetailsDashConnectorToolsCallDetails | EventDetailsDashCreatedStackDetails | EventDetailsDashDeletedCommentFromStackDetails | EventDetailsDashDeletedStackDetails | EventDetailsDashEditedCommentInStackDetails | EventDetailsDashExternalUserOpenedStackDetails | EventDetailsDashFirstLaunchedDesktopDetails | EventDetailsDashFirstLaunchedExtensionDetails | EventDetailsDashFirstLaunchedWebStartPageDetails | EventDetailsDashOpenedSharedLinkToStackDetails | EventDetailsDashOpenedStackDetails | EventDetailsDashPreviewOptOutStatusChangedDetails | EventDetailsDashRemovedConnectorDetails | EventDetailsDashRemovedLinkFromStackDetails | EventDetailsDashRemovedSharedLinkToStackDetails | EventDetailsDashRemovedTeamEmailDomainAllowlistDetails | EventDetailsDashRenamedStackDetails | EventDetailsDashSharedLinkToStackDetails | EventDetailsDashUnarchivedStackDetails | EventDetailsDashViewedCompanyStackDetails | EventDetailsDashViewedExternalAiActivityReportDetails | EventDetailsGovernancePolicyAddFoldersDetails | EventDetailsGovernancePolicyAddFolderFailedDetails | EventDetailsGovernancePolicyContentDisposedDetails | EventDetailsGovernancePolicyCreateDetails | EventDetailsGovernancePolicyDeleteDetails | EventDetailsGovernancePolicyEditDetailsDetails | EventDetailsGovernancePolicyEditDurationDetails | EventDetailsGovernancePolicyExportCreatedDetails | EventDetailsGovernancePolicyExportRemovedDetails | EventDetailsGovernancePolicyRemoveFoldersDetails | EventDetailsGovernancePolicyReportCreatedDetails | EventDetailsGovernancePolicyZipPartDownloadedDetails | EventDetailsLegalHoldsActivateAHoldDetails | EventDetailsLegalHoldsAddMembersDetails | EventDetailsLegalHoldsChangeHoldDetailsDetails | EventDetailsLegalHoldsChangeHoldNameDetails | EventDetailsLegalHoldsExportAHoldDetails | EventDetailsLegalHoldsExportCancelledDetails | EventDetailsLegalHoldsExportDownloadedDetails | EventDetailsLegalHoldsExportRemovedDetails | EventDetailsLegalHoldsReleaseAHoldDetails | EventDetailsLegalHoldsRemoveMembersDetails | EventDetailsLegalHoldsReportAHoldDetails | EventDetailsDeviceChangeIpDesktopDetails | EventDetailsDeviceChangeIpMobileDetails | EventDetailsDeviceChangeIpWebDetails | EventDetailsDeviceDeleteOnUnlinkFailDetails | EventDetailsDeviceDeleteOnUnlinkSuccessDetails | EventDetailsDeviceLinkFailDetails | EventDetailsDeviceLinkSuccessDetails | EventDetailsDeviceManagementDisabledDetails | EventDetailsDeviceManagementEnabledDetails | EventDetailsDeviceSyncBackupStatusChangedDetails | EventDetailsDeviceUnlinkDetails | EventDetailsDropboxPasswordsExportedDetails | EventDetailsDropboxPasswordsNewDeviceEnrolledDetails | EventDetailsEmmRefreshAuthTokenDetails | EventDetailsExternalDriveBackupEligibilityStatusCheckedDetails | EventDetailsExternalDriveBackupStatusChangedDetails | EventDetailsAccountCaptureChangeAvailabilityDetails | EventDetailsAccountCaptureMigrateAccountDetails | EventDetailsAccountCaptureNotificationEmailsSentDetails | EventDetailsAccountCaptureRelinquishAccountDetails | EventDetailsDisabledDomainInvitesDetails | EventDetailsDomainInvitesApproveRequestToJoinTeamDetails | EventDetailsDomainInvitesDeclineRequestToJoinTeamDetails | EventDetailsDomainInvitesEmailExistingUsersDetails | EventDetailsDomainInvitesRequestToJoinTeamDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToNoDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToYesDetails | EventDetailsDomainVerificationAddDomainFailDetails | EventDetailsDomainVerificationAddDomainSuccessDetails | EventDetailsDomainVerificationRemoveDomainDetails | EventDetailsEnabledDomainInvitesDetails | EventDetailsEncryptedFolderCancelTeamKeyRotationDetails | EventDetailsEncryptedFolderEnrollBackupKeyDetails | EventDetailsEncryptedFolderEnrollClientDetails | EventDetailsEncryptedFolderEnrollTeamDetails | EventDetailsEncryptedFolderFinishTeamUnenrollmentDetails | EventDetailsEncryptedFolderInitTeamKeyRotationDetails | EventDetailsEncryptedFolderInitTeamUnenrollmentDetails | EventDetailsEncryptedFolderRemoveBackupKeyDetails | EventDetailsEncryptedFolderRotateTeamKeyDetails | EventDetailsEncryptedFolderUnenrollClientDetails | EventDetailsTeamEncryptionKeyActivateKeyDetails | EventDetailsTeamEncryptionKeyCancelKeyDeletionDetails | EventDetailsTeamEncryptionKeyCreateKeyDetails | EventDetailsTeamEncryptionKeyDeactivateKeyDetails | EventDetailsTeamEncryptionKeyDeleteKeyDetails | EventDetailsTeamEncryptionKeyDisableKeyDetails | EventDetailsTeamEncryptionKeyEnableKeyDetails | EventDetailsTeamEncryptionKeyRotateKeyDetails | EventDetailsTeamEncryptionKeyScheduleKeyDeletionDetails | EventDetailsApplyNamingConventionDetails | EventDetailsCreateFolderDetails | EventDetailsFileAddDetails | EventDetailsFileAddFromAutomationDetails | EventDetailsFileCopyDetails | EventDetailsFileDeleteDetails | EventDetailsFileDownloadDetails | EventDetailsFileEditDetails | EventDetailsFileGetCopyReferenceDetails | EventDetailsFileLockingLockStatusChangedDetails | EventDetailsFileMoveDetails | EventDetailsFilePermanentlyDeleteDetails | EventDetailsFilePreviewDetails | EventDetailsFileRenameDetails | EventDetailsFileRestoreDetails | EventDetailsFileRevertDetails | EventDetailsFileRollbackChangesDetails | EventDetailsFileSaveCopyReferenceDetails | EventDetailsFolderOverviewDescriptionChangedDetails | EventDetailsFolderOverviewItemPinnedDetails | EventDetailsFolderOverviewItemUnpinnedDetails | EventDetailsMediaHubFileDownloadedDetails | EventDetailsObjectLabelAddedDetails | EventDetailsObjectLabelRemovedDetails | EventDetailsObjectLabelUpdatedValueDetails | EventDetailsOrganizeFolderWithTidyDetails | EventDetailsReplayFileDeleteDetails | EventDetailsReplayFileDownloadedDetails | EventDetailsReplayTeamProjectCreatedDetails | EventDetailsRewindFolderDetails | EventDetailsUndoNamingConventionDetails | EventDetailsUndoOrganizeFolderWithTidyDetails | EventDetailsUserTagsAddedDetails | EventDetailsUserTagsRemovedDetails | EventDetailsEmailIngestReceiveFileDetails | EventDetailsFileRequestAutoCloseDetails | EventDetailsFileRequestChangeDetails | EventDetailsFileRequestCloseDetails | EventDetailsFileRequestCreateDetails | EventDetailsFileRequestDeleteDetails | EventDetailsFileRequestReceiveFileDetails | EventDetailsGroupAddExternalIdDetails | EventDetailsGroupAddMemberDetails | EventDetailsGroupChangeExternalIdDetails | EventDetailsGroupChangeManagementTypeDetails | EventDetailsGroupChangeMemberRoleDetails | EventDetailsGroupCreateDetails | EventDetailsGroupDeleteDetails | EventDetailsGroupDescriptionUpdatedDetails | EventDetailsGroupExternalSharingSettingOverrideChangedDetails | EventDetailsGroupJoinPolicyUpdatedDetails | EventDetailsGroupMovedDetails | EventDetailsGroupRemoveExternalIdDetails | EventDetailsGroupRemoveMemberDetails | EventDetailsGroupRenameDetails | EventDetailsAccountLockOrUnlockedDetails | EventDetailsEmmErrorDetails | EventDetailsGuestAdminSignedInViaTrustedTeamsDetails | EventDetailsGuestAdminSignedOutViaTrustedTeamsDetails | EventDetailsLoginFailDetails | EventDetailsLoginSuccessDetails | EventDetailsLogoutDetails | EventDetailsResellerSupportSessionEndDetails | EventDetailsResellerSupportSessionStartDetails | EventDetailsSignInAsSessionEndDetails | EventDetailsSignInAsSessionStartDetails | EventDetailsSsoErrorDetails | EventDetailsAddonAssignedDetails | EventDetailsAddonRemovedDetails | EventDetailsBackupAdminInvitationSentDetails | EventDetailsBackupInvitationOpenedDetails | EventDetailsCreateTeamInviteLinkDetails | EventDetailsDeleteTeamInviteLinkDetails | EventDetailsMemberAddExternalIdDetails | EventDetailsMemberAddNameDetails | EventDetailsMemberChangeAdminRoleDetails | EventDetailsMemberChangeEmailDetails | EventDetailsMemberChangeExternalIdDetails | EventDetailsMemberChangeMembershipTypeDetails | EventDetailsMemberChangeNameDetails | EventDetailsMemberChangeResellerRoleDetails | EventDetailsMemberChangeStatusDetails | EventDetailsMemberDeleteManualContactsDetails | EventDetailsMemberDeleteProfilePhotoDetails | EventDetailsMemberPermanentlyDeleteAccountContentsDetails | EventDetailsMemberRemoveExternalIdDetails | EventDetailsMemberSetProfilePhotoDetails | EventDetailsMemberSpaceLimitsAddCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeStatusDetails | EventDetailsMemberSpaceLimitsRemoveCustomQuotaDetails | EventDetailsMemberSuggestDetails | EventDetailsMemberTransferAccountContentsDetails | EventDetailsPendingSecondaryEmailAddedDetails | EventDetailsProductAssignedToMemberDetails | EventDetailsProductRemovedFromMemberDetails | EventDetailsSecondaryEmailDeletedDetails | EventDetailsSecondaryEmailVerifiedDetails | EventDetailsSecondaryMailsPolicyChangedDetails | EventDetailsBinderAddPageDetails | EventDetailsBinderAddSectionDetails | EventDetailsBinderRemovePageDetails | EventDetailsBinderRemoveSectionDetails | EventDetailsBinderRenamePageDetails | EventDetailsBinderRenameSectionDetails | EventDetailsBinderReorderPageDetails | EventDetailsBinderReorderSectionDetails | EventDetailsPaperContentAddMemberDetails | EventDetailsPaperContentAddToFolderDetails | EventDetailsPaperContentArchiveDetails | EventDetailsPaperContentCreateDetails | EventDetailsPaperContentPermanentlyDeleteDetails | EventDetailsPaperContentRemoveFromFolderDetails | EventDetailsPaperContentRemoveMemberDetails | EventDetailsPaperContentRenameDetails | EventDetailsPaperContentRestoreDetails | EventDetailsPaperDocAddCommentDetails | EventDetailsPaperDocChangeMemberRoleDetails | EventDetailsPaperDocChangeSharingPolicyDetails | EventDetailsPaperDocChangeSubscriptionDetails | EventDetailsPaperDocDeletedDetails | EventDetailsPaperDocDeleteCommentDetails | EventDetailsPaperDocDownloadDetails | EventDetailsPaperDocEditDetails | EventDetailsPaperDocEditCommentDetails | EventDetailsPaperDocFollowedDetails | EventDetailsPaperDocMentionDetails | EventDetailsPaperDocOwnershipChangedDetails | EventDetailsPaperDocRequestAccessDetails | EventDetailsPaperDocResolveCommentDetails | EventDetailsPaperDocRevertDetails | EventDetailsPaperDocSlackShareDetails | EventDetailsPaperDocTeamInviteDetails | EventDetailsPaperDocTrashedDetails | EventDetailsPaperDocUnresolveCommentDetails | EventDetailsPaperDocUntrashedDetails | EventDetailsPaperDocViewDetails | EventDetailsPaperExternalViewAllowDetails | EventDetailsPaperExternalViewDefaultTeamDetails | EventDetailsPaperExternalViewForbidDetails | EventDetailsPaperFolderChangeSubscriptionDetails | EventDetailsPaperFolderDeletedDetails | EventDetailsPaperFolderFollowedDetails | EventDetailsPaperFolderTeamInviteDetails | EventDetailsPaperPublishedLinkChangePermissionDetails | EventDetailsPaperPublishedLinkCreateDetails | EventDetailsPaperPublishedLinkDisabledDetails | EventDetailsPaperPublishedLinkViewDetails | EventDetailsPasswordChangeDetails | EventDetailsPasswordResetDetails | EventDetailsPasswordResetAllDetails | EventDetailsProtectInternalDomainsChangedDetails | EventDetailsClassificationCreateReportDetails | EventDetailsClassificationCreateReportFailDetails | EventDetailsEmmCreateExceptionsReportDetails | EventDetailsEmmCreateUsageReportDetails | EventDetailsExportMembersReportDetails | EventDetailsExportMembersReportFailDetails | EventDetailsExternalSharingCreateReportDetails | EventDetailsExternalSharingReportFailedDetails | EventDetailsMemberAccessDetailsCreateReportDetails | EventDetailsMemberAccessDetailsCreateReportFailedDetails | EventDetailsNoExpirationLinkGenCreateReportDetails | EventDetailsNoExpirationLinkGenReportFailedDetails | EventDetailsNoPasswordLinkGenCreateReportDetails | EventDetailsNoPasswordLinkGenReportFailedDetails | EventDetailsNoPasswordLinkViewCreateReportDetails | EventDetailsNoPasswordLinkViewReportFailedDetails | EventDetailsOutdatedLinkViewCreateReportDetails | EventDetailsOutdatedLinkViewReportFailedDetails | EventDetailsPaperAdminExportStartDetails | EventDetailsRansomwareAlertCreateReportDetails | EventDetailsRansomwareAlertCreateReportFailedDetails | EventDetailsSharedFoldersCreateReportDetails | EventDetailsSharedFoldersCreateReportFailedDetails | EventDetailsSmartSyncCreateAdminPrivilegeReportDetails | EventDetailsTeamActivityCreateReportDetails | EventDetailsTeamActivityCreateReportFailDetails | EventDetailsTeamFoldersCreateReportDetails | EventDetailsTeamFoldersCreateReportFailedDetails | EventDetailsTeamStorageCreateReportDetails | EventDetailsTeamStorageCreateReportFailedDetails | EventDetailsCollectionShareDetails | EventDetailsFileTransfersFileAddDetails | EventDetailsFileTransfersTransferDeleteDetails | EventDetailsFileTransfersTransferDownloadDetails | EventDetailsFileTransfersTransferSendDetails | EventDetailsFileTransfersTransferViewDetails | EventDetailsMediaHubProjectTeamAddDetails | EventDetailsMediaHubProjectTeamDeleteDetails | EventDetailsMediaHubProjectTeamRoleChangedDetails | EventDetailsMediaHubSharedLinkAudienceChangedDetails | EventDetailsMediaHubSharedLinkCreatedDetails | EventDetailsMediaHubSharedLinkDownloadSettingChangedDetails | EventDetailsMediaHubSharedLinkRevokedDetails | EventDetailsNoteAclInviteOnlyDetails | EventDetailsNoteAclLinkDetails | EventDetailsNoteAclTeamLinkDetails | EventDetailsNoteSharedDetails | EventDetailsNoteShareReceiveDetails | EventDetailsOpenNoteSharedDetails | EventDetailsReplayFileSharedLinkCreatedDetails | EventDetailsReplayFileSharedLinkModifiedDetails | EventDetailsReplayProjectTeamAddDetails | EventDetailsReplayProjectTeamDeleteDetails | EventDetailsSendAndTrackFileAddedDetails | EventDetailsSendAndTrackFileRenamedDetails | EventDetailsSendAndTrackFileUpdatedDetails | EventDetailsSendAndTrackLinkCreatedDetails | EventDetailsSendAndTrackLinkDeletedDetails | EventDetailsSendAndTrackLinkUpdatedDetails | EventDetailsSendAndTrackLinkViewedDetails | EventDetailsSendAndTrackRemovedFileAndAssociatedLinksDetails | EventDetailsSfAddGroupDetails | EventDetailsSfAllowNonMembersToViewSharedLinksDetails | EventDetailsSfExternalInviteWarnDetails | EventDetailsSfFbInviteDetails | EventDetailsSfFbInviteChangeRoleDetails | EventDetailsSfFbUninviteDetails | EventDetailsSfInviteGroupDetails | EventDetailsSfTeamGrantAccessDetails | EventDetailsSfTeamInviteDetails | EventDetailsSfTeamInviteChangeRoleDetails | EventDetailsSfTeamJoinDetails | EventDetailsSfTeamJoinFromOobLinkDetails | EventDetailsSfTeamUninviteDetails | EventDetailsSharedContentAddInviteesDetails | EventDetailsSharedContentAddLinkExpiryDetails | EventDetailsSharedContentAddLinkPasswordDetails | EventDetailsSharedContentAddMemberDetails | EventDetailsSharedContentChangeDownloadsPolicyDetails | EventDetailsSharedContentChangeInviteeRoleDetails | EventDetailsSharedContentChangeLinkAudienceDetails | EventDetailsSharedContentChangeLinkExpiryDetails | EventDetailsSharedContentChangeLinkPasswordDetails | EventDetailsSharedContentChangeMemberRoleDetails | EventDetailsSharedContentChangeViewerInfoPolicyDetails | EventDetailsSharedContentClaimInvitationDetails | EventDetailsSharedContentCopyDetails | EventDetailsSharedContentDownloadDetails | EventDetailsSharedContentRelinquishMembershipDetails | EventDetailsSharedContentRemoveInviteesDetails | EventDetailsSharedContentRemoveLinkExpiryDetails | EventDetailsSharedContentRemoveLinkPasswordDetails | EventDetailsSharedContentRemoveMemberDetails | EventDetailsSharedContentRequestAccessDetails | EventDetailsSharedContentRestoreInviteesDetails | EventDetailsSharedContentRestoreMemberDetails | EventDetailsSharedContentUnshareDetails | EventDetailsSharedContentViewDetails | EventDetailsSharedFolderChangeLinkPolicyDetails | EventDetailsSharedFolderChangeMembersInheritancePolicyDetails | EventDetailsSharedFolderChangeMembersManagementPolicyDetails | EventDetailsSharedFolderChangeMembersPolicyDetails | EventDetailsSharedFolderCreateDetails | EventDetailsSharedFolderDeclineInvitationDetails | EventDetailsSharedFolderMountDetails | EventDetailsSharedFolderNestDetails | EventDetailsSharedFolderTransferOwnershipDetails | EventDetailsSharedFolderUnmountDetails | EventDetailsSharedLinkAddExpiryDetails | EventDetailsSharedLinkChangeExpiryDetails | EventDetailsSharedLinkChangeVisibilityDetails | EventDetailsSharedLinkCopyDetails | EventDetailsSharedLinkCreateDetails | EventDetailsSharedLinkDisableDetails | EventDetailsSharedLinkDownloadDetails | EventDetailsSharedLinkRemoveExpiryDetails | EventDetailsSharedLinkRemoveVisitorDetails | EventDetailsSharedLinkSettingsAddExpirationDetails | EventDetailsSharedLinkSettingsAddPasswordDetails | EventDetailsSharedLinkSettingsAllowDownloadDisabledDetails | EventDetailsSharedLinkSettingsAllowDownloadEnabledDetails | EventDetailsSharedLinkSettingsChangeAudienceDetails | EventDetailsSharedLinkSettingsChangeExpirationDetails | EventDetailsSharedLinkSettingsChangePasswordDetails | EventDetailsSharedLinkSettingsRemoveExpirationDetails | EventDetailsSharedLinkSettingsRemovePasswordDetails | EventDetailsSharedLinkShareDetails | EventDetailsSharedLinkViewDetails | EventDetailsSharedNoteOpenedDetails | EventDetailsShmodelDisableDownloadsDetails | EventDetailsShmodelEnableDownloadsDetails | EventDetailsShmodelGroupShareDetails | EventDetailsShowcaseAccessGrantedDetails | EventDetailsShowcaseAddMemberDetails | EventDetailsShowcaseArchivedDetails | EventDetailsShowcaseCreatedDetails | EventDetailsShowcaseDeleteCommentDetails | EventDetailsShowcaseEditedDetails | EventDetailsShowcaseEditCommentDetails | EventDetailsShowcaseFileAddedDetails | EventDetailsShowcaseFileDownloadDetails | EventDetailsShowcaseFileRemovedDetails | EventDetailsShowcaseFileViewDetails | EventDetailsShowcasePermanentlyDeletedDetails | EventDetailsShowcasePostCommentDetails | EventDetailsShowcaseRemoveMemberDetails | EventDetailsShowcaseRenamedDetails | EventDetailsShowcaseRequestAccessDetails | EventDetailsShowcaseResolveCommentDetails | EventDetailsShowcaseRestoredDetails | EventDetailsShowcaseTrashedDetails | EventDetailsShowcaseTrashedDeprecatedDetails | EventDetailsShowcaseUnresolveCommentDetails | EventDetailsShowcaseUntrashedDetails | EventDetailsShowcaseUntrashedDeprecatedDetails | EventDetailsShowcaseViewDetails | EventDetailsSignSignatureRequestCanceledDetails | EventDetailsSignSignatureRequestCompletedDetails | EventDetailsSignSignatureRequestDeclinedDetails | EventDetailsSignSignatureRequestOpenedDetails | EventDetailsSignSignatureRequestReminderSentDetails | EventDetailsSignSignatureRequestSentDetails | EventDetailsSignTemplateCreatedDetails | EventDetailsSignTemplateSharedDetails | EventDetailsRiscSecurityEventDetails | EventDetailsSsoAddCertDetails | EventDetailsSsoAddLoginUrlDetails | EventDetailsSsoAddLogoutUrlDetails | EventDetailsSsoChangeCertDetails | EventDetailsSsoChangeLoginUrlDetails | EventDetailsSsoChangeLogoutUrlDetails | EventDetailsSsoChangeSamlIdentityModeDetails | EventDetailsSsoRemoveCertDetails | EventDetailsSsoRemoveLoginUrlDetails | EventDetailsSsoRemoveLogoutUrlDetails | EventDetailsTeamFolderChangeStatusDetails | EventDetailsTeamFolderCreateDetails | EventDetailsTeamFolderDowngradeDetails | EventDetailsTeamFolderPermanentlyDeleteDetails | EventDetailsTeamFolderRenameDetails | EventDetailsTeamFolderSpaceLimitsChangeCapsTypeDetails | EventDetailsTeamFolderSpaceLimitsChangeLimitDetails | EventDetailsTeamFolderSpaceLimitsChangeNotificationTargetDetails | EventDetailsTeamSelectiveSyncSettingsChangedDetails | EventDetailsAccountCaptureChangePolicyDetails | EventDetailsAdminEmailRemindersChangedDetails | EventDetailsAiThirdPartySharingDropboxBasePolicyChangedDetails | EventDetailsAllowDownloadDisabledDetails | EventDetailsAllowDownloadEnabledDetails | EventDetailsAppleLoginChangePolicyDetails | EventDetailsAppPermissionsChangedDetails | EventDetailsCameraUploadsPolicyChangedDetails | EventDetailsCaptureTeamSpacePolicyChangedDetails | EventDetailsCaptureTranscriptPolicyChangedDetails | EventDetailsClassificationChangePolicyDetails | EventDetailsComputerBackupPolicyChangedDetails | EventDetailsContentAdministrationPolicyChangedDetails | EventDetailsContentDeletionProtectionChangePolicyDetails | EventDetailsDashExternalSharingPolicyChangedDetails | EventDetailsDataPlacementRestrictionChangePolicyDetails | EventDetailsDataPlacementRestrictionSatisfyPolicyDetails | EventDetailsDeviceApprovalsAddExceptionDetails | EventDetailsDeviceApprovalsChangeDesktopPolicyDetails | EventDetailsDeviceApprovalsChangeMobilePolicyDetails | EventDetailsDeviceApprovalsChangeOverageActionDetails | EventDetailsDeviceApprovalsChangeUnlinkActionDetails | EventDetailsDeviceApprovalsRemoveExceptionDetails | EventDetailsDirectoryRestrictionsAddMembersDetails | EventDetailsDirectoryRestrictionsRemoveMembersDetails | EventDetailsDropboxPasswordsPolicyChangedDetails | EventDetailsEmailIngestPolicyChangedDetails | EventDetailsEmmAddExceptionDetails | EventDetailsEmmChangePolicyDetails | EventDetailsEmmRemoveExceptionDetails | EventDetailsExtendedVersionHistoryChangePolicyDetails | EventDetailsExternalDriveBackupPolicyChangedDetails | EventDetailsFileCommentsChangePolicyDetails | EventDetailsFileLockingPolicyChangedDetails | EventDetailsFileProviderMigrationPolicyChangedDetails | EventDetailsFileRequestsChangePolicyDetails | EventDetailsFileRequestsEmailsEnabledDetails | EventDetailsFileRequestsEmailsRestrictedToTeamOnlyDetails | EventDetailsFileTransfersPolicyChangedDetails | EventDetailsFlexibleFileNamesPolicyChangedDetails | EventDetailsFolderLinkRestrictionPolicyChangedDetails | EventDetailsGoogleSsoChangePolicyDetails | EventDetailsGroupUserManagementChangePolicyDetails | EventDetailsIntegrationPolicyChangedDetails | EventDetailsInviteAcceptanceEmailPolicyChangedDetails | EventDetailsMediaHubAddingPeoplePolicyChangedDetails | EventDetailsMediaHubDownloadPolicyChangedDetails | EventDetailsMediaHubLinkSharingPolicyChangedDetails | EventDetailsMemberRequestsChangePolicyDetails | EventDetailsMemberSendInvitePolicyChangedDetails | EventDetailsMemberSpaceLimitsAddExceptionDetails | EventDetailsMemberSpaceLimitsChangeCapsTypePolicyDetails | EventDetailsMemberSpaceLimitsChangePolicyDetails | EventDetailsMemberSpaceLimitsRemoveExceptionDetails | EventDetailsMemberSuggestionsChangePolicyDetails | EventDetailsMicrosoftLoginChangePolicyDetails | EventDetailsMicrosoftOfficeAddinChangePolicyDetails | EventDetailsMultiTeamIdentityPolicyChangedDetails | EventDetailsNetworkControlChangePolicyDetails | EventDetailsPaperChangeDeploymentPolicyDetails | EventDetailsPaperChangeMemberLinkPolicyDetails | EventDetailsPaperChangeMemberPolicyDetails | EventDetailsPaperChangePolicyDetails | EventDetailsPaperDefaultFolderPolicyChangedDetails | EventDetailsPaperDesktopPolicyChangedDetails | EventDetailsPaperEnabledUsersGroupAdditionDetails | EventDetailsPaperEnabledUsersGroupRemovalDetails | EventDetailsPasskeyLoginPolicyChangedDetails | EventDetailsPasswordStrengthRequirementsChangePolicyDetails | EventDetailsPermanentDeleteChangePolicyDetails | EventDetailsPreviewsAiPolicyChangedDetails | EventDetailsReplayAddingPeoplePolicyChangedDetails | EventDetailsReplaySharingPolicyChangedDetails | EventDetailsResellerSupportChangePolicyDetails | EventDetailsRewindPolicyChangedDetails | EventDetailsSendAndTrackPolicyChangedDetails | EventDetailsSendExternalSharingPolicyChangedDetails | EventDetailsSendForSignaturePolicyChangedDetails | EventDetailsSharedLinkDefaultPermissionsPolicyChangedDetails | EventDetailsSharingChangeFolderJoinPolicyDetails | EventDetailsSharingChangeLinkAllowChangeExpirationPolicyDetails | EventDetailsSharingChangeLinkDefaultExpirationPolicyDetails | EventDetailsSharingChangeLinkEnforcePasswordPolicyDetails | EventDetailsSharingChangeLinkPolicyDetails | EventDetailsSharingChangeMemberPolicyDetails | EventDetailsShowcaseChangeDownloadPolicyDetails | EventDetailsShowcaseChangeEnabledPolicyDetails | EventDetailsShowcaseChangeExternalSharingPolicyDetails | EventDetailsSignExternalSharingPolicyChangedDetails | EventDetailsSignTemplateCreationPermissionChangedDetails | EventDetailsSmarterSmartSyncPolicyChangedDetails | EventDetailsSmartSyncChangePolicyDetails | EventDetailsSmartSyncNotOptOutDetails | EventDetailsSmartSyncOptOutDetails | EventDetailsSsoChangePolicyDetails | EventDetailsStackCrossTeamAccessPolicyChangedDetails | EventDetailsTeamBrandingPolicyChangedDetails | EventDetailsTeamExtensionsPolicyChangedDetails | EventDetailsTeamMemberStorageRequestPolicyChangedDetails | EventDetailsTeamSelectiveSyncPolicyChangedDetails | EventDetailsTeamSharingWhitelistSubjectsChangedDetails | EventDetailsTfaAddExceptionDetails | EventDetailsTfaChangePolicyDetails | EventDetailsTfaRemoveExceptionDetails | EventDetailsTopLevelContentPolicyChangedDetails | EventDetailsTwoAccountChangePolicyDetails | EventDetailsViewerInfoPolicyChangedDetails | EventDetailsWatermarkingPolicyChangedDetails | EventDetailsWebSessionsChangeActiveSessionLimitDetails | EventDetailsWebSessionsChangeFixedLengthPolicyDetails | EventDetailsWebSessionsChangeIdleLengthPolicyDetails | EventDetailsDataResidencyMigrationRequestSuccessfulDetails | EventDetailsDataResidencyMigrationRequestUnsuccessfulDetails | EventDetailsTeamMergeFromDetails | EventDetailsTeamMergeToDetails | EventDetailsTeamProfileAddBackgroundDetails | EventDetailsTeamProfileAddLogoDetails | EventDetailsTeamProfileChangeBackgroundDetails | EventDetailsTeamProfileChangeDefaultLanguageDetails | EventDetailsTeamProfileChangeLogoDetails | EventDetailsTeamProfileChangeNameDetails | EventDetailsTeamProfileRemoveBackgroundDetails | EventDetailsTeamProfileRemoveLogoDetails | EventDetailsPasskeyAddDetails | EventDetailsPasskeyRemoveDetails | EventDetailsTfaAddBackupPhoneDetails | EventDetailsTfaAddSecurityKeyDetails | EventDetailsTfaChangeBackupPhoneDetails | EventDetailsTfaChangeStatusDetails | EventDetailsTfaRemoveBackupPhoneDetails | EventDetailsTfaRemoveSecurityKeyDetails | EventDetailsTfaResetDetails | EventDetailsChangedEnterpriseAdminRoleDetails | EventDetailsChangedEnterpriseConnectedTeamStatusDetails | EventDetailsEndedEnterpriseAdminSessionDetails | EventDetailsEndedEnterpriseAdminSessionDeprecatedDetails | EventDetailsEnterpriseSettingsLockingDetails | EventDetailsGuestAdminChangeStatusDetails | EventDetailsStartedEnterpriseAdminSessionDetails | EventDetailsTeamMergeRequestAcceptedDetails | EventDetailsTeamMergeRequestAcceptedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestAcceptedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestAutoCanceledDetails | EventDetailsTeamMergeRequestCanceledDetails | EventDetailsTeamMergeRequestCanceledShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestCanceledShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestExpiredDetails | EventDetailsTeamMergeRequestExpiredShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestExpiredShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestReminderDetails | EventDetailsTeamMergeRequestReminderShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestReminderShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRevokedDetails | EventDetailsTeamMergeRequestSentShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestSentShownToSecondaryTeamDetails | EventDetailsMissingDetails | EventDetailsOther;
+    export type EventDetails = EventDetailsAdminAlertingAlertStateChangedDetails | EventDetailsAdminAlertingChangedAlertConfigDetails | EventDetailsAdminAlertingTriggeredAlertDetails | EventDetailsRansomwareRestoreProcessCompletedDetails | EventDetailsRansomwareRestoreProcessStartedDetails | EventDetailsAppBlockedByPermissionsDetails | EventDetailsAppLinkTeamDetails | EventDetailsAppLinkUserDetails | EventDetailsAppUnlinkTeamDetails | EventDetailsAppUnlinkUserDetails | EventDetailsIntegrationConnectedDetails | EventDetailsIntegrationDisconnectedDetails | EventDetailsFileAddCommentDetails | EventDetailsFileChangeCommentSubscriptionDetails | EventDetailsFileDeleteCommentDetails | EventDetailsFileEditCommentDetails | EventDetailsFileLikeCommentDetails | EventDetailsFileResolveCommentDetails | EventDetailsFileUnlikeCommentDetails | EventDetailsFileUnresolveCommentDetails | EventDetailsDashAddedCommentToStackDetails | EventDetailsDashAddedConnectorDetails | EventDetailsDashAddedLinkToStackDetails | EventDetailsDashAddedTeamEmailDomainAllowlistDetails | EventDetailsDashAdminAddedOrgWideConnectorDetails | EventDetailsDashAdminDisabledConnectorDetails | EventDetailsDashAdminEnabledConnectorDetails | EventDetailsDashAdminRemovedOrgWideConnectorDetails | EventDetailsDashArchivedStackDetails | EventDetailsDashChangedAudienceOfSharedLinkToStackDetails | EventDetailsDashClonedStackDetails | EventDetailsDashConnectorToolsCallDetails | EventDetailsDashCreatedStackDetails | EventDetailsDashDeletedCommentFromStackDetails | EventDetailsDashDeletedStackDetails | EventDetailsDashEditedCommentInStackDetails | EventDetailsDashExternalUserOpenedStackDetails | EventDetailsDashFirstLaunchedDesktopDetails | EventDetailsDashFirstLaunchedExtensionDetails | EventDetailsDashFirstLaunchedWebStartPageDetails | EventDetailsDashOpenedSharedLinkToStackDetails | EventDetailsDashOpenedStackDetails | EventDetailsDashPreviewOptOutStatusChangedDetails | EventDetailsDashRemovedConnectorDetails | EventDetailsDashRemovedLinkFromStackDetails | EventDetailsDashRemovedSharedLinkToStackDetails | EventDetailsDashRemovedTeamEmailDomainAllowlistDetails | EventDetailsDashRenamedStackDetails | EventDetailsDashSharedLinkToStackDetails | EventDetailsDashUnarchivedStackDetails | EventDetailsDashViewedCompanyStackDetails | EventDetailsDashViewedExternalAiActivityReportDetails | EventDetailsGovernancePolicyAddFoldersDetails | EventDetailsGovernancePolicyAddFolderFailedDetails | EventDetailsGovernancePolicyContentDisposedDetails | EventDetailsGovernancePolicyCreateDetails | EventDetailsGovernancePolicyDeleteDetails | EventDetailsGovernancePolicyEditDetailsDetails | EventDetailsGovernancePolicyEditDurationDetails | EventDetailsGovernancePolicyExportCreatedDetails | EventDetailsGovernancePolicyExportRemovedDetails | EventDetailsGovernancePolicyRemoveFoldersDetails | EventDetailsGovernancePolicyReportCreatedDetails | EventDetailsGovernancePolicyZipPartDownloadedDetails | EventDetailsLegalHoldsActivateAHoldDetails | EventDetailsLegalHoldsAddMembersDetails | EventDetailsLegalHoldsChangeHoldDetailsDetails | EventDetailsLegalHoldsChangeHoldNameDetails | EventDetailsLegalHoldsExportAHoldDetails | EventDetailsLegalHoldsExportCancelledDetails | EventDetailsLegalHoldsExportDownloadedDetails | EventDetailsLegalHoldsExportRemovedDetails | EventDetailsLegalHoldsReleaseAHoldDetails | EventDetailsLegalHoldsRemoveMembersDetails | EventDetailsLegalHoldsReportAHoldDetails | EventDetailsDeviceChangeIpDesktopDetails | EventDetailsDeviceChangeIpMobileDetails | EventDetailsDeviceChangeIpWebDetails | EventDetailsDeviceDeleteOnUnlinkFailDetails | EventDetailsDeviceDeleteOnUnlinkSuccessDetails | EventDetailsDeviceLinkFailDetails | EventDetailsDeviceLinkSuccessDetails | EventDetailsDeviceManagementDisabledDetails | EventDetailsDeviceManagementEnabledDetails | EventDetailsDeviceSyncBackupStatusChangedDetails | EventDetailsDeviceUnlinkDetails | EventDetailsDropboxPasswordsExportedDetails | EventDetailsDropboxPasswordsNewDeviceEnrolledDetails | EventDetailsEmmRefreshAuthTokenDetails | EventDetailsExternalDriveBackupEligibilityStatusCheckedDetails | EventDetailsExternalDriveBackupStatusChangedDetails | EventDetailsAccountCaptureChangeAvailabilityDetails | EventDetailsAccountCaptureMigrateAccountDetails | EventDetailsAccountCaptureNotificationEmailsSentDetails | EventDetailsAccountCaptureRelinquishAccountDetails | EventDetailsDisabledDomainInvitesDetails | EventDetailsDomainInvitesApproveRequestToJoinTeamDetails | EventDetailsDomainInvitesDeclineRequestToJoinTeamDetails | EventDetailsDomainInvitesEmailExistingUsersDetails | EventDetailsDomainInvitesRequestToJoinTeamDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToNoDetails | EventDetailsDomainInvitesSetInviteNewUserPrefToYesDetails | EventDetailsDomainVerificationAddDomainFailDetails | EventDetailsDomainVerificationAddDomainSuccessDetails | EventDetailsDomainVerificationRemoveDomainDetails | EventDetailsEnabledDomainInvitesDetails | EventDetailsEncryptedFolderCancelTeamKeyRotationDetails | EventDetailsEncryptedFolderEnrollBackupKeyDetails | EventDetailsEncryptedFolderEnrollClientDetails | EventDetailsEncryptedFolderEnrollTeamDetails | EventDetailsEncryptedFolderFinishTeamUnenrollmentDetails | EventDetailsEncryptedFolderInitTeamKeyRotationDetails | EventDetailsEncryptedFolderInitTeamUnenrollmentDetails | EventDetailsEncryptedFolderRemoveBackupKeyDetails | EventDetailsEncryptedFolderRotateTeamKeyDetails | EventDetailsEncryptedFolderUnenrollClientDetails | EventDetailsTeamEncryptionKeyActivateKeyDetails | EventDetailsTeamEncryptionKeyCancelKeyDeletionDetails | EventDetailsTeamEncryptionKeyCreateKeyDetails | EventDetailsTeamEncryptionKeyDeactivateKeyDetails | EventDetailsTeamEncryptionKeyDeleteKeyDetails | EventDetailsTeamEncryptionKeyDisableKeyDetails | EventDetailsTeamEncryptionKeyEnableKeyDetails | EventDetailsTeamEncryptionKeyRotateKeyDetails | EventDetailsTeamEncryptionKeyScheduleKeyDeletionDetails | EventDetailsApplyNamingConventionDetails | EventDetailsCreateFolderDetails | EventDetailsFileAddDetails | EventDetailsFileAddFromAutomationDetails | EventDetailsFileCopyDetails | EventDetailsFileDeleteDetails | EventDetailsFileDownloadDetails | EventDetailsFileEditDetails | EventDetailsFileGetCopyReferenceDetails | EventDetailsFileLockingLockStatusChangedDetails | EventDetailsFileMoveDetails | EventDetailsFilePermanentlyDeleteDetails | EventDetailsFilePreviewDetails | EventDetailsFileRenameDetails | EventDetailsFileRestoreDetails | EventDetailsFileRevertDetails | EventDetailsFileRollbackChangesDetails | EventDetailsFileSaveCopyReferenceDetails | EventDetailsFolderOverviewDescriptionChangedDetails | EventDetailsFolderOverviewItemPinnedDetails | EventDetailsFolderOverviewItemUnpinnedDetails | EventDetailsMediaHubFileDownloadedDetails | EventDetailsObjectLabelAddedDetails | EventDetailsObjectLabelRemovedDetails | EventDetailsObjectLabelUpdatedValueDetails | EventDetailsOrganizeFolderWithTidyDetails | EventDetailsReplayFileDeleteDetails | EventDetailsReplayFileDownloadedDetails | EventDetailsReplayTeamProjectCreatedDetails | EventDetailsRewindFolderDetails | EventDetailsUndoNamingConventionDetails | EventDetailsUndoOrganizeFolderWithTidyDetails | EventDetailsUserTagsAddedDetails | EventDetailsUserTagsRemovedDetails | EventDetailsEmailIngestReceiveFileDetails | EventDetailsFileRequestAutoCloseDetails | EventDetailsFileRequestChangeDetails | EventDetailsFileRequestCloseDetails | EventDetailsFileRequestCreateDetails | EventDetailsFileRequestDeleteDetails | EventDetailsFileRequestReceiveFileDetails | EventDetailsGroupAddExternalIdDetails | EventDetailsGroupAddMemberDetails | EventDetailsGroupChangeExternalIdDetails | EventDetailsGroupChangeManagementTypeDetails | EventDetailsGroupChangeMemberRoleDetails | EventDetailsGroupCreateDetails | EventDetailsGroupDeleteDetails | EventDetailsGroupDescriptionUpdatedDetails | EventDetailsGroupExternalSharingSettingOverrideChangedDetails | EventDetailsGroupJoinPolicyUpdatedDetails | EventDetailsGroupMovedDetails | EventDetailsGroupRemoveExternalIdDetails | EventDetailsGroupRemoveMemberDetails | EventDetailsGroupRenameDetails | EventDetailsAccountLockOrUnlockedDetails | EventDetailsEmmErrorDetails | EventDetailsGuestAdminSignedInViaTrustedTeamsDetails | EventDetailsGuestAdminSignedOutViaTrustedTeamsDetails | EventDetailsLoginFailDetails | EventDetailsLoginSuccessDetails | EventDetailsLogoutDetails | EventDetailsResellerSupportSessionEndDetails | EventDetailsResellerSupportSessionStartDetails | EventDetailsSignInAsSessionEndDetails | EventDetailsSignInAsSessionStartDetails | EventDetailsSsoErrorDetails | EventDetailsAddonAssignedDetails | EventDetailsAddonRemovedDetails | EventDetailsBackupAdminInvitationSentDetails | EventDetailsBackupInvitationOpenedDetails | EventDetailsCreateTeamInviteLinkDetails | EventDetailsDeleteTeamInviteLinkDetails | EventDetailsMemberAddExternalIdDetails | EventDetailsMemberAddNameDetails | EventDetailsMemberChangeAdminRoleDetails | EventDetailsMemberChangeEmailDetails | EventDetailsMemberChangeExternalIdDetails | EventDetailsMemberChangeMembershipTypeDetails | EventDetailsMemberChangeNameDetails | EventDetailsMemberChangeResellerRoleDetails | EventDetailsMemberChangeStatusDetails | EventDetailsMemberDeleteManualContactsDetails | EventDetailsMemberDeleteProfilePhotoDetails | EventDetailsMemberFolderContentsAccessedDetails | EventDetailsMemberPermanentlyDeleteAccountContentsDetails | EventDetailsMemberRemoveExternalIdDetails | EventDetailsMemberSetProfilePhotoDetails | EventDetailsMemberSpaceLimitsAddCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeCustomQuotaDetails | EventDetailsMemberSpaceLimitsChangeStatusDetails | EventDetailsMemberSpaceLimitsRemoveCustomQuotaDetails | EventDetailsMemberSuggestDetails | EventDetailsMemberTransferAccountContentsDetails | EventDetailsPendingSecondaryEmailAddedDetails | EventDetailsProductAssignedToMemberDetails | EventDetailsProductRemovedFromMemberDetails | EventDetailsSecondaryEmailDeletedDetails | EventDetailsSecondaryEmailVerifiedDetails | EventDetailsSecondaryMailsPolicyChangedDetails | EventDetailsBinderAddPageDetails | EventDetailsBinderAddSectionDetails | EventDetailsBinderRemovePageDetails | EventDetailsBinderRemoveSectionDetails | EventDetailsBinderRenamePageDetails | EventDetailsBinderRenameSectionDetails | EventDetailsBinderReorderPageDetails | EventDetailsBinderReorderSectionDetails | EventDetailsPaperContentAddMemberDetails | EventDetailsPaperContentAddToFolderDetails | EventDetailsPaperContentArchiveDetails | EventDetailsPaperContentCreateDetails | EventDetailsPaperContentPermanentlyDeleteDetails | EventDetailsPaperContentRemoveFromFolderDetails | EventDetailsPaperContentRemoveMemberDetails | EventDetailsPaperContentRenameDetails | EventDetailsPaperContentRestoreDetails | EventDetailsPaperDocAddCommentDetails | EventDetailsPaperDocChangeMemberRoleDetails | EventDetailsPaperDocChangeSharingPolicyDetails | EventDetailsPaperDocChangeSubscriptionDetails | EventDetailsPaperDocDeletedDetails | EventDetailsPaperDocDeleteCommentDetails | EventDetailsPaperDocDownloadDetails | EventDetailsPaperDocEditDetails | EventDetailsPaperDocEditCommentDetails | EventDetailsPaperDocFollowedDetails | EventDetailsPaperDocMentionDetails | EventDetailsPaperDocOwnershipChangedDetails | EventDetailsPaperDocRequestAccessDetails | EventDetailsPaperDocResolveCommentDetails | EventDetailsPaperDocRevertDetails | EventDetailsPaperDocSlackShareDetails | EventDetailsPaperDocTeamInviteDetails | EventDetailsPaperDocTrashedDetails | EventDetailsPaperDocUnresolveCommentDetails | EventDetailsPaperDocUntrashedDetails | EventDetailsPaperDocViewDetails | EventDetailsPaperExternalViewAllowDetails | EventDetailsPaperExternalViewDefaultTeamDetails | EventDetailsPaperExternalViewForbidDetails | EventDetailsPaperFolderChangeSubscriptionDetails | EventDetailsPaperFolderDeletedDetails | EventDetailsPaperFolderFollowedDetails | EventDetailsPaperFolderTeamInviteDetails | EventDetailsPaperPublishedLinkChangePermissionDetails | EventDetailsPaperPublishedLinkCreateDetails | EventDetailsPaperPublishedLinkDisabledDetails | EventDetailsPaperPublishedLinkViewDetails | EventDetailsPasswordChangeDetails | EventDetailsPasswordResetDetails | EventDetailsPasswordResetAllDetails | EventDetailsProtectActionAddCollaboratorDetails | EventDetailsProtectActionAddLinkDetails | EventDetailsProtectActionDeleteDetails | EventDetailsProtectActionExportDetails | EventDetailsProtectActionRemoveCollaboratorDetails | EventDetailsProtectActionRemoveLinkDetails | EventDetailsProtectActionStopSharingDetails | EventDetailsProtectInternalDomainsChangedDetails | EventDetailsProtectPolicyActivatedDetails | EventDetailsProtectPolicyDeactivatedDetails | EventDetailsProtectPolicyScheduledDetails | EventDetailsProtectPolicyUpdatedDetails | EventDetailsClassificationCreateReportDetails | EventDetailsClassificationCreateReportFailDetails | EventDetailsEmmCreateExceptionsReportDetails | EventDetailsEmmCreateUsageReportDetails | EventDetailsExportMembersReportDetails | EventDetailsExportMembersReportFailDetails | EventDetailsExternalSharingCreateReportDetails | EventDetailsExternalSharingReportFailedDetails | EventDetailsMemberAccessDetailsCreateReportDetails | EventDetailsMemberAccessDetailsCreateReportFailedDetails | EventDetailsNoExpirationLinkGenCreateReportDetails | EventDetailsNoExpirationLinkGenReportFailedDetails | EventDetailsNoPasswordLinkGenCreateReportDetails | EventDetailsNoPasswordLinkGenReportFailedDetails | EventDetailsNoPasswordLinkViewCreateReportDetails | EventDetailsNoPasswordLinkViewReportFailedDetails | EventDetailsOutdatedLinkViewCreateReportDetails | EventDetailsOutdatedLinkViewReportFailedDetails | EventDetailsPaperAdminExportStartDetails | EventDetailsRansomwareAlertCreateReportDetails | EventDetailsRansomwareAlertCreateReportFailedDetails | EventDetailsSharedFoldersCreateReportDetails | EventDetailsSharedFoldersCreateReportFailedDetails | EventDetailsSmartSyncCreateAdminPrivilegeReportDetails | EventDetailsTeamActivityCreateReportDetails | EventDetailsTeamActivityCreateReportFailDetails | EventDetailsTeamFoldersCreateReportDetails | EventDetailsTeamFoldersCreateReportFailedDetails | EventDetailsTeamStorageCreateReportDetails | EventDetailsTeamStorageCreateReportFailedDetails | EventDetailsCollectionShareDetails | EventDetailsFileTransfersFileAddDetails | EventDetailsFileTransfersTransferDeleteDetails | EventDetailsFileTransfersTransferDownloadDetails | EventDetailsFileTransfersTransferSendDetails | EventDetailsFileTransfersTransferViewDetails | EventDetailsMediaHubProjectTeamAddDetails | EventDetailsMediaHubProjectTeamDeleteDetails | EventDetailsMediaHubProjectTeamRoleChangedDetails | EventDetailsMediaHubSharedLinkAudienceChangedDetails | EventDetailsMediaHubSharedLinkCreatedDetails | EventDetailsMediaHubSharedLinkDownloadSettingChangedDetails | EventDetailsMediaHubSharedLinkRevokedDetails | EventDetailsNoteAclInviteOnlyDetails | EventDetailsNoteAclLinkDetails | EventDetailsNoteAclTeamLinkDetails | EventDetailsNoteSharedDetails | EventDetailsNoteShareReceiveDetails | EventDetailsOpenNoteSharedDetails | EventDetailsReplayFileSharedLinkCreatedDetails | EventDetailsReplayFileSharedLinkModifiedDetails | EventDetailsReplayProjectTeamAddDetails | EventDetailsReplayProjectTeamDeleteDetails | EventDetailsSendAndTrackFileAddedDetails | EventDetailsSendAndTrackFileRenamedDetails | EventDetailsSendAndTrackFileUpdatedDetails | EventDetailsSendAndTrackLinkCreatedDetails | EventDetailsSendAndTrackLinkDeletedDetails | EventDetailsSendAndTrackLinkUpdatedDetails | EventDetailsSendAndTrackLinkViewedDetails | EventDetailsSendAndTrackRemovedFileAndAssociatedLinksDetails | EventDetailsSfAddGroupDetails | EventDetailsSfAllowNonMembersToViewSharedLinksDetails | EventDetailsSfExternalInviteWarnDetails | EventDetailsSfFbInviteDetails | EventDetailsSfFbInviteChangeRoleDetails | EventDetailsSfFbUninviteDetails | EventDetailsSfInviteGroupDetails | EventDetailsSfTeamGrantAccessDetails | EventDetailsSfTeamInviteDetails | EventDetailsSfTeamInviteChangeRoleDetails | EventDetailsSfTeamJoinDetails | EventDetailsSfTeamJoinFromOobLinkDetails | EventDetailsSfTeamUninviteDetails | EventDetailsSharedContentAddInviteesDetails | EventDetailsSharedContentAddLinkExpiryDetails | EventDetailsSharedContentAddLinkPasswordDetails | EventDetailsSharedContentAddMemberDetails | EventDetailsSharedContentChangeDownloadsPolicyDetails | EventDetailsSharedContentChangeInviteeRoleDetails | EventDetailsSharedContentChangeLinkAudienceDetails | EventDetailsSharedContentChangeLinkExpiryDetails | EventDetailsSharedContentChangeLinkPasswordDetails | EventDetailsSharedContentChangeMemberRoleDetails | EventDetailsSharedContentChangeViewerInfoPolicyDetails | EventDetailsSharedContentClaimInvitationDetails | EventDetailsSharedContentCopyDetails | EventDetailsSharedContentDownloadDetails | EventDetailsSharedContentRelinquishMembershipDetails | EventDetailsSharedContentRemoveInviteesDetails | EventDetailsSharedContentRemoveLinkExpiryDetails | EventDetailsSharedContentRemoveLinkPasswordDetails | EventDetailsSharedContentRemoveMemberDetails | EventDetailsSharedContentRequestAccessDetails | EventDetailsSharedContentRestoreInviteesDetails | EventDetailsSharedContentRestoreMemberDetails | EventDetailsSharedContentUnshareDetails | EventDetailsSharedContentViewDetails | EventDetailsSharedFolderChangeLinkPolicyDetails | EventDetailsSharedFolderChangeMembersInheritancePolicyDetails | EventDetailsSharedFolderChangeMembersManagementPolicyDetails | EventDetailsSharedFolderChangeMembersPolicyDetails | EventDetailsSharedFolderCreateDetails | EventDetailsSharedFolderDeclineInvitationDetails | EventDetailsSharedFolderMountDetails | EventDetailsSharedFolderNestDetails | EventDetailsSharedFolderTransferOwnershipDetails | EventDetailsSharedFolderUnmountDetails | EventDetailsSharedLinkAddExpiryDetails | EventDetailsSharedLinkChangeExpiryDetails | EventDetailsSharedLinkChangeVisibilityDetails | EventDetailsSharedLinkCopyDetails | EventDetailsSharedLinkCreateDetails | EventDetailsSharedLinkDisableDetails | EventDetailsSharedLinkDownloadDetails | EventDetailsSharedLinkRemoveExpiryDetails | EventDetailsSharedLinkRemoveVisitorDetails | EventDetailsSharedLinkSettingsAddExpirationDetails | EventDetailsSharedLinkSettingsAddPasswordDetails | EventDetailsSharedLinkSettingsAllowDownloadDisabledDetails | EventDetailsSharedLinkSettingsAllowDownloadEnabledDetails | EventDetailsSharedLinkSettingsChangeAudienceDetails | EventDetailsSharedLinkSettingsChangeExpirationDetails | EventDetailsSharedLinkSettingsChangePasswordDetails | EventDetailsSharedLinkSettingsRemoveExpirationDetails | EventDetailsSharedLinkSettingsRemovePasswordDetails | EventDetailsSharedLinkShareDetails | EventDetailsSharedLinkViewDetails | EventDetailsSharedNoteOpenedDetails | EventDetailsShmodelDisableDownloadsDetails | EventDetailsShmodelEnableDownloadsDetails | EventDetailsShmodelGroupShareDetails | EventDetailsShowcaseAccessGrantedDetails | EventDetailsShowcaseAddMemberDetails | EventDetailsShowcaseArchivedDetails | EventDetailsShowcaseCreatedDetails | EventDetailsShowcaseDeleteCommentDetails | EventDetailsShowcaseEditedDetails | EventDetailsShowcaseEditCommentDetails | EventDetailsShowcaseFileAddedDetails | EventDetailsShowcaseFileDownloadDetails | EventDetailsShowcaseFileRemovedDetails | EventDetailsShowcaseFileViewDetails | EventDetailsShowcasePermanentlyDeletedDetails | EventDetailsShowcasePostCommentDetails | EventDetailsShowcaseRemoveMemberDetails | EventDetailsShowcaseRenamedDetails | EventDetailsShowcaseRequestAccessDetails | EventDetailsShowcaseResolveCommentDetails | EventDetailsShowcaseRestoredDetails | EventDetailsShowcaseTrashedDetails | EventDetailsShowcaseTrashedDeprecatedDetails | EventDetailsShowcaseUnresolveCommentDetails | EventDetailsShowcaseUntrashedDetails | EventDetailsShowcaseUntrashedDeprecatedDetails | EventDetailsShowcaseViewDetails | EventDetailsSignSignatureRequestCanceledDetails | EventDetailsSignSignatureRequestCompletedDetails | EventDetailsSignSignatureRequestDeclinedDetails | EventDetailsSignSignatureRequestOpenedDetails | EventDetailsSignSignatureRequestReminderSentDetails | EventDetailsSignSignatureRequestSentDetails | EventDetailsSignTemplateCreatedDetails | EventDetailsSignTemplateSharedDetails | EventDetailsRiscSecurityEventDetails | EventDetailsSsoAddCertDetails | EventDetailsSsoAddLoginUrlDetails | EventDetailsSsoAddLogoutUrlDetails | EventDetailsSsoChangeCertDetails | EventDetailsSsoChangeLoginUrlDetails | EventDetailsSsoChangeLogoutUrlDetails | EventDetailsSsoChangeSamlIdentityModeDetails | EventDetailsSsoRemoveCertDetails | EventDetailsSsoRemoveLoginUrlDetails | EventDetailsSsoRemoveLogoutUrlDetails | EventDetailsTeamFolderChangeStatusDetails | EventDetailsTeamFolderCreateDetails | EventDetailsTeamFolderDowngradeDetails | EventDetailsTeamFolderPermanentlyDeleteDetails | EventDetailsTeamFolderRenameDetails | EventDetailsTeamFolderSpaceLimitsChangeCapsTypeDetails | EventDetailsTeamFolderSpaceLimitsChangeLimitDetails | EventDetailsTeamFolderSpaceLimitsChangeNotificationTargetDetails | EventDetailsTeamSelectiveSyncSettingsChangedDetails | EventDetailsAccountCaptureChangePolicyDetails | EventDetailsAdminEmailRemindersChangedDetails | EventDetailsAiThirdPartySharingDropboxBasePolicyChangedDetails | EventDetailsAllowDownloadDisabledDetails | EventDetailsAllowDownloadEnabledDetails | EventDetailsAppleLoginChangePolicyDetails | EventDetailsAppPermissionsChangedDetails | EventDetailsCameraUploadsPolicyChangedDetails | EventDetailsCaptureTeamSpacePolicyChangedDetails | EventDetailsCaptureTranscriptPolicyChangedDetails | EventDetailsClassificationChangePolicyDetails | EventDetailsComputerBackupPolicyChangedDetails | EventDetailsContentAdministrationPolicyChangedDetails | EventDetailsContentDeletionProtectionChangePolicyDetails | EventDetailsDashExternalSharingPolicyChangedDetails | EventDetailsDataPlacementRestrictionChangePolicyDetails | EventDetailsDataPlacementRestrictionSatisfyPolicyDetails | EventDetailsDeviceApprovalsAddExceptionDetails | EventDetailsDeviceApprovalsChangeDesktopPolicyDetails | EventDetailsDeviceApprovalsChangeMobilePolicyDetails | EventDetailsDeviceApprovalsChangeOverageActionDetails | EventDetailsDeviceApprovalsChangeUnlinkActionDetails | EventDetailsDeviceApprovalsRemoveExceptionDetails | EventDetailsDirectoryRestrictionsAddMembersDetails | EventDetailsDirectoryRestrictionsRemoveMembersDetails | EventDetailsDropboxPasswordsPolicyChangedDetails | EventDetailsEmailIngestPolicyChangedDetails | EventDetailsEmmAddExceptionDetails | EventDetailsEmmChangePolicyDetails | EventDetailsEmmRemoveExceptionDetails | EventDetailsExtendedVersionHistoryChangePolicyDetails | EventDetailsExternalDriveBackupPolicyChangedDetails | EventDetailsFileCommentsChangePolicyDetails | EventDetailsFileLockingPolicyChangedDetails | EventDetailsFileProviderMigrationPolicyChangedDetails | EventDetailsFileRequestsChangePolicyDetails | EventDetailsFileRequestsEmailsEnabledDetails | EventDetailsFileRequestsEmailsRestrictedToTeamOnlyDetails | EventDetailsFileTransfersPolicyChangedDetails | EventDetailsFlexibleFileNamesPolicyChangedDetails | EventDetailsFolderLinkRestrictionPolicyChangedDetails | EventDetailsGoogleSsoChangePolicyDetails | EventDetailsGroupUserManagementChangePolicyDetails | EventDetailsIntegrationPolicyChangedDetails | EventDetailsInviteAcceptanceEmailPolicyChangedDetails | EventDetailsMediaHubAddingPeoplePolicyChangedDetails | EventDetailsMediaHubDownloadPolicyChangedDetails | EventDetailsMediaHubLinkSharingPolicyChangedDetails | EventDetailsMemberRequestsChangePolicyDetails | EventDetailsMemberSendInvitePolicyChangedDetails | EventDetailsMemberSpaceLimitsAddExceptionDetails | EventDetailsMemberSpaceLimitsChangeCapsTypePolicyDetails | EventDetailsMemberSpaceLimitsChangePolicyDetails | EventDetailsMemberSpaceLimitsRemoveExceptionDetails | EventDetailsMemberSuggestionsChangePolicyDetails | EventDetailsMicrosoftLoginChangePolicyDetails | EventDetailsMicrosoftOfficeAddinChangePolicyDetails | EventDetailsMultiTeamIdentityPolicyChangedDetails | EventDetailsNetworkControlChangePolicyDetails | EventDetailsPaperChangeDeploymentPolicyDetails | EventDetailsPaperChangeMemberLinkPolicyDetails | EventDetailsPaperChangeMemberPolicyDetails | EventDetailsPaperChangePolicyDetails | EventDetailsPaperDefaultFolderPolicyChangedDetails | EventDetailsPaperDesktopPolicyChangedDetails | EventDetailsPaperEnabledUsersGroupAdditionDetails | EventDetailsPaperEnabledUsersGroupRemovalDetails | EventDetailsPasskeyLoginPolicyChangedDetails | EventDetailsPasswordStrengthRequirementsChangePolicyDetails | EventDetailsPermanentDeleteChangePolicyDetails | EventDetailsPreviewsAiPolicyChangedDetails | EventDetailsReplayAddingPeoplePolicyChangedDetails | EventDetailsReplaySharingPolicyChangedDetails | EventDetailsResellerSupportChangePolicyDetails | EventDetailsRewindPolicyChangedDetails | EventDetailsSendAndTrackPolicyChangedDetails | EventDetailsSendExternalSharingPolicyChangedDetails | EventDetailsSendForSignaturePolicyChangedDetails | EventDetailsSharedLinkDefaultPermissionsPolicyChangedDetails | EventDetailsSharingChangeFolderJoinPolicyDetails | EventDetailsSharingChangeLinkAllowChangeExpirationPolicyDetails | EventDetailsSharingChangeLinkDefaultExpirationPolicyDetails | EventDetailsSharingChangeLinkEnforcePasswordPolicyDetails | EventDetailsSharingChangeLinkPolicyDetails | EventDetailsSharingChangeMemberPolicyDetails | EventDetailsShowcaseChangeDownloadPolicyDetails | EventDetailsShowcaseChangeEnabledPolicyDetails | EventDetailsShowcaseChangeExternalSharingPolicyDetails | EventDetailsSignExternalSharingPolicyChangedDetails | EventDetailsSignTemplateCreationPermissionChangedDetails | EventDetailsSmarterSmartSyncPolicyChangedDetails | EventDetailsSmartSyncChangePolicyDetails | EventDetailsSmartSyncNotOptOutDetails | EventDetailsSmartSyncOptOutDetails | EventDetailsSsoChangePolicyDetails | EventDetailsStackCrossTeamAccessPolicyChangedDetails | EventDetailsTeamBrandingPolicyChangedDetails | EventDetailsTeamExtensionsPolicyChangedDetails | EventDetailsTeamMemberStorageRequestPolicyChangedDetails | EventDetailsTeamSelectiveSyncPolicyChangedDetails | EventDetailsTeamSharingWhitelistSubjectsChangedDetails | EventDetailsTfaAddExceptionDetails | EventDetailsTfaChangePolicyDetails | EventDetailsTfaRemoveExceptionDetails | EventDetailsTopLevelContentPolicyChangedDetails | EventDetailsTwoAccountChangePolicyDetails | EventDetailsViewerInfoPolicyChangedDetails | EventDetailsWatermarkingPolicyChangedDetails | EventDetailsWebSessionsChangeActiveSessionLimitDetails | EventDetailsWebSessionsChangeFixedLengthPolicyDetails | EventDetailsWebSessionsChangeIdleLengthPolicyDetails | EventDetailsDataResidencyMigrationRequestSuccessfulDetails | EventDetailsDataResidencyMigrationRequestUnsuccessfulDetails | EventDetailsTeamMergeFromDetails | EventDetailsTeamMergeToDetails | EventDetailsTeamProfileAddBackgroundDetails | EventDetailsTeamProfileAddLogoDetails | EventDetailsTeamProfileChangeBackgroundDetails | EventDetailsTeamProfileChangeDefaultLanguageDetails | EventDetailsTeamProfileChangeLogoDetails | EventDetailsTeamProfileChangeNameDetails | EventDetailsTeamProfileRemoveBackgroundDetails | EventDetailsTeamProfileRemoveLogoDetails | EventDetailsPasskeyAddDetails | EventDetailsPasskeyRemoveDetails | EventDetailsTfaAddBackupPhoneDetails | EventDetailsTfaAddSecurityKeyDetails | EventDetailsTfaChangeBackupPhoneDetails | EventDetailsTfaChangeStatusDetails | EventDetailsTfaRemoveBackupPhoneDetails | EventDetailsTfaRemoveSecurityKeyDetails | EventDetailsTfaResetDetails | EventDetailsChangedEnterpriseAdminRoleDetails | EventDetailsChangedEnterpriseConnectedTeamStatusDetails | EventDetailsEndedEnterpriseAdminSessionDetails | EventDetailsEndedEnterpriseAdminSessionDeprecatedDetails | EventDetailsEnterpriseSettingsLockingDetails | EventDetailsGuestAdminChangeStatusDetails | EventDetailsStartedEnterpriseAdminSessionDetails | EventDetailsTeamMergeRequestAcceptedDetails | EventDetailsTeamMergeRequestAcceptedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestAcceptedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestAutoCanceledDetails | EventDetailsTeamMergeRequestCanceledDetails | EventDetailsTeamMergeRequestCanceledShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestCanceledShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestExpiredDetails | EventDetailsTeamMergeRequestExpiredShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestExpiredShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestRejectedShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestReminderDetails | EventDetailsTeamMergeRequestReminderShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestReminderShownToSecondaryTeamDetails | EventDetailsTeamMergeRequestRevokedDetails | EventDetailsTeamMergeRequestSentShownToPrimaryTeamDetails | EventDetailsTeamMergeRequestSentShownToSecondaryTeamDetails | EventDetailsMissingDetails | EventDetailsOther;
 
     /**
      * (admin_alerting) Changed an alert state
@@ -25250,7 +25529,7 @@
     }
 
     /**
-     * (file_operations) Downloaded files in Media Hub
+     * (file_operations) Downloaded files in Replay
      */
     export interface EventTypeMediaHubFileDownloaded extends MediaHubFileDownloadedType {
       '.tag': 'media_hub_file_downloaded';
@@ -25691,6 +25970,13 @@
      */
     export interface EventTypeMemberDeleteProfilePhoto extends MemberDeleteProfilePhotoType {
       '.tag': 'member_delete_profile_photo';
+    }
+
+    /**
+     * (members) Admin browsed a team member's folder contents
+     */
+    export interface EventTypeMemberFolderContentsAccessed extends MemberFolderContentsAccessedType {
+      '.tag': 'member_folder_contents_accessed';
     }
 
     /**
@@ -26171,10 +26457,87 @@
     }
 
     /**
+     * (protect) Added collaborators via Dropbox Protect
+     */
+    export interface EventTypeProtectActionAddCollaborator extends ProtectActionAddCollaboratorType {
+      '.tag': 'protect_action_add_collaborator';
+    }
+
+    /**
+     * (protect) Added a link via Dropbox Protect
+     */
+    export interface EventTypeProtectActionAddLink extends ProtectActionAddLinkType {
+      '.tag': 'protect_action_add_link';
+    }
+
+    /**
+     * (protect) Deleted content via Dropbox Protect
+     */
+    export interface EventTypeProtectActionDelete extends ProtectActionDeleteType {
+      '.tag': 'protect_action_delete';
+    }
+
+    /**
+     * (protect) Exported content via Dropbox Protect
+     */
+    export interface EventTypeProtectActionExport extends ProtectActionExportType {
+      '.tag': 'protect_action_export';
+    }
+
+    /**
+     * (protect) Removed collaborators via Dropbox Protect
+     */
+    export interface EventTypeProtectActionRemoveCollaborator extends ProtectActionRemoveCollaboratorType {
+      '.tag': 'protect_action_remove_collaborator';
+    }
+
+    /**
+     * (protect) Removed a link via Dropbox Protect
+     */
+    export interface EventTypeProtectActionRemoveLink extends ProtectActionRemoveLinkType {
+      '.tag': 'protect_action_remove_link';
+    }
+
+    /**
+     * (protect) Stopped sharing content via Dropbox Protect
+     */
+    export interface EventTypeProtectActionStopSharing extends ProtectActionStopSharingType {
+      '.tag': 'protect_action_stop_sharing';
+    }
+
+    /**
      * (protect) Modified Protect internal domains list
      */
     export interface EventTypeProtectInternalDomainsChanged extends ProtectInternalDomainsChangedType {
       '.tag': 'protect_internal_domains_changed';
+    }
+
+    /**
+     * (protect) Activated a Dropbox Protect policy
+     */
+    export interface EventTypeProtectPolicyActivated extends ProtectPolicyActivatedType {
+      '.tag': 'protect_policy_activated';
+    }
+
+    /**
+     * (protect) Deactivated a Dropbox Protect policy
+     */
+    export interface EventTypeProtectPolicyDeactivated extends ProtectPolicyDeactivatedType {
+      '.tag': 'protect_policy_deactivated';
+    }
+
+    /**
+     * (protect) Scheduled a Dropbox Protect policy
+     */
+    export interface EventTypeProtectPolicyScheduled extends ProtectPolicyScheduledType {
+      '.tag': 'protect_policy_scheduled';
+    }
+
+    /**
+     * (protect) Updated a Dropbox Protect policy
+     */
+    export interface EventTypeProtectPolicyUpdated extends ProtectPolicyUpdatedType {
+      '.tag': 'protect_policy_updated';
     }
 
     /**
@@ -26430,49 +26793,49 @@
     }
 
     /**
-     * (sharing) Added member to Media Hub project
+     * (sharing) Added member to Replay project
      */
     export interface EventTypeMediaHubProjectTeamAdd extends MediaHubProjectTeamAddType {
       '.tag': 'media_hub_project_team_add';
     }
 
     /**
-     * (sharing) Removed member from Media Hub project
+     * (sharing) Removed member from Replay project
      */
     export interface EventTypeMediaHubProjectTeamDelete extends MediaHubProjectTeamDeleteType {
       '.tag': 'media_hub_project_team_delete';
     }
 
     /**
-     * (sharing) Changed member role in Media Hub project
+     * (sharing) Changed member role in Replay project
      */
     export interface EventTypeMediaHubProjectTeamRoleChanged extends MediaHubProjectTeamRoleChangedType {
       '.tag': 'media_hub_project_team_role_changed';
     }
 
     /**
-     * (sharing) Changed Media Hub shared link audience
+     * (sharing) Changed Replay shared link audience
      */
     export interface EventTypeMediaHubSharedLinkAudienceChanged extends MediaHubSharedLinkAudienceChangedType {
       '.tag': 'media_hub_shared_link_audience_changed';
     }
 
     /**
-     * (sharing) Created Media Hub shared link
+     * (sharing) Created Replay shared link
      */
     export interface EventTypeMediaHubSharedLinkCreated extends MediaHubSharedLinkCreatedType {
       '.tag': 'media_hub_shared_link_created';
     }
 
     /**
-     * (sharing) Changed Media Hub shared link download setting
+     * (sharing) Changed Replay shared link download setting
      */
     export interface EventTypeMediaHubSharedLinkDownloadSettingChanged extends MediaHubSharedLinkDownloadSettingChangedType {
       '.tag': 'media_hub_shared_link_download_setting_changed';
     }
 
     /**
-     * (sharing) Revoked Media Hub shared link
+     * (sharing) Revoked Replay shared link
      */
     export interface EventTypeMediaHubSharedLinkRevoked extends MediaHubSharedLinkRevokedType {
       '.tag': 'media_hub_shared_link_revoked';
@@ -27817,21 +28180,21 @@
     }
 
     /**
-     * (team_policies) Changed the policy for adding people to Media Hub content
+     * (team_policies) Changed the policy for adding people to Replay content
      */
     export interface EventTypeMediaHubAddingPeoplePolicyChanged extends MediaHubAddingPeoplePolicyChangedType {
       '.tag': 'media_hub_adding_people_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for downloading Media Hub content
+     * (team_policies) Changed the policy for downloading Replay content
      */
     export interface EventTypeMediaHubDownloadPolicyChanged extends MediaHubDownloadPolicyChangedType {
       '.tag': 'media_hub_download_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for sharing Media Hub content
+     * (team_policies) Changed the policy for sharing Replay content
      */
     export interface EventTypeMediaHubLinkSharingPolicyChanged extends MediaHubLinkSharingPolicyChangedType {
       '.tag': 'media_hub_link_sharing_policy_changed';
@@ -28637,7 +29000,7 @@
     /**
      * The type of the event with description.
      */
-    export type EventType = EventTypeAdminAlertingAlertStateChanged | EventTypeAdminAlertingChangedAlertConfig | EventTypeAdminAlertingTriggeredAlert | EventTypeRansomwareRestoreProcessCompleted | EventTypeRansomwareRestoreProcessStarted | EventTypeAppBlockedByPermissions | EventTypeAppLinkTeam | EventTypeAppLinkUser | EventTypeAppUnlinkTeam | EventTypeAppUnlinkUser | EventTypeIntegrationConnected | EventTypeIntegrationDisconnected | EventTypeFileAddComment | EventTypeFileChangeCommentSubscription | EventTypeFileDeleteComment | EventTypeFileEditComment | EventTypeFileLikeComment | EventTypeFileResolveComment | EventTypeFileUnlikeComment | EventTypeFileUnresolveComment | EventTypeDashAddedCommentToStack | EventTypeDashAddedConnector | EventTypeDashAddedLinkToStack | EventTypeDashAddedTeamEmailDomainAllowlist | EventTypeDashAdminAddedOrgWideConnector | EventTypeDashAdminDisabledConnector | EventTypeDashAdminEnabledConnector | EventTypeDashAdminRemovedOrgWideConnector | EventTypeDashArchivedStack | EventTypeDashChangedAudienceOfSharedLinkToStack | EventTypeDashClonedStack | EventTypeDashConnectorToolsCall | EventTypeDashCreatedStack | EventTypeDashDeletedCommentFromStack | EventTypeDashDeletedStack | EventTypeDashEditedCommentInStack | EventTypeDashExternalUserOpenedStack | EventTypeDashFirstLaunchedDesktop | EventTypeDashFirstLaunchedExtension | EventTypeDashFirstLaunchedWebStartPage | EventTypeDashOpenedSharedLinkToStack | EventTypeDashOpenedStack | EventTypeDashPreviewOptOutStatusChanged | EventTypeDashRemovedConnector | EventTypeDashRemovedLinkFromStack | EventTypeDashRemovedSharedLinkToStack | EventTypeDashRemovedTeamEmailDomainAllowlist | EventTypeDashRenamedStack | EventTypeDashSharedLinkToStack | EventTypeDashUnarchivedStack | EventTypeDashViewedCompanyStack | EventTypeDashViewedExternalAiActivityReport | EventTypeGovernancePolicyAddFolders | EventTypeGovernancePolicyAddFolderFailed | EventTypeGovernancePolicyContentDisposed | EventTypeGovernancePolicyCreate | EventTypeGovernancePolicyDelete | EventTypeGovernancePolicyEditDetails | EventTypeGovernancePolicyEditDuration | EventTypeGovernancePolicyExportCreated | EventTypeGovernancePolicyExportRemoved | EventTypeGovernancePolicyRemoveFolders | EventTypeGovernancePolicyReportCreated | EventTypeGovernancePolicyZipPartDownloaded | EventTypeLegalHoldsActivateAHold | EventTypeLegalHoldsAddMembers | EventTypeLegalHoldsChangeHoldDetails | EventTypeLegalHoldsChangeHoldName | EventTypeLegalHoldsExportAHold | EventTypeLegalHoldsExportCancelled | EventTypeLegalHoldsExportDownloaded | EventTypeLegalHoldsExportRemoved | EventTypeLegalHoldsReleaseAHold | EventTypeLegalHoldsRemoveMembers | EventTypeLegalHoldsReportAHold | EventTypeDeviceChangeIpDesktop | EventTypeDeviceChangeIpMobile | EventTypeDeviceChangeIpWeb | EventTypeDeviceDeleteOnUnlinkFail | EventTypeDeviceDeleteOnUnlinkSuccess | EventTypeDeviceLinkFail | EventTypeDeviceLinkSuccess | EventTypeDeviceManagementDisabled | EventTypeDeviceManagementEnabled | EventTypeDeviceSyncBackupStatusChanged | EventTypeDeviceUnlink | EventTypeDropboxPasswordsExported | EventTypeDropboxPasswordsNewDeviceEnrolled | EventTypeEmmRefreshAuthToken | EventTypeExternalDriveBackupEligibilityStatusChecked | EventTypeExternalDriveBackupStatusChanged | EventTypeAccountCaptureChangeAvailability | EventTypeAccountCaptureMigrateAccount | EventTypeAccountCaptureNotificationEmailsSent | EventTypeAccountCaptureRelinquishAccount | EventTypeDisabledDomainInvites | EventTypeDomainInvitesApproveRequestToJoinTeam | EventTypeDomainInvitesDeclineRequestToJoinTeam | EventTypeDomainInvitesEmailExistingUsers | EventTypeDomainInvitesRequestToJoinTeam | EventTypeDomainInvitesSetInviteNewUserPrefToNo | EventTypeDomainInvitesSetInviteNewUserPrefToYes | EventTypeDomainVerificationAddDomainFail | EventTypeDomainVerificationAddDomainSuccess | EventTypeDomainVerificationRemoveDomain | EventTypeEnabledDomainInvites | EventTypeEncryptedFolderCancelTeamKeyRotation | EventTypeEncryptedFolderEnrollBackupKey | EventTypeEncryptedFolderEnrollClient | EventTypeEncryptedFolderEnrollTeam | EventTypeEncryptedFolderFinishTeamUnenrollment | EventTypeEncryptedFolderInitTeamKeyRotation | EventTypeEncryptedFolderInitTeamUnenrollment | EventTypeEncryptedFolderRemoveBackupKey | EventTypeEncryptedFolderRotateTeamKey | EventTypeEncryptedFolderUnenrollClient | EventTypeTeamEncryptionKeyActivateKey | EventTypeTeamEncryptionKeyCancelKeyDeletion | EventTypeTeamEncryptionKeyCreateKey | EventTypeTeamEncryptionKeyDeactivateKey | EventTypeTeamEncryptionKeyDeleteKey | EventTypeTeamEncryptionKeyDisableKey | EventTypeTeamEncryptionKeyEnableKey | EventTypeTeamEncryptionKeyRotateKey | EventTypeTeamEncryptionKeyScheduleKeyDeletion | EventTypeApplyNamingConvention | EventTypeCreateFolder | EventTypeFileAdd | EventTypeFileAddFromAutomation | EventTypeFileCopy | EventTypeFileDelete | EventTypeFileDownload | EventTypeFileEdit | EventTypeFileGetCopyReference | EventTypeFileLockingLockStatusChanged | EventTypeFileMove | EventTypeFilePermanentlyDelete | EventTypeFilePreview | EventTypeFileRename | EventTypeFileRestore | EventTypeFileRevert | EventTypeFileRollbackChanges | EventTypeFileSaveCopyReference | EventTypeFolderOverviewDescriptionChanged | EventTypeFolderOverviewItemPinned | EventTypeFolderOverviewItemUnpinned | EventTypeMediaHubFileDownloaded | EventTypeObjectLabelAdded | EventTypeObjectLabelRemoved | EventTypeObjectLabelUpdatedValue | EventTypeOrganizeFolderWithTidy | EventTypeReplayFileDelete | EventTypeReplayFileDownloaded | EventTypeReplayTeamProjectCreated | EventTypeRewindFolder | EventTypeUndoNamingConvention | EventTypeUndoOrganizeFolderWithTidy | EventTypeUserTagsAdded | EventTypeUserTagsRemoved | EventTypeEmailIngestReceiveFile | EventTypeFileRequestAutoClose | EventTypeFileRequestChange | EventTypeFileRequestClose | EventTypeFileRequestCreate | EventTypeFileRequestDelete | EventTypeFileRequestReceiveFile | EventTypeGroupAddExternalId | EventTypeGroupAddMember | EventTypeGroupChangeExternalId | EventTypeGroupChangeManagementType | EventTypeGroupChangeMemberRole | EventTypeGroupCreate | EventTypeGroupDelete | EventTypeGroupDescriptionUpdated | EventTypeGroupExternalSharingSettingOverrideChanged | EventTypeGroupJoinPolicyUpdated | EventTypeGroupMoved | EventTypeGroupRemoveExternalId | EventTypeGroupRemoveMember | EventTypeGroupRename | EventTypeAccountLockOrUnlocked | EventTypeEmmError | EventTypeGuestAdminSignedInViaTrustedTeams | EventTypeGuestAdminSignedOutViaTrustedTeams | EventTypeLoginFail | EventTypeLoginSuccess | EventTypeLogout | EventTypeResellerSupportSessionEnd | EventTypeResellerSupportSessionStart | EventTypeSignInAsSessionEnd | EventTypeSignInAsSessionStart | EventTypeSsoError | EventTypeAddonAssigned | EventTypeAddonRemoved | EventTypeBackupAdminInvitationSent | EventTypeBackupInvitationOpened | EventTypeCreateTeamInviteLink | EventTypeDeleteTeamInviteLink | EventTypeMemberAddExternalId | EventTypeMemberAddName | EventTypeMemberChangeAdminRole | EventTypeMemberChangeEmail | EventTypeMemberChangeExternalId | EventTypeMemberChangeMembershipType | EventTypeMemberChangeName | EventTypeMemberChangeResellerRole | EventTypeMemberChangeStatus | EventTypeMemberDeleteManualContacts | EventTypeMemberDeleteProfilePhoto | EventTypeMemberPermanentlyDeleteAccountContents | EventTypeMemberRemoveExternalId | EventTypeMemberSetProfilePhoto | EventTypeMemberSpaceLimitsAddCustomQuota | EventTypeMemberSpaceLimitsChangeCustomQuota | EventTypeMemberSpaceLimitsChangeStatus | EventTypeMemberSpaceLimitsRemoveCustomQuota | EventTypeMemberSuggest | EventTypeMemberTransferAccountContents | EventTypePendingSecondaryEmailAdded | EventTypeProductAssignedToMember | EventTypeProductRemovedFromMember | EventTypeSecondaryEmailDeleted | EventTypeSecondaryEmailVerified | EventTypeSecondaryMailsPolicyChanged | EventTypeBinderAddPage | EventTypeBinderAddSection | EventTypeBinderRemovePage | EventTypeBinderRemoveSection | EventTypeBinderRenamePage | EventTypeBinderRenameSection | EventTypeBinderReorderPage | EventTypeBinderReorderSection | EventTypePaperContentAddMember | EventTypePaperContentAddToFolder | EventTypePaperContentArchive | EventTypePaperContentCreate | EventTypePaperContentPermanentlyDelete | EventTypePaperContentRemoveFromFolder | EventTypePaperContentRemoveMember | EventTypePaperContentRename | EventTypePaperContentRestore | EventTypePaperDocAddComment | EventTypePaperDocChangeMemberRole | EventTypePaperDocChangeSharingPolicy | EventTypePaperDocChangeSubscription | EventTypePaperDocDeleted | EventTypePaperDocDeleteComment | EventTypePaperDocDownload | EventTypePaperDocEdit | EventTypePaperDocEditComment | EventTypePaperDocFollowed | EventTypePaperDocMention | EventTypePaperDocOwnershipChanged | EventTypePaperDocRequestAccess | EventTypePaperDocResolveComment | EventTypePaperDocRevert | EventTypePaperDocSlackShare | EventTypePaperDocTeamInvite | EventTypePaperDocTrashed | EventTypePaperDocUnresolveComment | EventTypePaperDocUntrashed | EventTypePaperDocView | EventTypePaperExternalViewAllow | EventTypePaperExternalViewDefaultTeam | EventTypePaperExternalViewForbid | EventTypePaperFolderChangeSubscription | EventTypePaperFolderDeleted | EventTypePaperFolderFollowed | EventTypePaperFolderTeamInvite | EventTypePaperPublishedLinkChangePermission | EventTypePaperPublishedLinkCreate | EventTypePaperPublishedLinkDisabled | EventTypePaperPublishedLinkView | EventTypePasswordChange | EventTypePasswordReset | EventTypePasswordResetAll | EventTypeProtectInternalDomainsChanged | EventTypeClassificationCreateReport | EventTypeClassificationCreateReportFail | EventTypeEmmCreateExceptionsReport | EventTypeEmmCreateUsageReport | EventTypeExportMembersReport | EventTypeExportMembersReportFail | EventTypeExternalSharingCreateReport | EventTypeExternalSharingReportFailed | EventTypeMemberAccessDetailsCreateReport | EventTypeMemberAccessDetailsCreateReportFailed | EventTypeNoExpirationLinkGenCreateReport | EventTypeNoExpirationLinkGenReportFailed | EventTypeNoPasswordLinkGenCreateReport | EventTypeNoPasswordLinkGenReportFailed | EventTypeNoPasswordLinkViewCreateReport | EventTypeNoPasswordLinkViewReportFailed | EventTypeOutdatedLinkViewCreateReport | EventTypeOutdatedLinkViewReportFailed | EventTypePaperAdminExportStart | EventTypeRansomwareAlertCreateReport | EventTypeRansomwareAlertCreateReportFailed | EventTypeSharedFoldersCreateReport | EventTypeSharedFoldersCreateReportFailed | EventTypeSmartSyncCreateAdminPrivilegeReport | EventTypeTeamActivityCreateReport | EventTypeTeamActivityCreateReportFail | EventTypeTeamFoldersCreateReport | EventTypeTeamFoldersCreateReportFailed | EventTypeTeamStorageCreateReport | EventTypeTeamStorageCreateReportFailed | EventTypeCollectionShare | EventTypeFileTransfersFileAdd | EventTypeFileTransfersTransferDelete | EventTypeFileTransfersTransferDownload | EventTypeFileTransfersTransferSend | EventTypeFileTransfersTransferView | EventTypeMediaHubProjectTeamAdd | EventTypeMediaHubProjectTeamDelete | EventTypeMediaHubProjectTeamRoleChanged | EventTypeMediaHubSharedLinkAudienceChanged | EventTypeMediaHubSharedLinkCreated | EventTypeMediaHubSharedLinkDownloadSettingChanged | EventTypeMediaHubSharedLinkRevoked | EventTypeNoteAclInviteOnly | EventTypeNoteAclLink | EventTypeNoteAclTeamLink | EventTypeNoteShared | EventTypeNoteShareReceive | EventTypeOpenNoteShared | EventTypeReplayFileSharedLinkCreated | EventTypeReplayFileSharedLinkModified | EventTypeReplayProjectTeamAdd | EventTypeReplayProjectTeamDelete | EventTypeSendAndTrackFileAdded | EventTypeSendAndTrackFileRenamed | EventTypeSendAndTrackFileUpdated | EventTypeSendAndTrackLinkCreated | EventTypeSendAndTrackLinkDeleted | EventTypeSendAndTrackLinkUpdated | EventTypeSendAndTrackLinkViewed | EventTypeSendAndTrackRemovedFileAndAssociatedLinks | EventTypeSfAddGroup | EventTypeSfAllowNonMembersToViewSharedLinks | EventTypeSfExternalInviteWarn | EventTypeSfFbInvite | EventTypeSfFbInviteChangeRole | EventTypeSfFbUninvite | EventTypeSfInviteGroup | EventTypeSfTeamGrantAccess | EventTypeSfTeamInvite | EventTypeSfTeamInviteChangeRole | EventTypeSfTeamJoin | EventTypeSfTeamJoinFromOobLink | EventTypeSfTeamUninvite | EventTypeSharedContentAddInvitees | EventTypeSharedContentAddLinkExpiry | EventTypeSharedContentAddLinkPassword | EventTypeSharedContentAddMember | EventTypeSharedContentChangeDownloadsPolicy | EventTypeSharedContentChangeInviteeRole | EventTypeSharedContentChangeLinkAudience | EventTypeSharedContentChangeLinkExpiry | EventTypeSharedContentChangeLinkPassword | EventTypeSharedContentChangeMemberRole | EventTypeSharedContentChangeViewerInfoPolicy | EventTypeSharedContentClaimInvitation | EventTypeSharedContentCopy | EventTypeSharedContentDownload | EventTypeSharedContentRelinquishMembership | EventTypeSharedContentRemoveInvitees | EventTypeSharedContentRemoveLinkExpiry | EventTypeSharedContentRemoveLinkPassword | EventTypeSharedContentRemoveMember | EventTypeSharedContentRequestAccess | EventTypeSharedContentRestoreInvitees | EventTypeSharedContentRestoreMember | EventTypeSharedContentUnshare | EventTypeSharedContentView | EventTypeSharedFolderChangeLinkPolicy | EventTypeSharedFolderChangeMembersInheritancePolicy | EventTypeSharedFolderChangeMembersManagementPolicy | EventTypeSharedFolderChangeMembersPolicy | EventTypeSharedFolderCreate | EventTypeSharedFolderDeclineInvitation | EventTypeSharedFolderMount | EventTypeSharedFolderNest | EventTypeSharedFolderTransferOwnership | EventTypeSharedFolderUnmount | EventTypeSharedLinkAddExpiry | EventTypeSharedLinkChangeExpiry | EventTypeSharedLinkChangeVisibility | EventTypeSharedLinkCopy | EventTypeSharedLinkCreate | EventTypeSharedLinkDisable | EventTypeSharedLinkDownload | EventTypeSharedLinkRemoveExpiry | EventTypeSharedLinkRemoveVisitor | EventTypeSharedLinkSettingsAddExpiration | EventTypeSharedLinkSettingsAddPassword | EventTypeSharedLinkSettingsAllowDownloadDisabled | EventTypeSharedLinkSettingsAllowDownloadEnabled | EventTypeSharedLinkSettingsChangeAudience | EventTypeSharedLinkSettingsChangeExpiration | EventTypeSharedLinkSettingsChangePassword | EventTypeSharedLinkSettingsRemoveExpiration | EventTypeSharedLinkSettingsRemovePassword | EventTypeSharedLinkShare | EventTypeSharedLinkView | EventTypeSharedNoteOpened | EventTypeShmodelDisableDownloads | EventTypeShmodelEnableDownloads | EventTypeShmodelGroupShare | EventTypeShowcaseAccessGranted | EventTypeShowcaseAddMember | EventTypeShowcaseArchived | EventTypeShowcaseCreated | EventTypeShowcaseDeleteComment | EventTypeShowcaseEdited | EventTypeShowcaseEditComment | EventTypeShowcaseFileAdded | EventTypeShowcaseFileDownload | EventTypeShowcaseFileRemoved | EventTypeShowcaseFileView | EventTypeShowcasePermanentlyDeleted | EventTypeShowcasePostComment | EventTypeShowcaseRemoveMember | EventTypeShowcaseRenamed | EventTypeShowcaseRequestAccess | EventTypeShowcaseResolveComment | EventTypeShowcaseRestored | EventTypeShowcaseTrashed | EventTypeShowcaseTrashedDeprecated | EventTypeShowcaseUnresolveComment | EventTypeShowcaseUntrashed | EventTypeShowcaseUntrashedDeprecated | EventTypeShowcaseView | EventTypeSignSignatureRequestCanceled | EventTypeSignSignatureRequestCompleted | EventTypeSignSignatureRequestDeclined | EventTypeSignSignatureRequestOpened | EventTypeSignSignatureRequestReminderSent | EventTypeSignSignatureRequestSent | EventTypeSignTemplateCreated | EventTypeSignTemplateShared | EventTypeRiscSecurityEvent | EventTypeSsoAddCert | EventTypeSsoAddLoginUrl | EventTypeSsoAddLogoutUrl | EventTypeSsoChangeCert | EventTypeSsoChangeLoginUrl | EventTypeSsoChangeLogoutUrl | EventTypeSsoChangeSamlIdentityMode | EventTypeSsoRemoveCert | EventTypeSsoRemoveLoginUrl | EventTypeSsoRemoveLogoutUrl | EventTypeTeamFolderChangeStatus | EventTypeTeamFolderCreate | EventTypeTeamFolderDowngrade | EventTypeTeamFolderPermanentlyDelete | EventTypeTeamFolderRename | EventTypeTeamFolderSpaceLimitsChangeCapsType | EventTypeTeamFolderSpaceLimitsChangeLimit | EventTypeTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeTeamSelectiveSyncSettingsChanged | EventTypeAccountCaptureChangePolicy | EventTypeAdminEmailRemindersChanged | EventTypeAiThirdPartySharingDropboxBasePolicyChanged | EventTypeAllowDownloadDisabled | EventTypeAllowDownloadEnabled | EventTypeAppleLoginChangePolicy | EventTypeAppPermissionsChanged | EventTypeCameraUploadsPolicyChanged | EventTypeCaptureTeamSpacePolicyChanged | EventTypeCaptureTranscriptPolicyChanged | EventTypeClassificationChangePolicy | EventTypeComputerBackupPolicyChanged | EventTypeContentAdministrationPolicyChanged | EventTypeContentDeletionProtectionChangePolicy | EventTypeDashExternalSharingPolicyChanged | EventTypeDataPlacementRestrictionChangePolicy | EventTypeDataPlacementRestrictionSatisfyPolicy | EventTypeDeviceApprovalsAddException | EventTypeDeviceApprovalsChangeDesktopPolicy | EventTypeDeviceApprovalsChangeMobilePolicy | EventTypeDeviceApprovalsChangeOverageAction | EventTypeDeviceApprovalsChangeUnlinkAction | EventTypeDeviceApprovalsRemoveException | EventTypeDirectoryRestrictionsAddMembers | EventTypeDirectoryRestrictionsRemoveMembers | EventTypeDropboxPasswordsPolicyChanged | EventTypeEmailIngestPolicyChanged | EventTypeEmmAddException | EventTypeEmmChangePolicy | EventTypeEmmRemoveException | EventTypeExtendedVersionHistoryChangePolicy | EventTypeExternalDriveBackupPolicyChanged | EventTypeFileCommentsChangePolicy | EventTypeFileLockingPolicyChanged | EventTypeFileProviderMigrationPolicyChanged | EventTypeFileRequestsChangePolicy | EventTypeFileRequestsEmailsEnabled | EventTypeFileRequestsEmailsRestrictedToTeamOnly | EventTypeFileTransfersPolicyChanged | EventTypeFlexibleFileNamesPolicyChanged | EventTypeFolderLinkRestrictionPolicyChanged | EventTypeGoogleSsoChangePolicy | EventTypeGroupUserManagementChangePolicy | EventTypeIntegrationPolicyChanged | EventTypeInviteAcceptanceEmailPolicyChanged | EventTypeMediaHubAddingPeoplePolicyChanged | EventTypeMediaHubDownloadPolicyChanged | EventTypeMediaHubLinkSharingPolicyChanged | EventTypeMemberRequestsChangePolicy | EventTypeMemberSendInvitePolicyChanged | EventTypeMemberSpaceLimitsAddException | EventTypeMemberSpaceLimitsChangeCapsTypePolicy | EventTypeMemberSpaceLimitsChangePolicy | EventTypeMemberSpaceLimitsRemoveException | EventTypeMemberSuggestionsChangePolicy | EventTypeMicrosoftLoginChangePolicy | EventTypeMicrosoftOfficeAddinChangePolicy | EventTypeMultiTeamIdentityPolicyChanged | EventTypeNetworkControlChangePolicy | EventTypePaperChangeDeploymentPolicy | EventTypePaperChangeMemberLinkPolicy | EventTypePaperChangeMemberPolicy | EventTypePaperChangePolicy | EventTypePaperDefaultFolderPolicyChanged | EventTypePaperDesktopPolicyChanged | EventTypePaperEnabledUsersGroupAddition | EventTypePaperEnabledUsersGroupRemoval | EventTypePasskeyLoginPolicyChanged | EventTypePasswordStrengthRequirementsChangePolicy | EventTypePermanentDeleteChangePolicy | EventTypePreviewsAiPolicyChanged | EventTypeReplayAddingPeoplePolicyChanged | EventTypeReplaySharingPolicyChanged | EventTypeResellerSupportChangePolicy | EventTypeRewindPolicyChanged | EventTypeSendAndTrackPolicyChanged | EventTypeSendExternalSharingPolicyChanged | EventTypeSendForSignaturePolicyChanged | EventTypeSharedLinkDefaultPermissionsPolicyChanged | EventTypeSharingChangeFolderJoinPolicy | EventTypeSharingChangeLinkAllowChangeExpirationPolicy | EventTypeSharingChangeLinkDefaultExpirationPolicy | EventTypeSharingChangeLinkEnforcePasswordPolicy | EventTypeSharingChangeLinkPolicy | EventTypeSharingChangeMemberPolicy | EventTypeShowcaseChangeDownloadPolicy | EventTypeShowcaseChangeEnabledPolicy | EventTypeShowcaseChangeExternalSharingPolicy | EventTypeSignExternalSharingPolicyChanged | EventTypeSignTemplateCreationPermissionChanged | EventTypeSmarterSmartSyncPolicyChanged | EventTypeSmartSyncChangePolicy | EventTypeSmartSyncNotOptOut | EventTypeSmartSyncOptOut | EventTypeSsoChangePolicy | EventTypeStackCrossTeamAccessPolicyChanged | EventTypeTeamBrandingPolicyChanged | EventTypeTeamExtensionsPolicyChanged | EventTypeTeamMemberStorageRequestPolicyChanged | EventTypeTeamSelectiveSyncPolicyChanged | EventTypeTeamSharingWhitelistSubjectsChanged | EventTypeTfaAddException | EventTypeTfaChangePolicy | EventTypeTfaRemoveException | EventTypeTopLevelContentPolicyChanged | EventTypeTwoAccountChangePolicy | EventTypeViewerInfoPolicyChanged | EventTypeWatermarkingPolicyChanged | EventTypeWebSessionsChangeActiveSessionLimit | EventTypeWebSessionsChangeFixedLengthPolicy | EventTypeWebSessionsChangeIdleLengthPolicy | EventTypeDataResidencyMigrationRequestSuccessful | EventTypeDataResidencyMigrationRequestUnsuccessful | EventTypeTeamMergeFrom | EventTypeTeamMergeTo | EventTypeTeamProfileAddBackground | EventTypeTeamProfileAddLogo | EventTypeTeamProfileChangeBackground | EventTypeTeamProfileChangeDefaultLanguage | EventTypeTeamProfileChangeLogo | EventTypeTeamProfileChangeName | EventTypeTeamProfileRemoveBackground | EventTypeTeamProfileRemoveLogo | EventTypePasskeyAdd | EventTypePasskeyRemove | EventTypeTfaAddBackupPhone | EventTypeTfaAddSecurityKey | EventTypeTfaChangeBackupPhone | EventTypeTfaChangeStatus | EventTypeTfaRemoveBackupPhone | EventTypeTfaRemoveSecurityKey | EventTypeTfaReset | EventTypeChangedEnterpriseAdminRole | EventTypeChangedEnterpriseConnectedTeamStatus | EventTypeEndedEnterpriseAdminSession | EventTypeEndedEnterpriseAdminSessionDeprecated | EventTypeEnterpriseSettingsLocking | EventTypeGuestAdminChangeStatus | EventTypeStartedEnterpriseAdminSession | EventTypeTeamMergeRequestAccepted | EventTypeTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeTeamMergeRequestAutoCanceled | EventTypeTeamMergeRequestCanceled | EventTypeTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeTeamMergeRequestExpired | EventTypeTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeTeamMergeRequestReminder | EventTypeTeamMergeRequestReminderShownToPrimaryTeam | EventTypeTeamMergeRequestReminderShownToSecondaryTeam | EventTypeTeamMergeRequestRevoked | EventTypeTeamMergeRequestSentShownToPrimaryTeam | EventTypeTeamMergeRequestSentShownToSecondaryTeam | EventTypeOther;
+    export type EventType = EventTypeAdminAlertingAlertStateChanged | EventTypeAdminAlertingChangedAlertConfig | EventTypeAdminAlertingTriggeredAlert | EventTypeRansomwareRestoreProcessCompleted | EventTypeRansomwareRestoreProcessStarted | EventTypeAppBlockedByPermissions | EventTypeAppLinkTeam | EventTypeAppLinkUser | EventTypeAppUnlinkTeam | EventTypeAppUnlinkUser | EventTypeIntegrationConnected | EventTypeIntegrationDisconnected | EventTypeFileAddComment | EventTypeFileChangeCommentSubscription | EventTypeFileDeleteComment | EventTypeFileEditComment | EventTypeFileLikeComment | EventTypeFileResolveComment | EventTypeFileUnlikeComment | EventTypeFileUnresolveComment | EventTypeDashAddedCommentToStack | EventTypeDashAddedConnector | EventTypeDashAddedLinkToStack | EventTypeDashAddedTeamEmailDomainAllowlist | EventTypeDashAdminAddedOrgWideConnector | EventTypeDashAdminDisabledConnector | EventTypeDashAdminEnabledConnector | EventTypeDashAdminRemovedOrgWideConnector | EventTypeDashArchivedStack | EventTypeDashChangedAudienceOfSharedLinkToStack | EventTypeDashClonedStack | EventTypeDashConnectorToolsCall | EventTypeDashCreatedStack | EventTypeDashDeletedCommentFromStack | EventTypeDashDeletedStack | EventTypeDashEditedCommentInStack | EventTypeDashExternalUserOpenedStack | EventTypeDashFirstLaunchedDesktop | EventTypeDashFirstLaunchedExtension | EventTypeDashFirstLaunchedWebStartPage | EventTypeDashOpenedSharedLinkToStack | EventTypeDashOpenedStack | EventTypeDashPreviewOptOutStatusChanged | EventTypeDashRemovedConnector | EventTypeDashRemovedLinkFromStack | EventTypeDashRemovedSharedLinkToStack | EventTypeDashRemovedTeamEmailDomainAllowlist | EventTypeDashRenamedStack | EventTypeDashSharedLinkToStack | EventTypeDashUnarchivedStack | EventTypeDashViewedCompanyStack | EventTypeDashViewedExternalAiActivityReport | EventTypeGovernancePolicyAddFolders | EventTypeGovernancePolicyAddFolderFailed | EventTypeGovernancePolicyContentDisposed | EventTypeGovernancePolicyCreate | EventTypeGovernancePolicyDelete | EventTypeGovernancePolicyEditDetails | EventTypeGovernancePolicyEditDuration | EventTypeGovernancePolicyExportCreated | EventTypeGovernancePolicyExportRemoved | EventTypeGovernancePolicyRemoveFolders | EventTypeGovernancePolicyReportCreated | EventTypeGovernancePolicyZipPartDownloaded | EventTypeLegalHoldsActivateAHold | EventTypeLegalHoldsAddMembers | EventTypeLegalHoldsChangeHoldDetails | EventTypeLegalHoldsChangeHoldName | EventTypeLegalHoldsExportAHold | EventTypeLegalHoldsExportCancelled | EventTypeLegalHoldsExportDownloaded | EventTypeLegalHoldsExportRemoved | EventTypeLegalHoldsReleaseAHold | EventTypeLegalHoldsRemoveMembers | EventTypeLegalHoldsReportAHold | EventTypeDeviceChangeIpDesktop | EventTypeDeviceChangeIpMobile | EventTypeDeviceChangeIpWeb | EventTypeDeviceDeleteOnUnlinkFail | EventTypeDeviceDeleteOnUnlinkSuccess | EventTypeDeviceLinkFail | EventTypeDeviceLinkSuccess | EventTypeDeviceManagementDisabled | EventTypeDeviceManagementEnabled | EventTypeDeviceSyncBackupStatusChanged | EventTypeDeviceUnlink | EventTypeDropboxPasswordsExported | EventTypeDropboxPasswordsNewDeviceEnrolled | EventTypeEmmRefreshAuthToken | EventTypeExternalDriveBackupEligibilityStatusChecked | EventTypeExternalDriveBackupStatusChanged | EventTypeAccountCaptureChangeAvailability | EventTypeAccountCaptureMigrateAccount | EventTypeAccountCaptureNotificationEmailsSent | EventTypeAccountCaptureRelinquishAccount | EventTypeDisabledDomainInvites | EventTypeDomainInvitesApproveRequestToJoinTeam | EventTypeDomainInvitesDeclineRequestToJoinTeam | EventTypeDomainInvitesEmailExistingUsers | EventTypeDomainInvitesRequestToJoinTeam | EventTypeDomainInvitesSetInviteNewUserPrefToNo | EventTypeDomainInvitesSetInviteNewUserPrefToYes | EventTypeDomainVerificationAddDomainFail | EventTypeDomainVerificationAddDomainSuccess | EventTypeDomainVerificationRemoveDomain | EventTypeEnabledDomainInvites | EventTypeEncryptedFolderCancelTeamKeyRotation | EventTypeEncryptedFolderEnrollBackupKey | EventTypeEncryptedFolderEnrollClient | EventTypeEncryptedFolderEnrollTeam | EventTypeEncryptedFolderFinishTeamUnenrollment | EventTypeEncryptedFolderInitTeamKeyRotation | EventTypeEncryptedFolderInitTeamUnenrollment | EventTypeEncryptedFolderRemoveBackupKey | EventTypeEncryptedFolderRotateTeamKey | EventTypeEncryptedFolderUnenrollClient | EventTypeTeamEncryptionKeyActivateKey | EventTypeTeamEncryptionKeyCancelKeyDeletion | EventTypeTeamEncryptionKeyCreateKey | EventTypeTeamEncryptionKeyDeactivateKey | EventTypeTeamEncryptionKeyDeleteKey | EventTypeTeamEncryptionKeyDisableKey | EventTypeTeamEncryptionKeyEnableKey | EventTypeTeamEncryptionKeyRotateKey | EventTypeTeamEncryptionKeyScheduleKeyDeletion | EventTypeApplyNamingConvention | EventTypeCreateFolder | EventTypeFileAdd | EventTypeFileAddFromAutomation | EventTypeFileCopy | EventTypeFileDelete | EventTypeFileDownload | EventTypeFileEdit | EventTypeFileGetCopyReference | EventTypeFileLockingLockStatusChanged | EventTypeFileMove | EventTypeFilePermanentlyDelete | EventTypeFilePreview | EventTypeFileRename | EventTypeFileRestore | EventTypeFileRevert | EventTypeFileRollbackChanges | EventTypeFileSaveCopyReference | EventTypeFolderOverviewDescriptionChanged | EventTypeFolderOverviewItemPinned | EventTypeFolderOverviewItemUnpinned | EventTypeMediaHubFileDownloaded | EventTypeObjectLabelAdded | EventTypeObjectLabelRemoved | EventTypeObjectLabelUpdatedValue | EventTypeOrganizeFolderWithTidy | EventTypeReplayFileDelete | EventTypeReplayFileDownloaded | EventTypeReplayTeamProjectCreated | EventTypeRewindFolder | EventTypeUndoNamingConvention | EventTypeUndoOrganizeFolderWithTidy | EventTypeUserTagsAdded | EventTypeUserTagsRemoved | EventTypeEmailIngestReceiveFile | EventTypeFileRequestAutoClose | EventTypeFileRequestChange | EventTypeFileRequestClose | EventTypeFileRequestCreate | EventTypeFileRequestDelete | EventTypeFileRequestReceiveFile | EventTypeGroupAddExternalId | EventTypeGroupAddMember | EventTypeGroupChangeExternalId | EventTypeGroupChangeManagementType | EventTypeGroupChangeMemberRole | EventTypeGroupCreate | EventTypeGroupDelete | EventTypeGroupDescriptionUpdated | EventTypeGroupExternalSharingSettingOverrideChanged | EventTypeGroupJoinPolicyUpdated | EventTypeGroupMoved | EventTypeGroupRemoveExternalId | EventTypeGroupRemoveMember | EventTypeGroupRename | EventTypeAccountLockOrUnlocked | EventTypeEmmError | EventTypeGuestAdminSignedInViaTrustedTeams | EventTypeGuestAdminSignedOutViaTrustedTeams | EventTypeLoginFail | EventTypeLoginSuccess | EventTypeLogout | EventTypeResellerSupportSessionEnd | EventTypeResellerSupportSessionStart | EventTypeSignInAsSessionEnd | EventTypeSignInAsSessionStart | EventTypeSsoError | EventTypeAddonAssigned | EventTypeAddonRemoved | EventTypeBackupAdminInvitationSent | EventTypeBackupInvitationOpened | EventTypeCreateTeamInviteLink | EventTypeDeleteTeamInviteLink | EventTypeMemberAddExternalId | EventTypeMemberAddName | EventTypeMemberChangeAdminRole | EventTypeMemberChangeEmail | EventTypeMemberChangeExternalId | EventTypeMemberChangeMembershipType | EventTypeMemberChangeName | EventTypeMemberChangeResellerRole | EventTypeMemberChangeStatus | EventTypeMemberDeleteManualContacts | EventTypeMemberDeleteProfilePhoto | EventTypeMemberFolderContentsAccessed | EventTypeMemberPermanentlyDeleteAccountContents | EventTypeMemberRemoveExternalId | EventTypeMemberSetProfilePhoto | EventTypeMemberSpaceLimitsAddCustomQuota | EventTypeMemberSpaceLimitsChangeCustomQuota | EventTypeMemberSpaceLimitsChangeStatus | EventTypeMemberSpaceLimitsRemoveCustomQuota | EventTypeMemberSuggest | EventTypeMemberTransferAccountContents | EventTypePendingSecondaryEmailAdded | EventTypeProductAssignedToMember | EventTypeProductRemovedFromMember | EventTypeSecondaryEmailDeleted | EventTypeSecondaryEmailVerified | EventTypeSecondaryMailsPolicyChanged | EventTypeBinderAddPage | EventTypeBinderAddSection | EventTypeBinderRemovePage | EventTypeBinderRemoveSection | EventTypeBinderRenamePage | EventTypeBinderRenameSection | EventTypeBinderReorderPage | EventTypeBinderReorderSection | EventTypePaperContentAddMember | EventTypePaperContentAddToFolder | EventTypePaperContentArchive | EventTypePaperContentCreate | EventTypePaperContentPermanentlyDelete | EventTypePaperContentRemoveFromFolder | EventTypePaperContentRemoveMember | EventTypePaperContentRename | EventTypePaperContentRestore | EventTypePaperDocAddComment | EventTypePaperDocChangeMemberRole | EventTypePaperDocChangeSharingPolicy | EventTypePaperDocChangeSubscription | EventTypePaperDocDeleted | EventTypePaperDocDeleteComment | EventTypePaperDocDownload | EventTypePaperDocEdit | EventTypePaperDocEditComment | EventTypePaperDocFollowed | EventTypePaperDocMention | EventTypePaperDocOwnershipChanged | EventTypePaperDocRequestAccess | EventTypePaperDocResolveComment | EventTypePaperDocRevert | EventTypePaperDocSlackShare | EventTypePaperDocTeamInvite | EventTypePaperDocTrashed | EventTypePaperDocUnresolveComment | EventTypePaperDocUntrashed | EventTypePaperDocView | EventTypePaperExternalViewAllow | EventTypePaperExternalViewDefaultTeam | EventTypePaperExternalViewForbid | EventTypePaperFolderChangeSubscription | EventTypePaperFolderDeleted | EventTypePaperFolderFollowed | EventTypePaperFolderTeamInvite | EventTypePaperPublishedLinkChangePermission | EventTypePaperPublishedLinkCreate | EventTypePaperPublishedLinkDisabled | EventTypePaperPublishedLinkView | EventTypePasswordChange | EventTypePasswordReset | EventTypePasswordResetAll | EventTypeProtectActionAddCollaborator | EventTypeProtectActionAddLink | EventTypeProtectActionDelete | EventTypeProtectActionExport | EventTypeProtectActionRemoveCollaborator | EventTypeProtectActionRemoveLink | EventTypeProtectActionStopSharing | EventTypeProtectInternalDomainsChanged | EventTypeProtectPolicyActivated | EventTypeProtectPolicyDeactivated | EventTypeProtectPolicyScheduled | EventTypeProtectPolicyUpdated | EventTypeClassificationCreateReport | EventTypeClassificationCreateReportFail | EventTypeEmmCreateExceptionsReport | EventTypeEmmCreateUsageReport | EventTypeExportMembersReport | EventTypeExportMembersReportFail | EventTypeExternalSharingCreateReport | EventTypeExternalSharingReportFailed | EventTypeMemberAccessDetailsCreateReport | EventTypeMemberAccessDetailsCreateReportFailed | EventTypeNoExpirationLinkGenCreateReport | EventTypeNoExpirationLinkGenReportFailed | EventTypeNoPasswordLinkGenCreateReport | EventTypeNoPasswordLinkGenReportFailed | EventTypeNoPasswordLinkViewCreateReport | EventTypeNoPasswordLinkViewReportFailed | EventTypeOutdatedLinkViewCreateReport | EventTypeOutdatedLinkViewReportFailed | EventTypePaperAdminExportStart | EventTypeRansomwareAlertCreateReport | EventTypeRansomwareAlertCreateReportFailed | EventTypeSharedFoldersCreateReport | EventTypeSharedFoldersCreateReportFailed | EventTypeSmartSyncCreateAdminPrivilegeReport | EventTypeTeamActivityCreateReport | EventTypeTeamActivityCreateReportFail | EventTypeTeamFoldersCreateReport | EventTypeTeamFoldersCreateReportFailed | EventTypeTeamStorageCreateReport | EventTypeTeamStorageCreateReportFailed | EventTypeCollectionShare | EventTypeFileTransfersFileAdd | EventTypeFileTransfersTransferDelete | EventTypeFileTransfersTransferDownload | EventTypeFileTransfersTransferSend | EventTypeFileTransfersTransferView | EventTypeMediaHubProjectTeamAdd | EventTypeMediaHubProjectTeamDelete | EventTypeMediaHubProjectTeamRoleChanged | EventTypeMediaHubSharedLinkAudienceChanged | EventTypeMediaHubSharedLinkCreated | EventTypeMediaHubSharedLinkDownloadSettingChanged | EventTypeMediaHubSharedLinkRevoked | EventTypeNoteAclInviteOnly | EventTypeNoteAclLink | EventTypeNoteAclTeamLink | EventTypeNoteShared | EventTypeNoteShareReceive | EventTypeOpenNoteShared | EventTypeReplayFileSharedLinkCreated | EventTypeReplayFileSharedLinkModified | EventTypeReplayProjectTeamAdd | EventTypeReplayProjectTeamDelete | EventTypeSendAndTrackFileAdded | EventTypeSendAndTrackFileRenamed | EventTypeSendAndTrackFileUpdated | EventTypeSendAndTrackLinkCreated | EventTypeSendAndTrackLinkDeleted | EventTypeSendAndTrackLinkUpdated | EventTypeSendAndTrackLinkViewed | EventTypeSendAndTrackRemovedFileAndAssociatedLinks | EventTypeSfAddGroup | EventTypeSfAllowNonMembersToViewSharedLinks | EventTypeSfExternalInviteWarn | EventTypeSfFbInvite | EventTypeSfFbInviteChangeRole | EventTypeSfFbUninvite | EventTypeSfInviteGroup | EventTypeSfTeamGrantAccess | EventTypeSfTeamInvite | EventTypeSfTeamInviteChangeRole | EventTypeSfTeamJoin | EventTypeSfTeamJoinFromOobLink | EventTypeSfTeamUninvite | EventTypeSharedContentAddInvitees | EventTypeSharedContentAddLinkExpiry | EventTypeSharedContentAddLinkPassword | EventTypeSharedContentAddMember | EventTypeSharedContentChangeDownloadsPolicy | EventTypeSharedContentChangeInviteeRole | EventTypeSharedContentChangeLinkAudience | EventTypeSharedContentChangeLinkExpiry | EventTypeSharedContentChangeLinkPassword | EventTypeSharedContentChangeMemberRole | EventTypeSharedContentChangeViewerInfoPolicy | EventTypeSharedContentClaimInvitation | EventTypeSharedContentCopy | EventTypeSharedContentDownload | EventTypeSharedContentRelinquishMembership | EventTypeSharedContentRemoveInvitees | EventTypeSharedContentRemoveLinkExpiry | EventTypeSharedContentRemoveLinkPassword | EventTypeSharedContentRemoveMember | EventTypeSharedContentRequestAccess | EventTypeSharedContentRestoreInvitees | EventTypeSharedContentRestoreMember | EventTypeSharedContentUnshare | EventTypeSharedContentView | EventTypeSharedFolderChangeLinkPolicy | EventTypeSharedFolderChangeMembersInheritancePolicy | EventTypeSharedFolderChangeMembersManagementPolicy | EventTypeSharedFolderChangeMembersPolicy | EventTypeSharedFolderCreate | EventTypeSharedFolderDeclineInvitation | EventTypeSharedFolderMount | EventTypeSharedFolderNest | EventTypeSharedFolderTransferOwnership | EventTypeSharedFolderUnmount | EventTypeSharedLinkAddExpiry | EventTypeSharedLinkChangeExpiry | EventTypeSharedLinkChangeVisibility | EventTypeSharedLinkCopy | EventTypeSharedLinkCreate | EventTypeSharedLinkDisable | EventTypeSharedLinkDownload | EventTypeSharedLinkRemoveExpiry | EventTypeSharedLinkRemoveVisitor | EventTypeSharedLinkSettingsAddExpiration | EventTypeSharedLinkSettingsAddPassword | EventTypeSharedLinkSettingsAllowDownloadDisabled | EventTypeSharedLinkSettingsAllowDownloadEnabled | EventTypeSharedLinkSettingsChangeAudience | EventTypeSharedLinkSettingsChangeExpiration | EventTypeSharedLinkSettingsChangePassword | EventTypeSharedLinkSettingsRemoveExpiration | EventTypeSharedLinkSettingsRemovePassword | EventTypeSharedLinkShare | EventTypeSharedLinkView | EventTypeSharedNoteOpened | EventTypeShmodelDisableDownloads | EventTypeShmodelEnableDownloads | EventTypeShmodelGroupShare | EventTypeShowcaseAccessGranted | EventTypeShowcaseAddMember | EventTypeShowcaseArchived | EventTypeShowcaseCreated | EventTypeShowcaseDeleteComment | EventTypeShowcaseEdited | EventTypeShowcaseEditComment | EventTypeShowcaseFileAdded | EventTypeShowcaseFileDownload | EventTypeShowcaseFileRemoved | EventTypeShowcaseFileView | EventTypeShowcasePermanentlyDeleted | EventTypeShowcasePostComment | EventTypeShowcaseRemoveMember | EventTypeShowcaseRenamed | EventTypeShowcaseRequestAccess | EventTypeShowcaseResolveComment | EventTypeShowcaseRestored | EventTypeShowcaseTrashed | EventTypeShowcaseTrashedDeprecated | EventTypeShowcaseUnresolveComment | EventTypeShowcaseUntrashed | EventTypeShowcaseUntrashedDeprecated | EventTypeShowcaseView | EventTypeSignSignatureRequestCanceled | EventTypeSignSignatureRequestCompleted | EventTypeSignSignatureRequestDeclined | EventTypeSignSignatureRequestOpened | EventTypeSignSignatureRequestReminderSent | EventTypeSignSignatureRequestSent | EventTypeSignTemplateCreated | EventTypeSignTemplateShared | EventTypeRiscSecurityEvent | EventTypeSsoAddCert | EventTypeSsoAddLoginUrl | EventTypeSsoAddLogoutUrl | EventTypeSsoChangeCert | EventTypeSsoChangeLoginUrl | EventTypeSsoChangeLogoutUrl | EventTypeSsoChangeSamlIdentityMode | EventTypeSsoRemoveCert | EventTypeSsoRemoveLoginUrl | EventTypeSsoRemoveLogoutUrl | EventTypeTeamFolderChangeStatus | EventTypeTeamFolderCreate | EventTypeTeamFolderDowngrade | EventTypeTeamFolderPermanentlyDelete | EventTypeTeamFolderRename | EventTypeTeamFolderSpaceLimitsChangeCapsType | EventTypeTeamFolderSpaceLimitsChangeLimit | EventTypeTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeTeamSelectiveSyncSettingsChanged | EventTypeAccountCaptureChangePolicy | EventTypeAdminEmailRemindersChanged | EventTypeAiThirdPartySharingDropboxBasePolicyChanged | EventTypeAllowDownloadDisabled | EventTypeAllowDownloadEnabled | EventTypeAppleLoginChangePolicy | EventTypeAppPermissionsChanged | EventTypeCameraUploadsPolicyChanged | EventTypeCaptureTeamSpacePolicyChanged | EventTypeCaptureTranscriptPolicyChanged | EventTypeClassificationChangePolicy | EventTypeComputerBackupPolicyChanged | EventTypeContentAdministrationPolicyChanged | EventTypeContentDeletionProtectionChangePolicy | EventTypeDashExternalSharingPolicyChanged | EventTypeDataPlacementRestrictionChangePolicy | EventTypeDataPlacementRestrictionSatisfyPolicy | EventTypeDeviceApprovalsAddException | EventTypeDeviceApprovalsChangeDesktopPolicy | EventTypeDeviceApprovalsChangeMobilePolicy | EventTypeDeviceApprovalsChangeOverageAction | EventTypeDeviceApprovalsChangeUnlinkAction | EventTypeDeviceApprovalsRemoveException | EventTypeDirectoryRestrictionsAddMembers | EventTypeDirectoryRestrictionsRemoveMembers | EventTypeDropboxPasswordsPolicyChanged | EventTypeEmailIngestPolicyChanged | EventTypeEmmAddException | EventTypeEmmChangePolicy | EventTypeEmmRemoveException | EventTypeExtendedVersionHistoryChangePolicy | EventTypeExternalDriveBackupPolicyChanged | EventTypeFileCommentsChangePolicy | EventTypeFileLockingPolicyChanged | EventTypeFileProviderMigrationPolicyChanged | EventTypeFileRequestsChangePolicy | EventTypeFileRequestsEmailsEnabled | EventTypeFileRequestsEmailsRestrictedToTeamOnly | EventTypeFileTransfersPolicyChanged | EventTypeFlexibleFileNamesPolicyChanged | EventTypeFolderLinkRestrictionPolicyChanged | EventTypeGoogleSsoChangePolicy | EventTypeGroupUserManagementChangePolicy | EventTypeIntegrationPolicyChanged | EventTypeInviteAcceptanceEmailPolicyChanged | EventTypeMediaHubAddingPeoplePolicyChanged | EventTypeMediaHubDownloadPolicyChanged | EventTypeMediaHubLinkSharingPolicyChanged | EventTypeMemberRequestsChangePolicy | EventTypeMemberSendInvitePolicyChanged | EventTypeMemberSpaceLimitsAddException | EventTypeMemberSpaceLimitsChangeCapsTypePolicy | EventTypeMemberSpaceLimitsChangePolicy | EventTypeMemberSpaceLimitsRemoveException | EventTypeMemberSuggestionsChangePolicy | EventTypeMicrosoftLoginChangePolicy | EventTypeMicrosoftOfficeAddinChangePolicy | EventTypeMultiTeamIdentityPolicyChanged | EventTypeNetworkControlChangePolicy | EventTypePaperChangeDeploymentPolicy | EventTypePaperChangeMemberLinkPolicy | EventTypePaperChangeMemberPolicy | EventTypePaperChangePolicy | EventTypePaperDefaultFolderPolicyChanged | EventTypePaperDesktopPolicyChanged | EventTypePaperEnabledUsersGroupAddition | EventTypePaperEnabledUsersGroupRemoval | EventTypePasskeyLoginPolicyChanged | EventTypePasswordStrengthRequirementsChangePolicy | EventTypePermanentDeleteChangePolicy | EventTypePreviewsAiPolicyChanged | EventTypeReplayAddingPeoplePolicyChanged | EventTypeReplaySharingPolicyChanged | EventTypeResellerSupportChangePolicy | EventTypeRewindPolicyChanged | EventTypeSendAndTrackPolicyChanged | EventTypeSendExternalSharingPolicyChanged | EventTypeSendForSignaturePolicyChanged | EventTypeSharedLinkDefaultPermissionsPolicyChanged | EventTypeSharingChangeFolderJoinPolicy | EventTypeSharingChangeLinkAllowChangeExpirationPolicy | EventTypeSharingChangeLinkDefaultExpirationPolicy | EventTypeSharingChangeLinkEnforcePasswordPolicy | EventTypeSharingChangeLinkPolicy | EventTypeSharingChangeMemberPolicy | EventTypeShowcaseChangeDownloadPolicy | EventTypeShowcaseChangeEnabledPolicy | EventTypeShowcaseChangeExternalSharingPolicy | EventTypeSignExternalSharingPolicyChanged | EventTypeSignTemplateCreationPermissionChanged | EventTypeSmarterSmartSyncPolicyChanged | EventTypeSmartSyncChangePolicy | EventTypeSmartSyncNotOptOut | EventTypeSmartSyncOptOut | EventTypeSsoChangePolicy | EventTypeStackCrossTeamAccessPolicyChanged | EventTypeTeamBrandingPolicyChanged | EventTypeTeamExtensionsPolicyChanged | EventTypeTeamMemberStorageRequestPolicyChanged | EventTypeTeamSelectiveSyncPolicyChanged | EventTypeTeamSharingWhitelistSubjectsChanged | EventTypeTfaAddException | EventTypeTfaChangePolicy | EventTypeTfaRemoveException | EventTypeTopLevelContentPolicyChanged | EventTypeTwoAccountChangePolicy | EventTypeViewerInfoPolicyChanged | EventTypeWatermarkingPolicyChanged | EventTypeWebSessionsChangeActiveSessionLimit | EventTypeWebSessionsChangeFixedLengthPolicy | EventTypeWebSessionsChangeIdleLengthPolicy | EventTypeDataResidencyMigrationRequestSuccessful | EventTypeDataResidencyMigrationRequestUnsuccessful | EventTypeTeamMergeFrom | EventTypeTeamMergeTo | EventTypeTeamProfileAddBackground | EventTypeTeamProfileAddLogo | EventTypeTeamProfileChangeBackground | EventTypeTeamProfileChangeDefaultLanguage | EventTypeTeamProfileChangeLogo | EventTypeTeamProfileChangeName | EventTypeTeamProfileRemoveBackground | EventTypeTeamProfileRemoveLogo | EventTypePasskeyAdd | EventTypePasskeyRemove | EventTypeTfaAddBackupPhone | EventTypeTfaAddSecurityKey | EventTypeTfaChangeBackupPhone | EventTypeTfaChangeStatus | EventTypeTfaRemoveBackupPhone | EventTypeTfaRemoveSecurityKey | EventTypeTfaReset | EventTypeChangedEnterpriseAdminRole | EventTypeChangedEnterpriseConnectedTeamStatus | EventTypeEndedEnterpriseAdminSession | EventTypeEndedEnterpriseAdminSessionDeprecated | EventTypeEnterpriseSettingsLocking | EventTypeGuestAdminChangeStatus | EventTypeStartedEnterpriseAdminSession | EventTypeTeamMergeRequestAccepted | EventTypeTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeTeamMergeRequestAutoCanceled | EventTypeTeamMergeRequestCanceled | EventTypeTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeTeamMergeRequestExpired | EventTypeTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeTeamMergeRequestReminder | EventTypeTeamMergeRequestReminderShownToPrimaryTeam | EventTypeTeamMergeRequestReminderShownToSecondaryTeam | EventTypeTeamMergeRequestRevoked | EventTypeTeamMergeRequestSentShownToPrimaryTeam | EventTypeTeamMergeRequestSentShownToSecondaryTeam | EventTypeOther;
 
     /**
      * (admin_alerting) Changed an alert state
@@ -29667,7 +30030,7 @@
     }
 
     /**
-     * (file_operations) Downloaded files in Media Hub
+     * (file_operations) Downloaded files in Replay
      */
     export interface EventTypeArgMediaHubFileDownloaded {
       '.tag': 'media_hub_file_downloaded';
@@ -30108,6 +30471,13 @@
      */
     export interface EventTypeArgMemberDeleteProfilePhoto {
       '.tag': 'member_delete_profile_photo';
+    }
+
+    /**
+     * (members) Admin browsed a team member's folder contents
+     */
+    export interface EventTypeArgMemberFolderContentsAccessed {
+      '.tag': 'member_folder_contents_accessed';
     }
 
     /**
@@ -30588,10 +30958,87 @@
     }
 
     /**
+     * (protect) Added collaborators via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionAddCollaborator {
+      '.tag': 'protect_action_add_collaborator';
+    }
+
+    /**
+     * (protect) Added a link via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionAddLink {
+      '.tag': 'protect_action_add_link';
+    }
+
+    /**
+     * (protect) Deleted content via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionDelete {
+      '.tag': 'protect_action_delete';
+    }
+
+    /**
+     * (protect) Exported content via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionExport {
+      '.tag': 'protect_action_export';
+    }
+
+    /**
+     * (protect) Removed collaborators via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionRemoveCollaborator {
+      '.tag': 'protect_action_remove_collaborator';
+    }
+
+    /**
+     * (protect) Removed a link via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionRemoveLink {
+      '.tag': 'protect_action_remove_link';
+    }
+
+    /**
+     * (protect) Stopped sharing content via Dropbox Protect
+     */
+    export interface EventTypeArgProtectActionStopSharing {
+      '.tag': 'protect_action_stop_sharing';
+    }
+
+    /**
      * (protect) Modified Protect internal domains list
      */
     export interface EventTypeArgProtectInternalDomainsChanged {
       '.tag': 'protect_internal_domains_changed';
+    }
+
+    /**
+     * (protect) Activated a Dropbox Protect policy
+     */
+    export interface EventTypeArgProtectPolicyActivated {
+      '.tag': 'protect_policy_activated';
+    }
+
+    /**
+     * (protect) Deactivated a Dropbox Protect policy
+     */
+    export interface EventTypeArgProtectPolicyDeactivated {
+      '.tag': 'protect_policy_deactivated';
+    }
+
+    /**
+     * (protect) Scheduled a Dropbox Protect policy
+     */
+    export interface EventTypeArgProtectPolicyScheduled {
+      '.tag': 'protect_policy_scheduled';
+    }
+
+    /**
+     * (protect) Updated a Dropbox Protect policy
+     */
+    export interface EventTypeArgProtectPolicyUpdated {
+      '.tag': 'protect_policy_updated';
     }
 
     /**
@@ -30847,49 +31294,49 @@
     }
 
     /**
-     * (sharing) Added member to Media Hub project
+     * (sharing) Added member to Replay project
      */
     export interface EventTypeArgMediaHubProjectTeamAdd {
       '.tag': 'media_hub_project_team_add';
     }
 
     /**
-     * (sharing) Removed member from Media Hub project
+     * (sharing) Removed member from Replay project
      */
     export interface EventTypeArgMediaHubProjectTeamDelete {
       '.tag': 'media_hub_project_team_delete';
     }
 
     /**
-     * (sharing) Changed member role in Media Hub project
+     * (sharing) Changed member role in Replay project
      */
     export interface EventTypeArgMediaHubProjectTeamRoleChanged {
       '.tag': 'media_hub_project_team_role_changed';
     }
 
     /**
-     * (sharing) Changed Media Hub shared link audience
+     * (sharing) Changed Replay shared link audience
      */
     export interface EventTypeArgMediaHubSharedLinkAudienceChanged {
       '.tag': 'media_hub_shared_link_audience_changed';
     }
 
     /**
-     * (sharing) Created Media Hub shared link
+     * (sharing) Created Replay shared link
      */
     export interface EventTypeArgMediaHubSharedLinkCreated {
       '.tag': 'media_hub_shared_link_created';
     }
 
     /**
-     * (sharing) Changed Media Hub shared link download setting
+     * (sharing) Changed Replay shared link download setting
      */
     export interface EventTypeArgMediaHubSharedLinkDownloadSettingChanged {
       '.tag': 'media_hub_shared_link_download_setting_changed';
     }
 
     /**
-     * (sharing) Revoked Media Hub shared link
+     * (sharing) Revoked Replay shared link
      */
     export interface EventTypeArgMediaHubSharedLinkRevoked {
       '.tag': 'media_hub_shared_link_revoked';
@@ -32234,21 +32681,21 @@
     }
 
     /**
-     * (team_policies) Changed the policy for adding people to Media Hub content
+     * (team_policies) Changed the policy for adding people to Replay content
      */
     export interface EventTypeArgMediaHubAddingPeoplePolicyChanged {
       '.tag': 'media_hub_adding_people_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for downloading Media Hub content
+     * (team_policies) Changed the policy for downloading Replay content
      */
     export interface EventTypeArgMediaHubDownloadPolicyChanged {
       '.tag': 'media_hub_download_policy_changed';
     }
 
     /**
-     * (team_policies) Changed the policy for sharing Media Hub content
+     * (team_policies) Changed the policy for sharing Replay content
      */
     export interface EventTypeArgMediaHubLinkSharingPolicyChanged {
       '.tag': 'media_hub_link_sharing_policy_changed';
@@ -33054,7 +33501,7 @@
     /**
      * The type of the event.
      */
-    export type EventTypeArg = EventTypeArgAdminAlertingAlertStateChanged | EventTypeArgAdminAlertingChangedAlertConfig | EventTypeArgAdminAlertingTriggeredAlert | EventTypeArgRansomwareRestoreProcessCompleted | EventTypeArgRansomwareRestoreProcessStarted | EventTypeArgAppBlockedByPermissions | EventTypeArgAppLinkTeam | EventTypeArgAppLinkUser | EventTypeArgAppUnlinkTeam | EventTypeArgAppUnlinkUser | EventTypeArgIntegrationConnected | EventTypeArgIntegrationDisconnected | EventTypeArgFileAddComment | EventTypeArgFileChangeCommentSubscription | EventTypeArgFileDeleteComment | EventTypeArgFileEditComment | EventTypeArgFileLikeComment | EventTypeArgFileResolveComment | EventTypeArgFileUnlikeComment | EventTypeArgFileUnresolveComment | EventTypeArgDashAddedCommentToStack | EventTypeArgDashAddedConnector | EventTypeArgDashAddedLinkToStack | EventTypeArgDashAddedTeamEmailDomainAllowlist | EventTypeArgDashAdminAddedOrgWideConnector | EventTypeArgDashAdminDisabledConnector | EventTypeArgDashAdminEnabledConnector | EventTypeArgDashAdminRemovedOrgWideConnector | EventTypeArgDashArchivedStack | EventTypeArgDashChangedAudienceOfSharedLinkToStack | EventTypeArgDashClonedStack | EventTypeArgDashConnectorToolsCall | EventTypeArgDashCreatedStack | EventTypeArgDashDeletedCommentFromStack | EventTypeArgDashDeletedStack | EventTypeArgDashEditedCommentInStack | EventTypeArgDashExternalUserOpenedStack | EventTypeArgDashFirstLaunchedDesktop | EventTypeArgDashFirstLaunchedExtension | EventTypeArgDashFirstLaunchedWebStartPage | EventTypeArgDashOpenedSharedLinkToStack | EventTypeArgDashOpenedStack | EventTypeArgDashPreviewOptOutStatusChanged | EventTypeArgDashRemovedConnector | EventTypeArgDashRemovedLinkFromStack | EventTypeArgDashRemovedSharedLinkToStack | EventTypeArgDashRemovedTeamEmailDomainAllowlist | EventTypeArgDashRenamedStack | EventTypeArgDashSharedLinkToStack | EventTypeArgDashUnarchivedStack | EventTypeArgDashViewedCompanyStack | EventTypeArgDashViewedExternalAiActivityReport | EventTypeArgGovernancePolicyAddFolders | EventTypeArgGovernancePolicyAddFolderFailed | EventTypeArgGovernancePolicyContentDisposed | EventTypeArgGovernancePolicyCreate | EventTypeArgGovernancePolicyDelete | EventTypeArgGovernancePolicyEditDetails | EventTypeArgGovernancePolicyEditDuration | EventTypeArgGovernancePolicyExportCreated | EventTypeArgGovernancePolicyExportRemoved | EventTypeArgGovernancePolicyRemoveFolders | EventTypeArgGovernancePolicyReportCreated | EventTypeArgGovernancePolicyZipPartDownloaded | EventTypeArgLegalHoldsActivateAHold | EventTypeArgLegalHoldsAddMembers | EventTypeArgLegalHoldsChangeHoldDetails | EventTypeArgLegalHoldsChangeHoldName | EventTypeArgLegalHoldsExportAHold | EventTypeArgLegalHoldsExportCancelled | EventTypeArgLegalHoldsExportDownloaded | EventTypeArgLegalHoldsExportRemoved | EventTypeArgLegalHoldsReleaseAHold | EventTypeArgLegalHoldsRemoveMembers | EventTypeArgLegalHoldsReportAHold | EventTypeArgDeviceChangeIpDesktop | EventTypeArgDeviceChangeIpMobile | EventTypeArgDeviceChangeIpWeb | EventTypeArgDeviceDeleteOnUnlinkFail | EventTypeArgDeviceDeleteOnUnlinkSuccess | EventTypeArgDeviceLinkFail | EventTypeArgDeviceLinkSuccess | EventTypeArgDeviceManagementDisabled | EventTypeArgDeviceManagementEnabled | EventTypeArgDeviceSyncBackupStatusChanged | EventTypeArgDeviceUnlink | EventTypeArgDropboxPasswordsExported | EventTypeArgDropboxPasswordsNewDeviceEnrolled | EventTypeArgEmmRefreshAuthToken | EventTypeArgExternalDriveBackupEligibilityStatusChecked | EventTypeArgExternalDriveBackupStatusChanged | EventTypeArgAccountCaptureChangeAvailability | EventTypeArgAccountCaptureMigrateAccount | EventTypeArgAccountCaptureNotificationEmailsSent | EventTypeArgAccountCaptureRelinquishAccount | EventTypeArgDisabledDomainInvites | EventTypeArgDomainInvitesApproveRequestToJoinTeam | EventTypeArgDomainInvitesDeclineRequestToJoinTeam | EventTypeArgDomainInvitesEmailExistingUsers | EventTypeArgDomainInvitesRequestToJoinTeam | EventTypeArgDomainInvitesSetInviteNewUserPrefToNo | EventTypeArgDomainInvitesSetInviteNewUserPrefToYes | EventTypeArgDomainVerificationAddDomainFail | EventTypeArgDomainVerificationAddDomainSuccess | EventTypeArgDomainVerificationRemoveDomain | EventTypeArgEnabledDomainInvites | EventTypeArgEncryptedFolderCancelTeamKeyRotation | EventTypeArgEncryptedFolderEnrollBackupKey | EventTypeArgEncryptedFolderEnrollClient | EventTypeArgEncryptedFolderEnrollTeam | EventTypeArgEncryptedFolderFinishTeamUnenrollment | EventTypeArgEncryptedFolderInitTeamKeyRotation | EventTypeArgEncryptedFolderInitTeamUnenrollment | EventTypeArgEncryptedFolderRemoveBackupKey | EventTypeArgEncryptedFolderRotateTeamKey | EventTypeArgEncryptedFolderUnenrollClient | EventTypeArgTeamEncryptionKeyActivateKey | EventTypeArgTeamEncryptionKeyCancelKeyDeletion | EventTypeArgTeamEncryptionKeyCreateKey | EventTypeArgTeamEncryptionKeyDeactivateKey | EventTypeArgTeamEncryptionKeyDeleteKey | EventTypeArgTeamEncryptionKeyDisableKey | EventTypeArgTeamEncryptionKeyEnableKey | EventTypeArgTeamEncryptionKeyRotateKey | EventTypeArgTeamEncryptionKeyScheduleKeyDeletion | EventTypeArgApplyNamingConvention | EventTypeArgCreateFolder | EventTypeArgFileAdd | EventTypeArgFileAddFromAutomation | EventTypeArgFileCopy | EventTypeArgFileDelete | EventTypeArgFileDownload | EventTypeArgFileEdit | EventTypeArgFileGetCopyReference | EventTypeArgFileLockingLockStatusChanged | EventTypeArgFileMove | EventTypeArgFilePermanentlyDelete | EventTypeArgFilePreview | EventTypeArgFileRename | EventTypeArgFileRestore | EventTypeArgFileRevert | EventTypeArgFileRollbackChanges | EventTypeArgFileSaveCopyReference | EventTypeArgFolderOverviewDescriptionChanged | EventTypeArgFolderOverviewItemPinned | EventTypeArgFolderOverviewItemUnpinned | EventTypeArgMediaHubFileDownloaded | EventTypeArgObjectLabelAdded | EventTypeArgObjectLabelRemoved | EventTypeArgObjectLabelUpdatedValue | EventTypeArgOrganizeFolderWithTidy | EventTypeArgReplayFileDelete | EventTypeArgReplayFileDownloaded | EventTypeArgReplayTeamProjectCreated | EventTypeArgRewindFolder | EventTypeArgUndoNamingConvention | EventTypeArgUndoOrganizeFolderWithTidy | EventTypeArgUserTagsAdded | EventTypeArgUserTagsRemoved | EventTypeArgEmailIngestReceiveFile | EventTypeArgFileRequestAutoClose | EventTypeArgFileRequestChange | EventTypeArgFileRequestClose | EventTypeArgFileRequestCreate | EventTypeArgFileRequestDelete | EventTypeArgFileRequestReceiveFile | EventTypeArgGroupAddExternalId | EventTypeArgGroupAddMember | EventTypeArgGroupChangeExternalId | EventTypeArgGroupChangeManagementType | EventTypeArgGroupChangeMemberRole | EventTypeArgGroupCreate | EventTypeArgGroupDelete | EventTypeArgGroupDescriptionUpdated | EventTypeArgGroupExternalSharingSettingOverrideChanged | EventTypeArgGroupJoinPolicyUpdated | EventTypeArgGroupMoved | EventTypeArgGroupRemoveExternalId | EventTypeArgGroupRemoveMember | EventTypeArgGroupRename | EventTypeArgAccountLockOrUnlocked | EventTypeArgEmmError | EventTypeArgGuestAdminSignedInViaTrustedTeams | EventTypeArgGuestAdminSignedOutViaTrustedTeams | EventTypeArgLoginFail | EventTypeArgLoginSuccess | EventTypeArgLogout | EventTypeArgResellerSupportSessionEnd | EventTypeArgResellerSupportSessionStart | EventTypeArgSignInAsSessionEnd | EventTypeArgSignInAsSessionStart | EventTypeArgSsoError | EventTypeArgAddonAssigned | EventTypeArgAddonRemoved | EventTypeArgBackupAdminInvitationSent | EventTypeArgBackupInvitationOpened | EventTypeArgCreateTeamInviteLink | EventTypeArgDeleteTeamInviteLink | EventTypeArgMemberAddExternalId | EventTypeArgMemberAddName | EventTypeArgMemberChangeAdminRole | EventTypeArgMemberChangeEmail | EventTypeArgMemberChangeExternalId | EventTypeArgMemberChangeMembershipType | EventTypeArgMemberChangeName | EventTypeArgMemberChangeResellerRole | EventTypeArgMemberChangeStatus | EventTypeArgMemberDeleteManualContacts | EventTypeArgMemberDeleteProfilePhoto | EventTypeArgMemberPermanentlyDeleteAccountContents | EventTypeArgMemberRemoveExternalId | EventTypeArgMemberSetProfilePhoto | EventTypeArgMemberSpaceLimitsAddCustomQuota | EventTypeArgMemberSpaceLimitsChangeCustomQuota | EventTypeArgMemberSpaceLimitsChangeStatus | EventTypeArgMemberSpaceLimitsRemoveCustomQuota | EventTypeArgMemberSuggest | EventTypeArgMemberTransferAccountContents | EventTypeArgPendingSecondaryEmailAdded | EventTypeArgProductAssignedToMember | EventTypeArgProductRemovedFromMember | EventTypeArgSecondaryEmailDeleted | EventTypeArgSecondaryEmailVerified | EventTypeArgSecondaryMailsPolicyChanged | EventTypeArgBinderAddPage | EventTypeArgBinderAddSection | EventTypeArgBinderRemovePage | EventTypeArgBinderRemoveSection | EventTypeArgBinderRenamePage | EventTypeArgBinderRenameSection | EventTypeArgBinderReorderPage | EventTypeArgBinderReorderSection | EventTypeArgPaperContentAddMember | EventTypeArgPaperContentAddToFolder | EventTypeArgPaperContentArchive | EventTypeArgPaperContentCreate | EventTypeArgPaperContentPermanentlyDelete | EventTypeArgPaperContentRemoveFromFolder | EventTypeArgPaperContentRemoveMember | EventTypeArgPaperContentRename | EventTypeArgPaperContentRestore | EventTypeArgPaperDocAddComment | EventTypeArgPaperDocChangeMemberRole | EventTypeArgPaperDocChangeSharingPolicy | EventTypeArgPaperDocChangeSubscription | EventTypeArgPaperDocDeleted | EventTypeArgPaperDocDeleteComment | EventTypeArgPaperDocDownload | EventTypeArgPaperDocEdit | EventTypeArgPaperDocEditComment | EventTypeArgPaperDocFollowed | EventTypeArgPaperDocMention | EventTypeArgPaperDocOwnershipChanged | EventTypeArgPaperDocRequestAccess | EventTypeArgPaperDocResolveComment | EventTypeArgPaperDocRevert | EventTypeArgPaperDocSlackShare | EventTypeArgPaperDocTeamInvite | EventTypeArgPaperDocTrashed | EventTypeArgPaperDocUnresolveComment | EventTypeArgPaperDocUntrashed | EventTypeArgPaperDocView | EventTypeArgPaperExternalViewAllow | EventTypeArgPaperExternalViewDefaultTeam | EventTypeArgPaperExternalViewForbid | EventTypeArgPaperFolderChangeSubscription | EventTypeArgPaperFolderDeleted | EventTypeArgPaperFolderFollowed | EventTypeArgPaperFolderTeamInvite | EventTypeArgPaperPublishedLinkChangePermission | EventTypeArgPaperPublishedLinkCreate | EventTypeArgPaperPublishedLinkDisabled | EventTypeArgPaperPublishedLinkView | EventTypeArgPasswordChange | EventTypeArgPasswordReset | EventTypeArgPasswordResetAll | EventTypeArgProtectInternalDomainsChanged | EventTypeArgClassificationCreateReport | EventTypeArgClassificationCreateReportFail | EventTypeArgEmmCreateExceptionsReport | EventTypeArgEmmCreateUsageReport | EventTypeArgExportMembersReport | EventTypeArgExportMembersReportFail | EventTypeArgExternalSharingCreateReport | EventTypeArgExternalSharingReportFailed | EventTypeArgMemberAccessDetailsCreateReport | EventTypeArgMemberAccessDetailsCreateReportFailed | EventTypeArgNoExpirationLinkGenCreateReport | EventTypeArgNoExpirationLinkGenReportFailed | EventTypeArgNoPasswordLinkGenCreateReport | EventTypeArgNoPasswordLinkGenReportFailed | EventTypeArgNoPasswordLinkViewCreateReport | EventTypeArgNoPasswordLinkViewReportFailed | EventTypeArgOutdatedLinkViewCreateReport | EventTypeArgOutdatedLinkViewReportFailed | EventTypeArgPaperAdminExportStart | EventTypeArgRansomwareAlertCreateReport | EventTypeArgRansomwareAlertCreateReportFailed | EventTypeArgSharedFoldersCreateReport | EventTypeArgSharedFoldersCreateReportFailed | EventTypeArgSmartSyncCreateAdminPrivilegeReport | EventTypeArgTeamActivityCreateReport | EventTypeArgTeamActivityCreateReportFail | EventTypeArgTeamFoldersCreateReport | EventTypeArgTeamFoldersCreateReportFailed | EventTypeArgTeamStorageCreateReport | EventTypeArgTeamStorageCreateReportFailed | EventTypeArgCollectionShare | EventTypeArgFileTransfersFileAdd | EventTypeArgFileTransfersTransferDelete | EventTypeArgFileTransfersTransferDownload | EventTypeArgFileTransfersTransferSend | EventTypeArgFileTransfersTransferView | EventTypeArgMediaHubProjectTeamAdd | EventTypeArgMediaHubProjectTeamDelete | EventTypeArgMediaHubProjectTeamRoleChanged | EventTypeArgMediaHubSharedLinkAudienceChanged | EventTypeArgMediaHubSharedLinkCreated | EventTypeArgMediaHubSharedLinkDownloadSettingChanged | EventTypeArgMediaHubSharedLinkRevoked | EventTypeArgNoteAclInviteOnly | EventTypeArgNoteAclLink | EventTypeArgNoteAclTeamLink | EventTypeArgNoteShared | EventTypeArgNoteShareReceive | EventTypeArgOpenNoteShared | EventTypeArgReplayFileSharedLinkCreated | EventTypeArgReplayFileSharedLinkModified | EventTypeArgReplayProjectTeamAdd | EventTypeArgReplayProjectTeamDelete | EventTypeArgSendAndTrackFileAdded | EventTypeArgSendAndTrackFileRenamed | EventTypeArgSendAndTrackFileUpdated | EventTypeArgSendAndTrackLinkCreated | EventTypeArgSendAndTrackLinkDeleted | EventTypeArgSendAndTrackLinkUpdated | EventTypeArgSendAndTrackLinkViewed | EventTypeArgSendAndTrackRemovedFileAndAssociatedLinks | EventTypeArgSfAddGroup | EventTypeArgSfAllowNonMembersToViewSharedLinks | EventTypeArgSfExternalInviteWarn | EventTypeArgSfFbInvite | EventTypeArgSfFbInviteChangeRole | EventTypeArgSfFbUninvite | EventTypeArgSfInviteGroup | EventTypeArgSfTeamGrantAccess | EventTypeArgSfTeamInvite | EventTypeArgSfTeamInviteChangeRole | EventTypeArgSfTeamJoin | EventTypeArgSfTeamJoinFromOobLink | EventTypeArgSfTeamUninvite | EventTypeArgSharedContentAddInvitees | EventTypeArgSharedContentAddLinkExpiry | EventTypeArgSharedContentAddLinkPassword | EventTypeArgSharedContentAddMember | EventTypeArgSharedContentChangeDownloadsPolicy | EventTypeArgSharedContentChangeInviteeRole | EventTypeArgSharedContentChangeLinkAudience | EventTypeArgSharedContentChangeLinkExpiry | EventTypeArgSharedContentChangeLinkPassword | EventTypeArgSharedContentChangeMemberRole | EventTypeArgSharedContentChangeViewerInfoPolicy | EventTypeArgSharedContentClaimInvitation | EventTypeArgSharedContentCopy | EventTypeArgSharedContentDownload | EventTypeArgSharedContentRelinquishMembership | EventTypeArgSharedContentRemoveInvitees | EventTypeArgSharedContentRemoveLinkExpiry | EventTypeArgSharedContentRemoveLinkPassword | EventTypeArgSharedContentRemoveMember | EventTypeArgSharedContentRequestAccess | EventTypeArgSharedContentRestoreInvitees | EventTypeArgSharedContentRestoreMember | EventTypeArgSharedContentUnshare | EventTypeArgSharedContentView | EventTypeArgSharedFolderChangeLinkPolicy | EventTypeArgSharedFolderChangeMembersInheritancePolicy | EventTypeArgSharedFolderChangeMembersManagementPolicy | EventTypeArgSharedFolderChangeMembersPolicy | EventTypeArgSharedFolderCreate | EventTypeArgSharedFolderDeclineInvitation | EventTypeArgSharedFolderMount | EventTypeArgSharedFolderNest | EventTypeArgSharedFolderTransferOwnership | EventTypeArgSharedFolderUnmount | EventTypeArgSharedLinkAddExpiry | EventTypeArgSharedLinkChangeExpiry | EventTypeArgSharedLinkChangeVisibility | EventTypeArgSharedLinkCopy | EventTypeArgSharedLinkCreate | EventTypeArgSharedLinkDisable | EventTypeArgSharedLinkDownload | EventTypeArgSharedLinkRemoveExpiry | EventTypeArgSharedLinkRemoveVisitor | EventTypeArgSharedLinkSettingsAddExpiration | EventTypeArgSharedLinkSettingsAddPassword | EventTypeArgSharedLinkSettingsAllowDownloadDisabled | EventTypeArgSharedLinkSettingsAllowDownloadEnabled | EventTypeArgSharedLinkSettingsChangeAudience | EventTypeArgSharedLinkSettingsChangeExpiration | EventTypeArgSharedLinkSettingsChangePassword | EventTypeArgSharedLinkSettingsRemoveExpiration | EventTypeArgSharedLinkSettingsRemovePassword | EventTypeArgSharedLinkShare | EventTypeArgSharedLinkView | EventTypeArgSharedNoteOpened | EventTypeArgShmodelDisableDownloads | EventTypeArgShmodelEnableDownloads | EventTypeArgShmodelGroupShare | EventTypeArgShowcaseAccessGranted | EventTypeArgShowcaseAddMember | EventTypeArgShowcaseArchived | EventTypeArgShowcaseCreated | EventTypeArgShowcaseDeleteComment | EventTypeArgShowcaseEdited | EventTypeArgShowcaseEditComment | EventTypeArgShowcaseFileAdded | EventTypeArgShowcaseFileDownload | EventTypeArgShowcaseFileRemoved | EventTypeArgShowcaseFileView | EventTypeArgShowcasePermanentlyDeleted | EventTypeArgShowcasePostComment | EventTypeArgShowcaseRemoveMember | EventTypeArgShowcaseRenamed | EventTypeArgShowcaseRequestAccess | EventTypeArgShowcaseResolveComment | EventTypeArgShowcaseRestored | EventTypeArgShowcaseTrashed | EventTypeArgShowcaseTrashedDeprecated | EventTypeArgShowcaseUnresolveComment | EventTypeArgShowcaseUntrashed | EventTypeArgShowcaseUntrashedDeprecated | EventTypeArgShowcaseView | EventTypeArgSignSignatureRequestCanceled | EventTypeArgSignSignatureRequestCompleted | EventTypeArgSignSignatureRequestDeclined | EventTypeArgSignSignatureRequestOpened | EventTypeArgSignSignatureRequestReminderSent | EventTypeArgSignSignatureRequestSent | EventTypeArgSignTemplateCreated | EventTypeArgSignTemplateShared | EventTypeArgRiscSecurityEvent | EventTypeArgSsoAddCert | EventTypeArgSsoAddLoginUrl | EventTypeArgSsoAddLogoutUrl | EventTypeArgSsoChangeCert | EventTypeArgSsoChangeLoginUrl | EventTypeArgSsoChangeLogoutUrl | EventTypeArgSsoChangeSamlIdentityMode | EventTypeArgSsoRemoveCert | EventTypeArgSsoRemoveLoginUrl | EventTypeArgSsoRemoveLogoutUrl | EventTypeArgTeamFolderChangeStatus | EventTypeArgTeamFolderCreate | EventTypeArgTeamFolderDowngrade | EventTypeArgTeamFolderPermanentlyDelete | EventTypeArgTeamFolderRename | EventTypeArgTeamFolderSpaceLimitsChangeCapsType | EventTypeArgTeamFolderSpaceLimitsChangeLimit | EventTypeArgTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeArgTeamSelectiveSyncSettingsChanged | EventTypeArgAccountCaptureChangePolicy | EventTypeArgAdminEmailRemindersChanged | EventTypeArgAiThirdPartySharingDropboxBasePolicyChanged | EventTypeArgAllowDownloadDisabled | EventTypeArgAllowDownloadEnabled | EventTypeArgAppleLoginChangePolicy | EventTypeArgAppPermissionsChanged | EventTypeArgCameraUploadsPolicyChanged | EventTypeArgCaptureTeamSpacePolicyChanged | EventTypeArgCaptureTranscriptPolicyChanged | EventTypeArgClassificationChangePolicy | EventTypeArgComputerBackupPolicyChanged | EventTypeArgContentAdministrationPolicyChanged | EventTypeArgContentDeletionProtectionChangePolicy | EventTypeArgDashExternalSharingPolicyChanged | EventTypeArgDataPlacementRestrictionChangePolicy | EventTypeArgDataPlacementRestrictionSatisfyPolicy | EventTypeArgDeviceApprovalsAddException | EventTypeArgDeviceApprovalsChangeDesktopPolicy | EventTypeArgDeviceApprovalsChangeMobilePolicy | EventTypeArgDeviceApprovalsChangeOverageAction | EventTypeArgDeviceApprovalsChangeUnlinkAction | EventTypeArgDeviceApprovalsRemoveException | EventTypeArgDirectoryRestrictionsAddMembers | EventTypeArgDirectoryRestrictionsRemoveMembers | EventTypeArgDropboxPasswordsPolicyChanged | EventTypeArgEmailIngestPolicyChanged | EventTypeArgEmmAddException | EventTypeArgEmmChangePolicy | EventTypeArgEmmRemoveException | EventTypeArgExtendedVersionHistoryChangePolicy | EventTypeArgExternalDriveBackupPolicyChanged | EventTypeArgFileCommentsChangePolicy | EventTypeArgFileLockingPolicyChanged | EventTypeArgFileProviderMigrationPolicyChanged | EventTypeArgFileRequestsChangePolicy | EventTypeArgFileRequestsEmailsEnabled | EventTypeArgFileRequestsEmailsRestrictedToTeamOnly | EventTypeArgFileTransfersPolicyChanged | EventTypeArgFlexibleFileNamesPolicyChanged | EventTypeArgFolderLinkRestrictionPolicyChanged | EventTypeArgGoogleSsoChangePolicy | EventTypeArgGroupUserManagementChangePolicy | EventTypeArgIntegrationPolicyChanged | EventTypeArgInviteAcceptanceEmailPolicyChanged | EventTypeArgMediaHubAddingPeoplePolicyChanged | EventTypeArgMediaHubDownloadPolicyChanged | EventTypeArgMediaHubLinkSharingPolicyChanged | EventTypeArgMemberRequestsChangePolicy | EventTypeArgMemberSendInvitePolicyChanged | EventTypeArgMemberSpaceLimitsAddException | EventTypeArgMemberSpaceLimitsChangeCapsTypePolicy | EventTypeArgMemberSpaceLimitsChangePolicy | EventTypeArgMemberSpaceLimitsRemoveException | EventTypeArgMemberSuggestionsChangePolicy | EventTypeArgMicrosoftLoginChangePolicy | EventTypeArgMicrosoftOfficeAddinChangePolicy | EventTypeArgMultiTeamIdentityPolicyChanged | EventTypeArgNetworkControlChangePolicy | EventTypeArgPaperChangeDeploymentPolicy | EventTypeArgPaperChangeMemberLinkPolicy | EventTypeArgPaperChangeMemberPolicy | EventTypeArgPaperChangePolicy | EventTypeArgPaperDefaultFolderPolicyChanged | EventTypeArgPaperDesktopPolicyChanged | EventTypeArgPaperEnabledUsersGroupAddition | EventTypeArgPaperEnabledUsersGroupRemoval | EventTypeArgPasskeyLoginPolicyChanged | EventTypeArgPasswordStrengthRequirementsChangePolicy | EventTypeArgPermanentDeleteChangePolicy | EventTypeArgPreviewsAiPolicyChanged | EventTypeArgReplayAddingPeoplePolicyChanged | EventTypeArgReplaySharingPolicyChanged | EventTypeArgResellerSupportChangePolicy | EventTypeArgRewindPolicyChanged | EventTypeArgSendAndTrackPolicyChanged | EventTypeArgSendExternalSharingPolicyChanged | EventTypeArgSendForSignaturePolicyChanged | EventTypeArgSharedLinkDefaultPermissionsPolicyChanged | EventTypeArgSharingChangeFolderJoinPolicy | EventTypeArgSharingChangeLinkAllowChangeExpirationPolicy | EventTypeArgSharingChangeLinkDefaultExpirationPolicy | EventTypeArgSharingChangeLinkEnforcePasswordPolicy | EventTypeArgSharingChangeLinkPolicy | EventTypeArgSharingChangeMemberPolicy | EventTypeArgShowcaseChangeDownloadPolicy | EventTypeArgShowcaseChangeEnabledPolicy | EventTypeArgShowcaseChangeExternalSharingPolicy | EventTypeArgSignExternalSharingPolicyChanged | EventTypeArgSignTemplateCreationPermissionChanged | EventTypeArgSmarterSmartSyncPolicyChanged | EventTypeArgSmartSyncChangePolicy | EventTypeArgSmartSyncNotOptOut | EventTypeArgSmartSyncOptOut | EventTypeArgSsoChangePolicy | EventTypeArgStackCrossTeamAccessPolicyChanged | EventTypeArgTeamBrandingPolicyChanged | EventTypeArgTeamExtensionsPolicyChanged | EventTypeArgTeamMemberStorageRequestPolicyChanged | EventTypeArgTeamSelectiveSyncPolicyChanged | EventTypeArgTeamSharingWhitelistSubjectsChanged | EventTypeArgTfaAddException | EventTypeArgTfaChangePolicy | EventTypeArgTfaRemoveException | EventTypeArgTopLevelContentPolicyChanged | EventTypeArgTwoAccountChangePolicy | EventTypeArgViewerInfoPolicyChanged | EventTypeArgWatermarkingPolicyChanged | EventTypeArgWebSessionsChangeActiveSessionLimit | EventTypeArgWebSessionsChangeFixedLengthPolicy | EventTypeArgWebSessionsChangeIdleLengthPolicy | EventTypeArgDataResidencyMigrationRequestSuccessful | EventTypeArgDataResidencyMigrationRequestUnsuccessful | EventTypeArgTeamMergeFrom | EventTypeArgTeamMergeTo | EventTypeArgTeamProfileAddBackground | EventTypeArgTeamProfileAddLogo | EventTypeArgTeamProfileChangeBackground | EventTypeArgTeamProfileChangeDefaultLanguage | EventTypeArgTeamProfileChangeLogo | EventTypeArgTeamProfileChangeName | EventTypeArgTeamProfileRemoveBackground | EventTypeArgTeamProfileRemoveLogo | EventTypeArgPasskeyAdd | EventTypeArgPasskeyRemove | EventTypeArgTfaAddBackupPhone | EventTypeArgTfaAddSecurityKey | EventTypeArgTfaChangeBackupPhone | EventTypeArgTfaChangeStatus | EventTypeArgTfaRemoveBackupPhone | EventTypeArgTfaRemoveSecurityKey | EventTypeArgTfaReset | EventTypeArgChangedEnterpriseAdminRole | EventTypeArgChangedEnterpriseConnectedTeamStatus | EventTypeArgEndedEnterpriseAdminSession | EventTypeArgEndedEnterpriseAdminSessionDeprecated | EventTypeArgEnterpriseSettingsLocking | EventTypeArgGuestAdminChangeStatus | EventTypeArgStartedEnterpriseAdminSession | EventTypeArgTeamMergeRequestAccepted | EventTypeArgTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeArgTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeArgTeamMergeRequestAutoCanceled | EventTypeArgTeamMergeRequestCanceled | EventTypeArgTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeArgTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeArgTeamMergeRequestExpired | EventTypeArgTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeArgTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeArgTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeArgTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeArgTeamMergeRequestReminder | EventTypeArgTeamMergeRequestReminderShownToPrimaryTeam | EventTypeArgTeamMergeRequestReminderShownToSecondaryTeam | EventTypeArgTeamMergeRequestRevoked | EventTypeArgTeamMergeRequestSentShownToPrimaryTeam | EventTypeArgTeamMergeRequestSentShownToSecondaryTeam | EventTypeArgOther;
+    export type EventTypeArg = EventTypeArgAdminAlertingAlertStateChanged | EventTypeArgAdminAlertingChangedAlertConfig | EventTypeArgAdminAlertingTriggeredAlert | EventTypeArgRansomwareRestoreProcessCompleted | EventTypeArgRansomwareRestoreProcessStarted | EventTypeArgAppBlockedByPermissions | EventTypeArgAppLinkTeam | EventTypeArgAppLinkUser | EventTypeArgAppUnlinkTeam | EventTypeArgAppUnlinkUser | EventTypeArgIntegrationConnected | EventTypeArgIntegrationDisconnected | EventTypeArgFileAddComment | EventTypeArgFileChangeCommentSubscription | EventTypeArgFileDeleteComment | EventTypeArgFileEditComment | EventTypeArgFileLikeComment | EventTypeArgFileResolveComment | EventTypeArgFileUnlikeComment | EventTypeArgFileUnresolveComment | EventTypeArgDashAddedCommentToStack | EventTypeArgDashAddedConnector | EventTypeArgDashAddedLinkToStack | EventTypeArgDashAddedTeamEmailDomainAllowlist | EventTypeArgDashAdminAddedOrgWideConnector | EventTypeArgDashAdminDisabledConnector | EventTypeArgDashAdminEnabledConnector | EventTypeArgDashAdminRemovedOrgWideConnector | EventTypeArgDashArchivedStack | EventTypeArgDashChangedAudienceOfSharedLinkToStack | EventTypeArgDashClonedStack | EventTypeArgDashConnectorToolsCall | EventTypeArgDashCreatedStack | EventTypeArgDashDeletedCommentFromStack | EventTypeArgDashDeletedStack | EventTypeArgDashEditedCommentInStack | EventTypeArgDashExternalUserOpenedStack | EventTypeArgDashFirstLaunchedDesktop | EventTypeArgDashFirstLaunchedExtension | EventTypeArgDashFirstLaunchedWebStartPage | EventTypeArgDashOpenedSharedLinkToStack | EventTypeArgDashOpenedStack | EventTypeArgDashPreviewOptOutStatusChanged | EventTypeArgDashRemovedConnector | EventTypeArgDashRemovedLinkFromStack | EventTypeArgDashRemovedSharedLinkToStack | EventTypeArgDashRemovedTeamEmailDomainAllowlist | EventTypeArgDashRenamedStack | EventTypeArgDashSharedLinkToStack | EventTypeArgDashUnarchivedStack | EventTypeArgDashViewedCompanyStack | EventTypeArgDashViewedExternalAiActivityReport | EventTypeArgGovernancePolicyAddFolders | EventTypeArgGovernancePolicyAddFolderFailed | EventTypeArgGovernancePolicyContentDisposed | EventTypeArgGovernancePolicyCreate | EventTypeArgGovernancePolicyDelete | EventTypeArgGovernancePolicyEditDetails | EventTypeArgGovernancePolicyEditDuration | EventTypeArgGovernancePolicyExportCreated | EventTypeArgGovernancePolicyExportRemoved | EventTypeArgGovernancePolicyRemoveFolders | EventTypeArgGovernancePolicyReportCreated | EventTypeArgGovernancePolicyZipPartDownloaded | EventTypeArgLegalHoldsActivateAHold | EventTypeArgLegalHoldsAddMembers | EventTypeArgLegalHoldsChangeHoldDetails | EventTypeArgLegalHoldsChangeHoldName | EventTypeArgLegalHoldsExportAHold | EventTypeArgLegalHoldsExportCancelled | EventTypeArgLegalHoldsExportDownloaded | EventTypeArgLegalHoldsExportRemoved | EventTypeArgLegalHoldsReleaseAHold | EventTypeArgLegalHoldsRemoveMembers | EventTypeArgLegalHoldsReportAHold | EventTypeArgDeviceChangeIpDesktop | EventTypeArgDeviceChangeIpMobile | EventTypeArgDeviceChangeIpWeb | EventTypeArgDeviceDeleteOnUnlinkFail | EventTypeArgDeviceDeleteOnUnlinkSuccess | EventTypeArgDeviceLinkFail | EventTypeArgDeviceLinkSuccess | EventTypeArgDeviceManagementDisabled | EventTypeArgDeviceManagementEnabled | EventTypeArgDeviceSyncBackupStatusChanged | EventTypeArgDeviceUnlink | EventTypeArgDropboxPasswordsExported | EventTypeArgDropboxPasswordsNewDeviceEnrolled | EventTypeArgEmmRefreshAuthToken | EventTypeArgExternalDriveBackupEligibilityStatusChecked | EventTypeArgExternalDriveBackupStatusChanged | EventTypeArgAccountCaptureChangeAvailability | EventTypeArgAccountCaptureMigrateAccount | EventTypeArgAccountCaptureNotificationEmailsSent | EventTypeArgAccountCaptureRelinquishAccount | EventTypeArgDisabledDomainInvites | EventTypeArgDomainInvitesApproveRequestToJoinTeam | EventTypeArgDomainInvitesDeclineRequestToJoinTeam | EventTypeArgDomainInvitesEmailExistingUsers | EventTypeArgDomainInvitesRequestToJoinTeam | EventTypeArgDomainInvitesSetInviteNewUserPrefToNo | EventTypeArgDomainInvitesSetInviteNewUserPrefToYes | EventTypeArgDomainVerificationAddDomainFail | EventTypeArgDomainVerificationAddDomainSuccess | EventTypeArgDomainVerificationRemoveDomain | EventTypeArgEnabledDomainInvites | EventTypeArgEncryptedFolderCancelTeamKeyRotation | EventTypeArgEncryptedFolderEnrollBackupKey | EventTypeArgEncryptedFolderEnrollClient | EventTypeArgEncryptedFolderEnrollTeam | EventTypeArgEncryptedFolderFinishTeamUnenrollment | EventTypeArgEncryptedFolderInitTeamKeyRotation | EventTypeArgEncryptedFolderInitTeamUnenrollment | EventTypeArgEncryptedFolderRemoveBackupKey | EventTypeArgEncryptedFolderRotateTeamKey | EventTypeArgEncryptedFolderUnenrollClient | EventTypeArgTeamEncryptionKeyActivateKey | EventTypeArgTeamEncryptionKeyCancelKeyDeletion | EventTypeArgTeamEncryptionKeyCreateKey | EventTypeArgTeamEncryptionKeyDeactivateKey | EventTypeArgTeamEncryptionKeyDeleteKey | EventTypeArgTeamEncryptionKeyDisableKey | EventTypeArgTeamEncryptionKeyEnableKey | EventTypeArgTeamEncryptionKeyRotateKey | EventTypeArgTeamEncryptionKeyScheduleKeyDeletion | EventTypeArgApplyNamingConvention | EventTypeArgCreateFolder | EventTypeArgFileAdd | EventTypeArgFileAddFromAutomation | EventTypeArgFileCopy | EventTypeArgFileDelete | EventTypeArgFileDownload | EventTypeArgFileEdit | EventTypeArgFileGetCopyReference | EventTypeArgFileLockingLockStatusChanged | EventTypeArgFileMove | EventTypeArgFilePermanentlyDelete | EventTypeArgFilePreview | EventTypeArgFileRename | EventTypeArgFileRestore | EventTypeArgFileRevert | EventTypeArgFileRollbackChanges | EventTypeArgFileSaveCopyReference | EventTypeArgFolderOverviewDescriptionChanged | EventTypeArgFolderOverviewItemPinned | EventTypeArgFolderOverviewItemUnpinned | EventTypeArgMediaHubFileDownloaded | EventTypeArgObjectLabelAdded | EventTypeArgObjectLabelRemoved | EventTypeArgObjectLabelUpdatedValue | EventTypeArgOrganizeFolderWithTidy | EventTypeArgReplayFileDelete | EventTypeArgReplayFileDownloaded | EventTypeArgReplayTeamProjectCreated | EventTypeArgRewindFolder | EventTypeArgUndoNamingConvention | EventTypeArgUndoOrganizeFolderWithTidy | EventTypeArgUserTagsAdded | EventTypeArgUserTagsRemoved | EventTypeArgEmailIngestReceiveFile | EventTypeArgFileRequestAutoClose | EventTypeArgFileRequestChange | EventTypeArgFileRequestClose | EventTypeArgFileRequestCreate | EventTypeArgFileRequestDelete | EventTypeArgFileRequestReceiveFile | EventTypeArgGroupAddExternalId | EventTypeArgGroupAddMember | EventTypeArgGroupChangeExternalId | EventTypeArgGroupChangeManagementType | EventTypeArgGroupChangeMemberRole | EventTypeArgGroupCreate | EventTypeArgGroupDelete | EventTypeArgGroupDescriptionUpdated | EventTypeArgGroupExternalSharingSettingOverrideChanged | EventTypeArgGroupJoinPolicyUpdated | EventTypeArgGroupMoved | EventTypeArgGroupRemoveExternalId | EventTypeArgGroupRemoveMember | EventTypeArgGroupRename | EventTypeArgAccountLockOrUnlocked | EventTypeArgEmmError | EventTypeArgGuestAdminSignedInViaTrustedTeams | EventTypeArgGuestAdminSignedOutViaTrustedTeams | EventTypeArgLoginFail | EventTypeArgLoginSuccess | EventTypeArgLogout | EventTypeArgResellerSupportSessionEnd | EventTypeArgResellerSupportSessionStart | EventTypeArgSignInAsSessionEnd | EventTypeArgSignInAsSessionStart | EventTypeArgSsoError | EventTypeArgAddonAssigned | EventTypeArgAddonRemoved | EventTypeArgBackupAdminInvitationSent | EventTypeArgBackupInvitationOpened | EventTypeArgCreateTeamInviteLink | EventTypeArgDeleteTeamInviteLink | EventTypeArgMemberAddExternalId | EventTypeArgMemberAddName | EventTypeArgMemberChangeAdminRole | EventTypeArgMemberChangeEmail | EventTypeArgMemberChangeExternalId | EventTypeArgMemberChangeMembershipType | EventTypeArgMemberChangeName | EventTypeArgMemberChangeResellerRole | EventTypeArgMemberChangeStatus | EventTypeArgMemberDeleteManualContacts | EventTypeArgMemberDeleteProfilePhoto | EventTypeArgMemberFolderContentsAccessed | EventTypeArgMemberPermanentlyDeleteAccountContents | EventTypeArgMemberRemoveExternalId | EventTypeArgMemberSetProfilePhoto | EventTypeArgMemberSpaceLimitsAddCustomQuota | EventTypeArgMemberSpaceLimitsChangeCustomQuota | EventTypeArgMemberSpaceLimitsChangeStatus | EventTypeArgMemberSpaceLimitsRemoveCustomQuota | EventTypeArgMemberSuggest | EventTypeArgMemberTransferAccountContents | EventTypeArgPendingSecondaryEmailAdded | EventTypeArgProductAssignedToMember | EventTypeArgProductRemovedFromMember | EventTypeArgSecondaryEmailDeleted | EventTypeArgSecondaryEmailVerified | EventTypeArgSecondaryMailsPolicyChanged | EventTypeArgBinderAddPage | EventTypeArgBinderAddSection | EventTypeArgBinderRemovePage | EventTypeArgBinderRemoveSection | EventTypeArgBinderRenamePage | EventTypeArgBinderRenameSection | EventTypeArgBinderReorderPage | EventTypeArgBinderReorderSection | EventTypeArgPaperContentAddMember | EventTypeArgPaperContentAddToFolder | EventTypeArgPaperContentArchive | EventTypeArgPaperContentCreate | EventTypeArgPaperContentPermanentlyDelete | EventTypeArgPaperContentRemoveFromFolder | EventTypeArgPaperContentRemoveMember | EventTypeArgPaperContentRename | EventTypeArgPaperContentRestore | EventTypeArgPaperDocAddComment | EventTypeArgPaperDocChangeMemberRole | EventTypeArgPaperDocChangeSharingPolicy | EventTypeArgPaperDocChangeSubscription | EventTypeArgPaperDocDeleted | EventTypeArgPaperDocDeleteComment | EventTypeArgPaperDocDownload | EventTypeArgPaperDocEdit | EventTypeArgPaperDocEditComment | EventTypeArgPaperDocFollowed | EventTypeArgPaperDocMention | EventTypeArgPaperDocOwnershipChanged | EventTypeArgPaperDocRequestAccess | EventTypeArgPaperDocResolveComment | EventTypeArgPaperDocRevert | EventTypeArgPaperDocSlackShare | EventTypeArgPaperDocTeamInvite | EventTypeArgPaperDocTrashed | EventTypeArgPaperDocUnresolveComment | EventTypeArgPaperDocUntrashed | EventTypeArgPaperDocView | EventTypeArgPaperExternalViewAllow | EventTypeArgPaperExternalViewDefaultTeam | EventTypeArgPaperExternalViewForbid | EventTypeArgPaperFolderChangeSubscription | EventTypeArgPaperFolderDeleted | EventTypeArgPaperFolderFollowed | EventTypeArgPaperFolderTeamInvite | EventTypeArgPaperPublishedLinkChangePermission | EventTypeArgPaperPublishedLinkCreate | EventTypeArgPaperPublishedLinkDisabled | EventTypeArgPaperPublishedLinkView | EventTypeArgPasswordChange | EventTypeArgPasswordReset | EventTypeArgPasswordResetAll | EventTypeArgProtectActionAddCollaborator | EventTypeArgProtectActionAddLink | EventTypeArgProtectActionDelete | EventTypeArgProtectActionExport | EventTypeArgProtectActionRemoveCollaborator | EventTypeArgProtectActionRemoveLink | EventTypeArgProtectActionStopSharing | EventTypeArgProtectInternalDomainsChanged | EventTypeArgProtectPolicyActivated | EventTypeArgProtectPolicyDeactivated | EventTypeArgProtectPolicyScheduled | EventTypeArgProtectPolicyUpdated | EventTypeArgClassificationCreateReport | EventTypeArgClassificationCreateReportFail | EventTypeArgEmmCreateExceptionsReport | EventTypeArgEmmCreateUsageReport | EventTypeArgExportMembersReport | EventTypeArgExportMembersReportFail | EventTypeArgExternalSharingCreateReport | EventTypeArgExternalSharingReportFailed | EventTypeArgMemberAccessDetailsCreateReport | EventTypeArgMemberAccessDetailsCreateReportFailed | EventTypeArgNoExpirationLinkGenCreateReport | EventTypeArgNoExpirationLinkGenReportFailed | EventTypeArgNoPasswordLinkGenCreateReport | EventTypeArgNoPasswordLinkGenReportFailed | EventTypeArgNoPasswordLinkViewCreateReport | EventTypeArgNoPasswordLinkViewReportFailed | EventTypeArgOutdatedLinkViewCreateReport | EventTypeArgOutdatedLinkViewReportFailed | EventTypeArgPaperAdminExportStart | EventTypeArgRansomwareAlertCreateReport | EventTypeArgRansomwareAlertCreateReportFailed | EventTypeArgSharedFoldersCreateReport | EventTypeArgSharedFoldersCreateReportFailed | EventTypeArgSmartSyncCreateAdminPrivilegeReport | EventTypeArgTeamActivityCreateReport | EventTypeArgTeamActivityCreateReportFail | EventTypeArgTeamFoldersCreateReport | EventTypeArgTeamFoldersCreateReportFailed | EventTypeArgTeamStorageCreateReport | EventTypeArgTeamStorageCreateReportFailed | EventTypeArgCollectionShare | EventTypeArgFileTransfersFileAdd | EventTypeArgFileTransfersTransferDelete | EventTypeArgFileTransfersTransferDownload | EventTypeArgFileTransfersTransferSend | EventTypeArgFileTransfersTransferView | EventTypeArgMediaHubProjectTeamAdd | EventTypeArgMediaHubProjectTeamDelete | EventTypeArgMediaHubProjectTeamRoleChanged | EventTypeArgMediaHubSharedLinkAudienceChanged | EventTypeArgMediaHubSharedLinkCreated | EventTypeArgMediaHubSharedLinkDownloadSettingChanged | EventTypeArgMediaHubSharedLinkRevoked | EventTypeArgNoteAclInviteOnly | EventTypeArgNoteAclLink | EventTypeArgNoteAclTeamLink | EventTypeArgNoteShared | EventTypeArgNoteShareReceive | EventTypeArgOpenNoteShared | EventTypeArgReplayFileSharedLinkCreated | EventTypeArgReplayFileSharedLinkModified | EventTypeArgReplayProjectTeamAdd | EventTypeArgReplayProjectTeamDelete | EventTypeArgSendAndTrackFileAdded | EventTypeArgSendAndTrackFileRenamed | EventTypeArgSendAndTrackFileUpdated | EventTypeArgSendAndTrackLinkCreated | EventTypeArgSendAndTrackLinkDeleted | EventTypeArgSendAndTrackLinkUpdated | EventTypeArgSendAndTrackLinkViewed | EventTypeArgSendAndTrackRemovedFileAndAssociatedLinks | EventTypeArgSfAddGroup | EventTypeArgSfAllowNonMembersToViewSharedLinks | EventTypeArgSfExternalInviteWarn | EventTypeArgSfFbInvite | EventTypeArgSfFbInviteChangeRole | EventTypeArgSfFbUninvite | EventTypeArgSfInviteGroup | EventTypeArgSfTeamGrantAccess | EventTypeArgSfTeamInvite | EventTypeArgSfTeamInviteChangeRole | EventTypeArgSfTeamJoin | EventTypeArgSfTeamJoinFromOobLink | EventTypeArgSfTeamUninvite | EventTypeArgSharedContentAddInvitees | EventTypeArgSharedContentAddLinkExpiry | EventTypeArgSharedContentAddLinkPassword | EventTypeArgSharedContentAddMember | EventTypeArgSharedContentChangeDownloadsPolicy | EventTypeArgSharedContentChangeInviteeRole | EventTypeArgSharedContentChangeLinkAudience | EventTypeArgSharedContentChangeLinkExpiry | EventTypeArgSharedContentChangeLinkPassword | EventTypeArgSharedContentChangeMemberRole | EventTypeArgSharedContentChangeViewerInfoPolicy | EventTypeArgSharedContentClaimInvitation | EventTypeArgSharedContentCopy | EventTypeArgSharedContentDownload | EventTypeArgSharedContentRelinquishMembership | EventTypeArgSharedContentRemoveInvitees | EventTypeArgSharedContentRemoveLinkExpiry | EventTypeArgSharedContentRemoveLinkPassword | EventTypeArgSharedContentRemoveMember | EventTypeArgSharedContentRequestAccess | EventTypeArgSharedContentRestoreInvitees | EventTypeArgSharedContentRestoreMember | EventTypeArgSharedContentUnshare | EventTypeArgSharedContentView | EventTypeArgSharedFolderChangeLinkPolicy | EventTypeArgSharedFolderChangeMembersInheritancePolicy | EventTypeArgSharedFolderChangeMembersManagementPolicy | EventTypeArgSharedFolderChangeMembersPolicy | EventTypeArgSharedFolderCreate | EventTypeArgSharedFolderDeclineInvitation | EventTypeArgSharedFolderMount | EventTypeArgSharedFolderNest | EventTypeArgSharedFolderTransferOwnership | EventTypeArgSharedFolderUnmount | EventTypeArgSharedLinkAddExpiry | EventTypeArgSharedLinkChangeExpiry | EventTypeArgSharedLinkChangeVisibility | EventTypeArgSharedLinkCopy | EventTypeArgSharedLinkCreate | EventTypeArgSharedLinkDisable | EventTypeArgSharedLinkDownload | EventTypeArgSharedLinkRemoveExpiry | EventTypeArgSharedLinkRemoveVisitor | EventTypeArgSharedLinkSettingsAddExpiration | EventTypeArgSharedLinkSettingsAddPassword | EventTypeArgSharedLinkSettingsAllowDownloadDisabled | EventTypeArgSharedLinkSettingsAllowDownloadEnabled | EventTypeArgSharedLinkSettingsChangeAudience | EventTypeArgSharedLinkSettingsChangeExpiration | EventTypeArgSharedLinkSettingsChangePassword | EventTypeArgSharedLinkSettingsRemoveExpiration | EventTypeArgSharedLinkSettingsRemovePassword | EventTypeArgSharedLinkShare | EventTypeArgSharedLinkView | EventTypeArgSharedNoteOpened | EventTypeArgShmodelDisableDownloads | EventTypeArgShmodelEnableDownloads | EventTypeArgShmodelGroupShare | EventTypeArgShowcaseAccessGranted | EventTypeArgShowcaseAddMember | EventTypeArgShowcaseArchived | EventTypeArgShowcaseCreated | EventTypeArgShowcaseDeleteComment | EventTypeArgShowcaseEdited | EventTypeArgShowcaseEditComment | EventTypeArgShowcaseFileAdded | EventTypeArgShowcaseFileDownload | EventTypeArgShowcaseFileRemoved | EventTypeArgShowcaseFileView | EventTypeArgShowcasePermanentlyDeleted | EventTypeArgShowcasePostComment | EventTypeArgShowcaseRemoveMember | EventTypeArgShowcaseRenamed | EventTypeArgShowcaseRequestAccess | EventTypeArgShowcaseResolveComment | EventTypeArgShowcaseRestored | EventTypeArgShowcaseTrashed | EventTypeArgShowcaseTrashedDeprecated | EventTypeArgShowcaseUnresolveComment | EventTypeArgShowcaseUntrashed | EventTypeArgShowcaseUntrashedDeprecated | EventTypeArgShowcaseView | EventTypeArgSignSignatureRequestCanceled | EventTypeArgSignSignatureRequestCompleted | EventTypeArgSignSignatureRequestDeclined | EventTypeArgSignSignatureRequestOpened | EventTypeArgSignSignatureRequestReminderSent | EventTypeArgSignSignatureRequestSent | EventTypeArgSignTemplateCreated | EventTypeArgSignTemplateShared | EventTypeArgRiscSecurityEvent | EventTypeArgSsoAddCert | EventTypeArgSsoAddLoginUrl | EventTypeArgSsoAddLogoutUrl | EventTypeArgSsoChangeCert | EventTypeArgSsoChangeLoginUrl | EventTypeArgSsoChangeLogoutUrl | EventTypeArgSsoChangeSamlIdentityMode | EventTypeArgSsoRemoveCert | EventTypeArgSsoRemoveLoginUrl | EventTypeArgSsoRemoveLogoutUrl | EventTypeArgTeamFolderChangeStatus | EventTypeArgTeamFolderCreate | EventTypeArgTeamFolderDowngrade | EventTypeArgTeamFolderPermanentlyDelete | EventTypeArgTeamFolderRename | EventTypeArgTeamFolderSpaceLimitsChangeCapsType | EventTypeArgTeamFolderSpaceLimitsChangeLimit | EventTypeArgTeamFolderSpaceLimitsChangeNotificationTarget | EventTypeArgTeamSelectiveSyncSettingsChanged | EventTypeArgAccountCaptureChangePolicy | EventTypeArgAdminEmailRemindersChanged | EventTypeArgAiThirdPartySharingDropboxBasePolicyChanged | EventTypeArgAllowDownloadDisabled | EventTypeArgAllowDownloadEnabled | EventTypeArgAppleLoginChangePolicy | EventTypeArgAppPermissionsChanged | EventTypeArgCameraUploadsPolicyChanged | EventTypeArgCaptureTeamSpacePolicyChanged | EventTypeArgCaptureTranscriptPolicyChanged | EventTypeArgClassificationChangePolicy | EventTypeArgComputerBackupPolicyChanged | EventTypeArgContentAdministrationPolicyChanged | EventTypeArgContentDeletionProtectionChangePolicy | EventTypeArgDashExternalSharingPolicyChanged | EventTypeArgDataPlacementRestrictionChangePolicy | EventTypeArgDataPlacementRestrictionSatisfyPolicy | EventTypeArgDeviceApprovalsAddException | EventTypeArgDeviceApprovalsChangeDesktopPolicy | EventTypeArgDeviceApprovalsChangeMobilePolicy | EventTypeArgDeviceApprovalsChangeOverageAction | EventTypeArgDeviceApprovalsChangeUnlinkAction | EventTypeArgDeviceApprovalsRemoveException | EventTypeArgDirectoryRestrictionsAddMembers | EventTypeArgDirectoryRestrictionsRemoveMembers | EventTypeArgDropboxPasswordsPolicyChanged | EventTypeArgEmailIngestPolicyChanged | EventTypeArgEmmAddException | EventTypeArgEmmChangePolicy | EventTypeArgEmmRemoveException | EventTypeArgExtendedVersionHistoryChangePolicy | EventTypeArgExternalDriveBackupPolicyChanged | EventTypeArgFileCommentsChangePolicy | EventTypeArgFileLockingPolicyChanged | EventTypeArgFileProviderMigrationPolicyChanged | EventTypeArgFileRequestsChangePolicy | EventTypeArgFileRequestsEmailsEnabled | EventTypeArgFileRequestsEmailsRestrictedToTeamOnly | EventTypeArgFileTransfersPolicyChanged | EventTypeArgFlexibleFileNamesPolicyChanged | EventTypeArgFolderLinkRestrictionPolicyChanged | EventTypeArgGoogleSsoChangePolicy | EventTypeArgGroupUserManagementChangePolicy | EventTypeArgIntegrationPolicyChanged | EventTypeArgInviteAcceptanceEmailPolicyChanged | EventTypeArgMediaHubAddingPeoplePolicyChanged | EventTypeArgMediaHubDownloadPolicyChanged | EventTypeArgMediaHubLinkSharingPolicyChanged | EventTypeArgMemberRequestsChangePolicy | EventTypeArgMemberSendInvitePolicyChanged | EventTypeArgMemberSpaceLimitsAddException | EventTypeArgMemberSpaceLimitsChangeCapsTypePolicy | EventTypeArgMemberSpaceLimitsChangePolicy | EventTypeArgMemberSpaceLimitsRemoveException | EventTypeArgMemberSuggestionsChangePolicy | EventTypeArgMicrosoftLoginChangePolicy | EventTypeArgMicrosoftOfficeAddinChangePolicy | EventTypeArgMultiTeamIdentityPolicyChanged | EventTypeArgNetworkControlChangePolicy | EventTypeArgPaperChangeDeploymentPolicy | EventTypeArgPaperChangeMemberLinkPolicy | EventTypeArgPaperChangeMemberPolicy | EventTypeArgPaperChangePolicy | EventTypeArgPaperDefaultFolderPolicyChanged | EventTypeArgPaperDesktopPolicyChanged | EventTypeArgPaperEnabledUsersGroupAddition | EventTypeArgPaperEnabledUsersGroupRemoval | EventTypeArgPasskeyLoginPolicyChanged | EventTypeArgPasswordStrengthRequirementsChangePolicy | EventTypeArgPermanentDeleteChangePolicy | EventTypeArgPreviewsAiPolicyChanged | EventTypeArgReplayAddingPeoplePolicyChanged | EventTypeArgReplaySharingPolicyChanged | EventTypeArgResellerSupportChangePolicy | EventTypeArgRewindPolicyChanged | EventTypeArgSendAndTrackPolicyChanged | EventTypeArgSendExternalSharingPolicyChanged | EventTypeArgSendForSignaturePolicyChanged | EventTypeArgSharedLinkDefaultPermissionsPolicyChanged | EventTypeArgSharingChangeFolderJoinPolicy | EventTypeArgSharingChangeLinkAllowChangeExpirationPolicy | EventTypeArgSharingChangeLinkDefaultExpirationPolicy | EventTypeArgSharingChangeLinkEnforcePasswordPolicy | EventTypeArgSharingChangeLinkPolicy | EventTypeArgSharingChangeMemberPolicy | EventTypeArgShowcaseChangeDownloadPolicy | EventTypeArgShowcaseChangeEnabledPolicy | EventTypeArgShowcaseChangeExternalSharingPolicy | EventTypeArgSignExternalSharingPolicyChanged | EventTypeArgSignTemplateCreationPermissionChanged | EventTypeArgSmarterSmartSyncPolicyChanged | EventTypeArgSmartSyncChangePolicy | EventTypeArgSmartSyncNotOptOut | EventTypeArgSmartSyncOptOut | EventTypeArgSsoChangePolicy | EventTypeArgStackCrossTeamAccessPolicyChanged | EventTypeArgTeamBrandingPolicyChanged | EventTypeArgTeamExtensionsPolicyChanged | EventTypeArgTeamMemberStorageRequestPolicyChanged | EventTypeArgTeamSelectiveSyncPolicyChanged | EventTypeArgTeamSharingWhitelistSubjectsChanged | EventTypeArgTfaAddException | EventTypeArgTfaChangePolicy | EventTypeArgTfaRemoveException | EventTypeArgTopLevelContentPolicyChanged | EventTypeArgTwoAccountChangePolicy | EventTypeArgViewerInfoPolicyChanged | EventTypeArgWatermarkingPolicyChanged | EventTypeArgWebSessionsChangeActiveSessionLimit | EventTypeArgWebSessionsChangeFixedLengthPolicy | EventTypeArgWebSessionsChangeIdleLengthPolicy | EventTypeArgDataResidencyMigrationRequestSuccessful | EventTypeArgDataResidencyMigrationRequestUnsuccessful | EventTypeArgTeamMergeFrom | EventTypeArgTeamMergeTo | EventTypeArgTeamProfileAddBackground | EventTypeArgTeamProfileAddLogo | EventTypeArgTeamProfileChangeBackground | EventTypeArgTeamProfileChangeDefaultLanguage | EventTypeArgTeamProfileChangeLogo | EventTypeArgTeamProfileChangeName | EventTypeArgTeamProfileRemoveBackground | EventTypeArgTeamProfileRemoveLogo | EventTypeArgPasskeyAdd | EventTypeArgPasskeyRemove | EventTypeArgTfaAddBackupPhone | EventTypeArgTfaAddSecurityKey | EventTypeArgTfaChangeBackupPhone | EventTypeArgTfaChangeStatus | EventTypeArgTfaRemoveBackupPhone | EventTypeArgTfaRemoveSecurityKey | EventTypeArgTfaReset | EventTypeArgChangedEnterpriseAdminRole | EventTypeArgChangedEnterpriseConnectedTeamStatus | EventTypeArgEndedEnterpriseAdminSession | EventTypeArgEndedEnterpriseAdminSessionDeprecated | EventTypeArgEnterpriseSettingsLocking | EventTypeArgGuestAdminChangeStatus | EventTypeArgStartedEnterpriseAdminSession | EventTypeArgTeamMergeRequestAccepted | EventTypeArgTeamMergeRequestAcceptedShownToPrimaryTeam | EventTypeArgTeamMergeRequestAcceptedShownToSecondaryTeam | EventTypeArgTeamMergeRequestAutoCanceled | EventTypeArgTeamMergeRequestCanceled | EventTypeArgTeamMergeRequestCanceledShownToPrimaryTeam | EventTypeArgTeamMergeRequestCanceledShownToSecondaryTeam | EventTypeArgTeamMergeRequestExpired | EventTypeArgTeamMergeRequestExpiredShownToPrimaryTeam | EventTypeArgTeamMergeRequestExpiredShownToSecondaryTeam | EventTypeArgTeamMergeRequestRejectedShownToPrimaryTeam | EventTypeArgTeamMergeRequestRejectedShownToSecondaryTeam | EventTypeArgTeamMergeRequestReminder | EventTypeArgTeamMergeRequestReminderShownToPrimaryTeam | EventTypeArgTeamMergeRequestReminderShownToSecondaryTeam | EventTypeArgTeamMergeRequestRevoked | EventTypeArgTeamMergeRequestSentShownToPrimaryTeam | EventTypeArgTeamMergeRequestSentShownToSecondaryTeam | EventTypeArgOther;
 
     /**
      * Created member data report.
@@ -35902,7 +36349,7 @@
     export type MediaHubAddingPeoplePolicy = MediaHubAddingPeoplePolicyAnyone | MediaHubAddingPeoplePolicyTeamOnly | MediaHubAddingPeoplePolicyOther;
 
     /**
-     * Changed the policy for adding people to Media Hub content.
+     * Changed the policy for adding people to Replay content.
      */
     export interface MediaHubAddingPeoplePolicyChangedDetails {
       /**
@@ -35937,7 +36384,7 @@
     export type MediaHubDownloadPolicy = MediaHubDownloadPolicyDisabled | MediaHubDownloadPolicyEnabled | MediaHubDownloadPolicyOther;
 
     /**
-     * Changed the policy for downloading Media Hub content.
+     * Changed the policy for downloading Replay content.
      */
     export interface MediaHubDownloadPolicyChangedDetails {
       /**
@@ -35955,7 +36402,7 @@
     }
 
     /**
-     * Downloaded files in Media Hub.
+     * Downloaded files in Replay.
      */
     export interface MediaHubFileDownloadedDetails {
     }
@@ -35987,7 +36434,7 @@
     export type MediaHubLinkSharingPolicy = MediaHubLinkSharingPolicyNoOne | MediaHubLinkSharingPolicyPublic | MediaHubLinkSharingPolicyTeamOnly | MediaHubLinkSharingPolicyOther;
 
     /**
-     * Changed the policy for sharing Media Hub content.
+     * Changed the policy for sharing Replay content.
      */
     export interface MediaHubLinkSharingPolicyChangedDetails {
       /**
@@ -36002,6 +36449,20 @@
 
     export interface MediaHubLinkSharingPolicyChangedType {
       description: string;
+    }
+
+    /**
+     * Replay project
+     */
+    export interface MediaHubProjectLogInfo {
+      /**
+       * Replay project name.
+       */
+      project_name: string;
+      /**
+       * Replay project ID.
+       */
+      project_id?: string;
     }
 
     export interface MediaHubProjectRoleEditor {
@@ -36026,9 +36487,13 @@
     export type MediaHubProjectRole = MediaHubProjectRoleEditor | MediaHubProjectRoleOwner | MediaHubProjectRoleReviewer | MediaHubProjectRoleOther;
 
     /**
-     * Added member to Media Hub project.
+     * Added member to Replay project.
      */
     export interface MediaHubProjectTeamAddDetails {
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamAddType {
@@ -36036,9 +36501,13 @@
     }
 
     /**
-     * Removed member from Media Hub project.
+     * Removed member from Replay project.
      */
     export interface MediaHubProjectTeamDeleteDetails {
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamDeleteType {
@@ -36046,7 +36515,7 @@
     }
 
     /**
-     * Changed member role in Media Hub project.
+     * Changed member role in Replay project.
      */
     export interface MediaHubProjectTeamRoleChangedDetails {
       /**
@@ -36057,6 +36526,10 @@
        * New Media Hub project role.
        */
       new_role: MediaHubProjectRole;
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubProjectTeamRoleChangedType {
@@ -36085,7 +36558,7 @@
     export type MediaHubSharedLinkAudience = MediaHubSharedLinkAudienceNoOne | MediaHubSharedLinkAudiencePublic | MediaHubSharedLinkAudienceTeamOnly | MediaHubSharedLinkAudienceOther;
 
     /**
-     * Changed Media Hub shared link audience.
+     * Changed Replay shared link audience.
      */
     export interface MediaHubSharedLinkAudienceChangedDetails {
       /**
@@ -36100,6 +36573,10 @@
        * New Media Hub shared link audience.
        */
       new_value: MediaHubSharedLinkAudience;
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkAudienceChangedType {
@@ -36107,7 +36584,7 @@
     }
 
     /**
-     * Created Media Hub shared link.
+     * Created Replay shared link.
      */
     export interface MediaHubSharedLinkCreatedDetails {
       /**
@@ -36118,6 +36595,10 @@
        * Media Hub shared link audience.
        */
       audience: MediaHubSharedLinkAudience;
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkCreatedType {
@@ -36142,7 +36623,7 @@
     export type MediaHubSharedLinkDownloadSetting = MediaHubSharedLinkDownloadSettingDisabled | MediaHubSharedLinkDownloadSettingEnabled | MediaHubSharedLinkDownloadSettingOther;
 
     /**
-     * Changed Media Hub shared link download setting.
+     * Changed Replay shared link download setting.
      */
     export interface MediaHubSharedLinkDownloadSettingChangedDetails {
       /**
@@ -36157,6 +36638,10 @@
        * New Media Hub shared link download setting.
        */
       new_value: MediaHubSharedLinkDownloadSetting;
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkDownloadSettingChangedType {
@@ -36164,13 +36649,17 @@
     }
 
     /**
-     * Revoked Media Hub shared link.
+     * Revoked Replay shared link.
      */
     export interface MediaHubSharedLinkRevokedDetails {
       /**
        * Media Hub shared link target type.
        */
       target_type: MediaHubSharedLinkTargetType;
+      /**
+       * Replay project.
+       */
+      project?: MediaHubProjectLogInfo;
     }
 
     export interface MediaHubSharedLinkRevokedType {
@@ -36408,6 +36897,16 @@
     }
 
     export interface MemberDeleteProfilePhotoType {
+      description: string;
+    }
+
+    /**
+     * Admin browsed a team member's folder contents.
+     */
+    export interface MemberFolderContentsAccessedDetails {
+    }
+
+    export interface MemberFolderContentsAccessedType {
       description: string;
     }
 
@@ -38620,6 +39119,104 @@
     }
 
     /**
+     * Added collaborators via Dropbox Protect.
+     */
+    export interface ProtectActionAddCollaboratorDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionAddCollaboratorType {
+      description: string;
+    }
+
+    /**
+     * Added a link via Dropbox Protect.
+     */
+    export interface ProtectActionAddLinkDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionAddLinkType {
+      description: string;
+    }
+
+    /**
+     * Deleted content via Dropbox Protect.
+     */
+    export interface ProtectActionDeleteDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionDeleteType {
+      description: string;
+    }
+
+    /**
+     * Exported content via Dropbox Protect.
+     */
+    export interface ProtectActionExportDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionExportType {
+      description: string;
+    }
+
+    /**
+     * Removed collaborators via Dropbox Protect.
+     */
+    export interface ProtectActionRemoveCollaboratorDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionRemoveCollaboratorType {
+      description: string;
+    }
+
+    /**
+     * Removed a link via Dropbox Protect.
+     */
+    export interface ProtectActionRemoveLinkDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionRemoveLinkType {
+      description: string;
+    }
+
+    /**
+     * Stopped sharing content via Dropbox Protect.
+     */
+    export interface ProtectActionStopSharingDetails {
+      /**
+       * Action ID.
+       */
+      action_id: string;
+    }
+
+    export interface ProtectActionStopSharingType {
+      description: string;
+    }
+
+    /**
      * Modified Protect internal domains list.
      */
     export interface ProtectInternalDomainsChangedDetails {
@@ -38634,6 +39231,62 @@
     }
 
     export interface ProtectInternalDomainsChangedType {
+      description: string;
+    }
+
+    /**
+     * Activated a Dropbox Protect policy.
+     */
+    export interface ProtectPolicyActivatedDetails {
+      /**
+       * Policy ID.
+       */
+      policy_id: string;
+    }
+
+    export interface ProtectPolicyActivatedType {
+      description: string;
+    }
+
+    /**
+     * Deactivated a Dropbox Protect policy.
+     */
+    export interface ProtectPolicyDeactivatedDetails {
+      /**
+       * Policy ID.
+       */
+      policy_id: string;
+    }
+
+    export interface ProtectPolicyDeactivatedType {
+      description: string;
+    }
+
+    /**
+     * Scheduled a Dropbox Protect policy.
+     */
+    export interface ProtectPolicyScheduledDetails {
+      /**
+       * Policy ID.
+       */
+      policy_id: string;
+    }
+
+    export interface ProtectPolicyScheduledType {
+      description: string;
+    }
+
+    /**
+     * Updated a Dropbox Protect policy.
+     */
+    export interface ProtectPolicyUpdatedDetails {
+      /**
+       * Policy ID.
+       */
+      policy_id: string;
+    }
+
+    export interface ProtectPolicyUpdatedType {
       description: string;
     }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2197,6 +2197,10 @@ export class Dropbox {
 
     /**
      * Asynchronous document-to-markdown conversion for supported file formats.
+     * Supported formats: .binder, .docx, .html, .paper, .papert, .pptx, .xlsx,
+     * .gsheet, .ods, .pdf. Unsupported formats return an
+     * `unsupported_format_error`. Size limit: the source file must be at most
+     * 50 MB. Larger files are rejected.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -2220,7 +2224,18 @@ export class Dropbox {
     public rivieraGetMarkdownAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMarkdownAsyncCheckResult>>;
 
     /**
-     * Asynchronous file metadata extraction for supported file formats.
+     * Asynchronous file metadata extraction for supported file formats. The
+     * kind of metadata returned depends on the file type: - Image (EXIF)
+     * formats: .3fr, .arw, .avif, .bmp, .cr2, .cr3, .crw, .dcr, .dcs, .dng,
+     * .erf, .gif, .heic, .j2c, .j2k, .jp2, .jpc, .jpeg, .jpf, .jpg, .jpg2,
+     * .jpm, .jpx, .kdc, .mef, .mos, .mrw, .nef, .nrw, .orf, .pef, .png, .ppm,
+     * .r3d, .raf, .rw2, .rwl, .sr2, .tga, .tif, .tiff, .wbmp, .web, .webp,
+     * .x3f. - Audio/video (media) formats: .aac, .aif, .aiff, .flac, .m4a,
+     * .m4r, .mp3, .oga, .ogg, .wav, .wma, .3gp, .3gpp, .3gpp2, .asf, .avi, .dv,
+     * .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf,
+     * .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. - PDF format: .pdf. - MS
+     * Office formats: .docx, .pptx, .xlsx. Unsupported formats return an
+     * `unsupported_format_error`.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -2244,7 +2259,45 @@ export class Dropbox {
     public rivieraGetMetadataAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMetadataAsyncCheckResult>>;
 
     /**
-     * Asynchronous transcript generation for audio and video files.
+     * Asynchronous plain-text extraction from documents. Supported formats
+     * include: - Word processing: .doc, .docx, .docm, .rtf. - Presentations:
+     * .ppt, .pptx, .pptm. - Spreadsheets: .xls, .xlsx, .xlsm. - PDF: .pdf. -
+     * Dropbox document types: .paper, .papert, .binder, .gdoc, .gsheet,
+     * .gslides. - Plain text / subtitles: .txt, .vtt. Unsupported formats
+     * return an `unsupported_format_error`. For the `url` variant only Dropbox
+     * shared links are supported; external URLs return
+     * `unsupported_format_error`.
+     *
+     * Route attributes:
+     *   scope: files.content.read
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<void>.
+     * @param arg The request parameters.
+     */
+    public rivieraGetTextAsync(arg: riviera.GetTextArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
+
+    /**
+     * Returns the status or result of specified get_text_async task.
+     *
+     * Route attributes:
+     *   scope: files.content.read
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<async.PollError>.
+     * @param arg The request parameters.
+     */
+    public rivieraGetTextAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetTextAsyncCheckResult>>;
+
+    /**
+     * Asynchronous transcript generation for audio and video files. Supported
+     * audio formats: .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg,
+     * .wav, .wma. Supported video formats: .3gp, .3gpp, .3gpp2, .asf, .avi,
+     * .dv, .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf,
+     * .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. Unsupported formats return
+     * an `unsupported_format_error`. Size limits: the source file must be at
+     * most 10 GB and its audio track at most 1 hour in duration. Files
+     * exceeding these limits are rejected.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -3443,6 +3496,30 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public teamMembersAddJobStatusGetV2(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatusV2Result>>;
+
+    /**
+     * Launch a bulk suspend job. The server enforces a maximum of 500 members.
+     *
+     * Route attributes:
+     *   scope: members.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<team.BulkSuspendError>.
+     * @param arg The request parameters.
+     */
+    public teamMembersBulkSuspend(arg: team.BulkSuspendArg): Promise<DropboxResponse<async.LaunchResultBase>>;
+
+    /**
+     * Poll a previously launched bulk suspend job.
+     *
+     * Route attributes:
+     *   scope: members.write
+     *
+     * When an error occurs, the route rejects the promise with type
+     * DropboxResponseError<async.PollError>.
+     * @param arg The request parameters.
+     */
+    public teamMembersBulkSuspendJobStatusCheck(arg: async.PollArg): Promise<DropboxResponse<team.BulkSuspendJobStatus>>;
 
     /**
      * Permanently delete the files of a user who has been removed from the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2197,10 +2197,6 @@ export class Dropbox {
 
     /**
      * Asynchronous document-to-markdown conversion for supported file formats.
-     * Supported formats: .binder, .docx, .html, .paper, .papert, .pptx, .xlsx,
-     * .gsheet, .ods, .pdf. Unsupported formats return an
-     * `unsupported_format_error`. Size limit: the source file must be at most
-     * 50 MB. Larger files are rejected.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -2224,18 +2220,7 @@ export class Dropbox {
     public rivieraGetMarkdownAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMarkdownAsyncCheckResult>>;
 
     /**
-     * Asynchronous file metadata extraction for supported file formats. The
-     * kind of metadata returned depends on the file type: - Image (EXIF)
-     * formats: .3fr, .arw, .avif, .bmp, .cr2, .cr3, .crw, .dcr, .dcs, .dng,
-     * .erf, .gif, .heic, .j2c, .j2k, .jp2, .jpc, .jpeg, .jpf, .jpg, .jpg2,
-     * .jpm, .jpx, .kdc, .mef, .mos, .mrw, .nef, .nrw, .orf, .pef, .png, .ppm,
-     * .r3d, .raf, .rw2, .rwl, .sr2, .tga, .tif, .tiff, .wbmp, .web, .webp,
-     * .x3f. - Audio/video (media) formats: .aac, .aif, .aiff, .flac, .m4a,
-     * .m4r, .mp3, .oga, .ogg, .wav, .wma, .3gp, .3gpp, .3gpp2, .asf, .avi, .dv,
-     * .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf,
-     * .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. - PDF format: .pdf. - MS
-     * Office formats: .docx, .pptx, .xlsx. Unsupported formats return an
-     * `unsupported_format_error`.
+     * Asynchronous file metadata extraction for supported file formats.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -2259,45 +2244,7 @@ export class Dropbox {
     public rivieraGetMetadataAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMetadataAsyncCheckResult>>;
 
     /**
-     * Asynchronous plain-text extraction from documents. Supported formats
-     * include: - Word processing: .doc, .docx, .docm, .rtf. - Presentations:
-     * .ppt, .pptx, .pptm. - Spreadsheets: .xls, .xlsx, .xlsm. - PDF: .pdf. -
-     * Dropbox document types: .paper, .papert, .binder, .gdoc, .gsheet,
-     * .gslides. - Plain text / subtitles: .txt, .vtt. Unsupported formats
-     * return an `unsupported_format_error`. For the `url` variant only Dropbox
-     * shared links are supported; external URLs return
-     * `unsupported_format_error`.
-     *
-     * Route attributes:
-     *   scope: files.content.read
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<void>.
-     * @param arg The request parameters.
-     */
-    public rivieraGetTextAsync(arg: riviera.GetTextArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
-
-    /**
-     * Returns the status or result of specified get_text_async task.
-     *
-     * Route attributes:
-     *   scope: files.content.read
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<async.PollError>.
-     * @param arg The request parameters.
-     */
-    public rivieraGetTextAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetTextAsyncCheckResult>>;
-
-    /**
-     * Asynchronous transcript generation for audio and video files. Supported
-     * audio formats: .aac, .aif, .aiff, .flac, .m4a, .m4r, .mp3, .oga, .ogg,
-     * .wav, .wma. Supported video formats: .3gp, .3gpp, .3gpp2, .asf, .avi,
-     * .dv, .flv, .m2t, .m2ts, .m4v, .mkv, .mov, .mp4, .mpeg, .mpg, .mts, .mxf,
-     * .oggtheora, .ogv, .rm, .ts, .vob, .webm, .wmv. Unsupported formats return
-     * an `unsupported_format_error`. Size limits: the source file must be at
-     * most 10 GB and its audio track at most 1 hour in duration. Files
-     * exceeding these limits are rejected.
+     * Asynchronous transcript generation for audio and video files.
      *
      * Route attributes:
      *   scope: files.content.read
@@ -3496,30 +3443,6 @@ export class Dropbox {
      * @param arg The request parameters.
      */
     public teamMembersAddJobStatusGetV2(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatusV2Result>>;
-
-    /**
-     * Launch a bulk suspend job. The server enforces a maximum of 500 members.
-     *
-     * Route attributes:
-     *   scope: members.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<team.BulkSuspendError>.
-     * @param arg The request parameters.
-     */
-    public teamMembersBulkSuspend(arg: team.BulkSuspendArg): Promise<DropboxResponse<async.LaunchResultBase>>;
-
-    /**
-     * Poll a previously launched bulk suspend job.
-     *
-     * Route attributes:
-     *   scope: members.write
-     *
-     * When an error occurs, the route rejects the promise with type
-     * DropboxResponseError<async.PollError>.
-     * @param arg The request parameters.
-     */
-    public teamMembersBulkSuspendJobStatusCheck(arg: async.PollArg): Promise<DropboxResponse<team.BulkSuspendJobStatus>>;
 
     /**
      * Permanently delete the files of a user who has been removed from the

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,6 +4,14 @@
 import { account, async, auth, check, common, contacts, file_properties, file_requests, files, openid, paper, riviera, secondary_emails, seen_state, sharing, team, team_common, team_log, team_policies, users, users_common } from './dropbox_types';
 export * from './dropbox_types';
 
+/**
+ * Optional transport settings for a single Dropbox API request.
+ */
+export interface DropboxRequestOptions {
+  /** An AbortSignal used to cancel the request. */
+  signal?: AbortSignal;
+}
+
 /** Binary download content returned by the SDK in Node.js environments. */
 export interface DropboxFileBinary extends Uint8Array {
   toString(encoding?: string, start?: number, end?: number): string;
@@ -273,8 +281,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<account.DeleteProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public accountDeleteProfilePhoto(arg: account.DeleteProfilePhotoArg): Promise<DropboxResponse<account.DeleteProfilePhotoResult>>;
+    public accountDeleteProfilePhoto(arg: account.DeleteProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<account.DeleteProfilePhotoResult>>;
 
     /**
      * This lovely endpoint gets the account photo of a given user.
@@ -285,8 +294,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<account.AccountPhotoGetError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public accountGetPhoto(arg: account.AccountPhotoGetArg): Promise<DropboxResponse<DropboxDownloadResult<account.AccountPhotoGetResult>>>;
+    public accountGetPhoto(arg: account.AccountPhotoGetArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<account.AccountPhotoGetResult>>>;
 
     /**
      * Sets a user's profile photo.
@@ -297,8 +307,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<account.SetProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public accountSetProfilePhoto(arg: account.SetProfilePhotoArg): Promise<DropboxResponse<account.SetProfilePhotoResult>>;
+    public accountSetProfilePhoto(arg: account.SetProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<account.SetProfilePhotoResult>>;
 
     /**
      * Creates an OAuth 2.0 access token from the supplied OAuth 1.0 access
@@ -308,8 +319,9 @@ export class Dropbox {
      * DropboxResponseError<auth.TokenFromOAuth1Error>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public authTokenFromOauth1(arg: auth.TokenFromOAuth1Arg): Promise<DropboxResponse<auth.TokenFromOAuth1Result>>;
+    public authTokenFromOauth1(arg: auth.TokenFromOAuth1Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<auth.TokenFromOAuth1Result>>;
 
     /**
      * Disables the access token used to authenticate the call. If there is a
@@ -318,8 +330,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public authTokenRevoke(): Promise<DropboxResponse<void>>;
+    public authTokenRevoke(options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * This endpoint performs App Authentication, validating the supplied app
@@ -332,8 +345,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<check.EchoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public checkApp(arg: check.EchoArg): Promise<DropboxResponse<check.EchoResult>>;
+    public checkApp(arg: check.EchoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<check.EchoResult>>;
 
     /**
      * This endpoint performs User Authentication, validating the supplied
@@ -349,8 +363,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<check.EchoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public checkUser(arg: check.EchoArg): Promise<DropboxResponse<check.EchoResult>>;
+    public checkUser(arg: check.EchoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<check.EchoResult>>;
 
     /**
      * Removes all manually added contacts. You'll still keep contacts who are
@@ -362,8 +377,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public contactsDeleteManualContacts(): Promise<DropboxResponse<void>>;
+    public contactsDeleteManualContacts(options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Removes manually added contacts from the given list.
@@ -374,8 +390,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<contacts.DeleteManualContactsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public contactsDeleteManualContactsBatch(arg: contacts.DeleteManualContactsArg): Promise<DropboxResponse<void>>;
+    public contactsDeleteManualContactsBatch(arg: contacts.DeleteManualContactsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Add property groups to a Dropbox file. See templatesAddForUser() or
@@ -387,8 +404,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.AddPropertiesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesAdd(arg: file_properties.AddPropertiesArg): Promise<DropboxResponse<void>>;
+    public filePropertiesPropertiesAdd(arg: file_properties.AddPropertiesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Overwrite property groups associated with a file. This endpoint should be
@@ -404,8 +422,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.InvalidPropertyGroupError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesOverwrite(arg: file_properties.OverwritePropertyGroupArg): Promise<DropboxResponse<void>>;
+    public filePropertiesPropertiesOverwrite(arg: file_properties.OverwritePropertyGroupArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Permanently removes the specified property group from the file. To remove
@@ -420,8 +439,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.RemovePropertiesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesRemove(arg: file_properties.RemovePropertiesArg): Promise<DropboxResponse<void>>;
+    public filePropertiesPropertiesRemove(arg: file_properties.RemovePropertiesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Search across property templates for particular property field values.
@@ -432,8 +452,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.PropertiesSearchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesSearch(arg: file_properties.PropertiesSearchArg): Promise<DropboxResponse<file_properties.PropertiesSearchResult>>;
+    public filePropertiesPropertiesSearch(arg: file_properties.PropertiesSearchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.PropertiesSearchResult>>;
 
     /**
      * Once a cursor has been retrieved from propertiesSearch(), use this to
@@ -445,8 +466,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.PropertiesSearchContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesSearchContinue(arg: file_properties.PropertiesSearchContinueArg): Promise<DropboxResponse<file_properties.PropertiesSearchResult>>;
+    public filePropertiesPropertiesSearchContinue(arg: file_properties.PropertiesSearchContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.PropertiesSearchResult>>;
 
     /**
      * Add, update or remove properties associated with the supplied file and
@@ -462,8 +484,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.UpdatePropertiesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesPropertiesUpdate(arg: file_properties.UpdatePropertiesArg): Promise<DropboxResponse<void>>;
+    public filePropertiesPropertiesUpdate(arg: file_properties.UpdatePropertiesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Add a template associated with a team. See propertiesAdd() to add
@@ -476,8 +499,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.ModifyTemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesAddForTeam(arg: file_properties.AddTemplateArg): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
+    public filePropertiesTemplatesAddForTeam(arg: file_properties.AddTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
 
     /**
      * Add a template associated with a user. See propertiesAdd() to add
@@ -490,8 +514,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.ModifyTemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesAddForUser(arg: file_properties.AddTemplateArg): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
+    public filePropertiesTemplatesAddForUser(arg: file_properties.AddTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
 
     /**
      * Get the schema for a specified template.
@@ -502,8 +527,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesGetForTeam(arg: file_properties.GetTemplateArg): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
+    public filePropertiesTemplatesGetForTeam(arg: file_properties.GetTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
 
     /**
      * Get the schema for a specified template. This endpoint can't be called on
@@ -515,8 +541,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesGetForUser(arg: file_properties.GetTemplateArg): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
+    public filePropertiesTemplatesGetForUser(arg: file_properties.GetTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
 
     /**
      * Get the template identifiers for a team. To get the schema of each
@@ -527,8 +554,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesListForTeam(): Promise<DropboxResponse<file_properties.ListTemplateResult>>;
+    public filePropertiesTemplatesListForTeam(options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.ListTemplateResult>>;
 
     /**
      * Get the template identifiers for a team. To get the schema of each
@@ -540,8 +568,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesListForUser(): Promise<DropboxResponse<file_properties.ListTemplateResult>>;
+    public filePropertiesTemplatesListForUser(options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.ListTemplateResult>>;
 
     /**
      * Permanently removes the specified template created from
@@ -554,8 +583,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesRemoveForTeam(arg: file_properties.RemoveTemplateArg): Promise<DropboxResponse<void>>;
+    public filePropertiesTemplatesRemoveForTeam(arg: file_properties.RemoveTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Permanently removes the specified template created from
@@ -568,8 +598,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.TemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesRemoveForUser(arg: file_properties.RemoveTemplateArg): Promise<DropboxResponse<void>>;
+    public filePropertiesTemplatesRemoveForUser(arg: file_properties.RemoveTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Update a template associated with a team. This route can update the
@@ -582,8 +613,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.ModifyTemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesUpdateForTeam(arg: file_properties.UpdateTemplateArg): Promise<DropboxResponse<file_properties.UpdateTemplateResult>>;
+    public filePropertiesTemplatesUpdateForTeam(arg: file_properties.UpdateTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.UpdateTemplateResult>>;
 
     /**
      * Update a template associated with a user. This route can update the
@@ -597,8 +629,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_properties.ModifyTemplateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filePropertiesTemplatesUpdateForUser(arg: file_properties.UpdateTemplateArg): Promise<DropboxResponse<file_properties.UpdateTemplateResult>>;
+    public filePropertiesTemplatesUpdateForUser(arg: file_properties.UpdateTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.UpdateTemplateResult>>;
 
     /**
      * Returns the total number of file requests owned by this user. Includes
@@ -609,8 +642,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.CountFileRequestsError>.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsCount(): Promise<DropboxResponse<file_requests.CountFileRequestsResult>>;
+    public fileRequestsCount(options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.CountFileRequestsResult>>;
 
     /**
      * Creates a file request for this user.
@@ -621,8 +655,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.CreateFileRequestError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsCreate(arg: file_requests.CreateFileRequestArgs): Promise<DropboxResponse<file_requests.FileRequest>>;
+    public fileRequestsCreate(arg: file_requests.CreateFileRequestArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.FileRequest>>;
 
     /**
      * Delete a batch of closed file requests.
@@ -633,8 +668,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.DeleteFileRequestError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsDelete(arg: file_requests.DeleteFileRequestArgs): Promise<DropboxResponse<file_requests.DeleteFileRequestsResult>>;
+    public fileRequestsDelete(arg: file_requests.DeleteFileRequestArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.DeleteFileRequestsResult>>;
 
     /**
      * Delete all closed file requests owned by this user.
@@ -644,8 +680,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.DeleteAllClosedFileRequestsError>.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsDeleteAllClosed(): Promise<DropboxResponse<file_requests.DeleteAllClosedFileRequestsResult>>;
+    public fileRequestsDeleteAllClosed(options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.DeleteAllClosedFileRequestsResult>>;
 
     /**
      * Returns the specified file request.
@@ -656,8 +693,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.GetFileRequestError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsGet(arg: file_requests.GetFileRequestArgs): Promise<DropboxResponse<file_requests.FileRequest>>;
+    public fileRequestsGet(arg: file_requests.GetFileRequestArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.FileRequest>>;
 
     /**
      * Returns a list of file requests owned by this user. For apps with the app
@@ -669,8 +707,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.ListFileRequestsError>.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsList(): Promise<DropboxResponse<file_requests.ListFileRequestsResult>>;
+    public fileRequestsList(options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.ListFileRequestsResult>>;
 
     /**
      * Returns a list of file requests owned by this user. For apps with the app
@@ -683,8 +722,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.ListFileRequestsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsListV2(arg: file_requests.ListFileRequestsArg): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
+    public fileRequestsListV2(arg: file_requests.ListFileRequestsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
 
     /**
      * Once a cursor has been retrieved from listV2(), use this to paginate
@@ -697,8 +737,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.ListFileRequestsContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsListContinue(arg: file_requests.ListFileRequestsContinueArg): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
+    public fileRequestsListContinue(arg: file_requests.ListFileRequestsContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.ListFileRequestsV2Result>>;
 
     /**
      * Update a file request.
@@ -709,8 +750,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<file_requests.UpdateFileRequestError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public fileRequestsUpdate(arg: file_requests.UpdateFileRequestArgs): Promise<DropboxResponse<file_requests.FileRequest>>;
+    public fileRequestsUpdate(arg: file_requests.UpdateFileRequestArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<file_requests.FileRequest>>;
 
     /**
      * Returns the metadata for a file or folder. This is an alpha endpoint
@@ -724,8 +766,9 @@ export class Dropbox {
      * DropboxResponseError<files.AlphaGetMetadataError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesAlphaGetMetadata(arg: files.AlphaGetMetadataArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesAlphaGetMetadata(arg: files.AlphaGetMetadataArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Create a new file with the contents provided in the request. Note that
@@ -740,8 +783,9 @@ export class Dropbox {
      * DropboxResponseError<files.UploadError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesAlphaUpload(arg: files.UploadArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesAlphaUpload(arg: files.UploadArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadata>>;
 
     /**
      * Copy a file or folder to a different location in the user's Dropbox. If
@@ -754,8 +798,9 @@ export class Dropbox {
      * DropboxResponseError<files.RelocationError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopy(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesCopy(arg: files.RelocationArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Copy a file or folder to a different location in the user's Dropbox. If
@@ -767,8 +812,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RelocationError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyV2(arg: files.RelocationArg): Promise<DropboxResponse<files.RelocationResult>>;
+    public filesCopyV2(arg: files.RelocationArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationResult>>;
 
     /**
      * Copy multiple files or folders to different locations at once in the
@@ -783,8 +829,9 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
+    public filesCopyBatch(arg: files.RelocationBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
 
     /**
      * Copy multiple files or folders to different locations at once in the
@@ -800,8 +847,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyBatchV2(arg: files.CopyBatchArg): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
+    public filesCopyBatchV2(arg: files.CopyBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
 
     /**
      * Returns the status of an asynchronous job for copyBatch(). If success, it
@@ -814,8 +862,9 @@ export class Dropbox {
      * DropboxResponseError<async.PollError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
+    public filesCopyBatchCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for copyBatchV2(). It returns
@@ -827,8 +876,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyBatchCheckV2(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
+    public filesCopyBatchCheckV2(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
 
     /**
      * Get a copy reference to a file or folder. This reference string can be
@@ -841,8 +891,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.GetCopyReferenceError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyReferenceGet(arg: files.GetCopyReferenceArg): Promise<DropboxResponse<files.GetCopyReferenceResult>>;
+    public filesCopyReferenceGet(arg: files.GetCopyReferenceArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.GetCopyReferenceResult>>;
 
     /**
      * Save a copy reference returned by copyReferenceGet() to the user's
@@ -854,8 +905,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.SaveCopyReferenceError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCopyReferenceSave(arg: files.SaveCopyReferenceArg): Promise<DropboxResponse<files.SaveCopyReferenceResult>>;
+    public filesCopyReferenceSave(arg: files.SaveCopyReferenceArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SaveCopyReferenceResult>>;
 
     /**
      * Create a folder at a given path.
@@ -867,8 +919,9 @@ export class Dropbox {
      * DropboxResponseError<files.CreateFolderError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCreateFolder(arg: files.CreateFolderArg): Promise<DropboxResponse<files.FolderMetadata>>;
+    public filesCreateFolder(arg: files.CreateFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FolderMetadata>>;
 
     /**
      * Create a folder at a given path.
@@ -879,8 +932,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.CreateFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCreateFolderV2(arg: files.CreateFolderArg): Promise<DropboxResponse<files.CreateFolderResult>>;
+    public filesCreateFolderV2(arg: files.CreateFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.CreateFolderResult>>;
 
     /**
      * Create multiple folders at once. This route is asynchronous for large
@@ -896,8 +950,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCreateFolderBatch(arg: files.CreateFolderBatchArg): Promise<DropboxResponse<files.CreateFolderBatchLaunch>>;
+    public filesCreateFolderBatch(arg: files.CreateFolderBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.CreateFolderBatchLaunch>>;
 
     /**
      * Returns the status of an asynchronous job for createFolderBatch(). If
@@ -909,8 +964,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesCreateFolderBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.CreateFolderBatchJobStatus>>;
+    public filesCreateFolderBatchCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.CreateFolderBatchJobStatus>>;
 
     /**
      * Delete the file or folder at a given path. If the path is a folder, all
@@ -926,8 +982,9 @@ export class Dropbox {
      * DropboxResponseError<files.DeleteError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDelete(arg: files.DeleteArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesDelete(arg: files.DeleteArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Delete the file or folder at a given path. If the path is a folder, all
@@ -942,8 +999,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DeleteError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDeleteV2(arg: files.DeleteArg): Promise<DropboxResponse<files.DeleteResult>>;
+    public filesDeleteV2(arg: files.DeleteArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.DeleteResult>>;
 
     /**
      * Delete multiple files/folders at once. This route is asynchronous, which
@@ -956,8 +1014,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDeleteBatch(arg: files.DeleteBatchArg): Promise<DropboxResponse<files.DeleteBatchLaunch>>;
+    public filesDeleteBatch(arg: files.DeleteBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.DeleteBatchLaunch>>;
 
     /**
      * Returns the status of an asynchronous job for deleteBatch(). If success,
@@ -969,8 +1028,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDeleteBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.DeleteBatchJobStatus>>;
+    public filesDeleteBatchCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.DeleteBatchJobStatus>>;
 
     /**
      * Download a file from a user's Dropbox.
@@ -981,8 +1041,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DownloadError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDownload(arg: files.DownloadArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
+    public filesDownload(arg: files.DownloadArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Download a folder from the user's Dropbox, as a zip file. The folder must
@@ -997,8 +1058,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DownloadZipError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesDownloadZip(arg: files.DownloadZipArg): Promise<DropboxResponse<DropboxDownloadResult<files.DownloadZipResult>>>;
+    public filesDownloadZip(arg: files.DownloadZipArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.DownloadZipResult>>>;
 
     /**
      * Export a file from a user's Dropbox. This route only supports exporting
@@ -1011,8 +1073,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ExportError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesExport(arg: files.ExportArg): Promise<DropboxResponse<DropboxDownloadResult<files.ExportResult>>>;
+    public filesExport(arg: files.ExportArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.ExportResult>>>;
 
     /**
      * Return the lock metadata for the given list of paths.
@@ -1023,8 +1086,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.LockFileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetFileLockBatch(arg: files.LockFileBatchArg): Promise<DropboxResponse<files.LockFileBatchResult>>;
+    public filesGetFileLockBatch(arg: files.LockFileBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.LockFileBatchResult>>;
 
     /**
      * Returns the metadata for a file or folder. Note: Metadata for the root
@@ -1036,8 +1100,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.GetMetadataError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetMetadata(arg: files.GetMetadataArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesGetMetadata(arg: files.GetMetadataArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Get a preview for a file. Currently, PDF previews are generated for files
@@ -1052,8 +1117,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.PreviewError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetPreview(arg: files.PreviewArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
+    public filesGetPreview(arg: files.PreviewArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Get a temporary link to stream content of a file. This link will expire
@@ -1067,8 +1133,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.GetTemporaryLinkError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetTemporaryLink(arg: files.GetTemporaryLinkArg): Promise<DropboxResponse<files.GetTemporaryLinkResult>>;
+    public filesGetTemporaryLink(arg: files.GetTemporaryLinkArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.GetTemporaryLinkResult>>;
 
     /**
      * Get a one-time use temporary upload link to upload a file to a Dropbox
@@ -1107,8 +1174,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetTemporaryUploadLink(arg: files.GetTemporaryUploadLinkArg): Promise<DropboxResponse<files.GetTemporaryUploadLinkResult>>;
+    public filesGetTemporaryUploadLink(arg: files.GetTemporaryUploadLinkArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.GetTemporaryUploadLinkResult>>;
 
     /**
      * Get a thumbnail for an image. This method currently supports files with
@@ -1122,8 +1190,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ThumbnailError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetThumbnail(arg: files.ThumbnailArg): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
+    public filesGetThumbnail(arg: files.ThumbnailArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.FileMetadata>>>;
 
     /**
      * Get a thumbnail for an image. This method currently supports files with
@@ -1137,8 +1206,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ThumbnailV2Error>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetThumbnailV2(arg: files.ThumbnailV2Arg): Promise<DropboxResponse<DropboxDownloadResult<files.PreviewResult>>>;
+    public filesGetThumbnailV2(arg: files.ThumbnailV2Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<files.PreviewResult>>>;
 
     /**
      * Get thumbnails for a list of images. We allow up to 25 thumbnails in a
@@ -1153,8 +1223,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.GetThumbnailBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesGetThumbnailBatch(arg: files.GetThumbnailBatchArg): Promise<DropboxResponse<files.GetThumbnailBatchResult>>;
+    public filesGetThumbnailBatch(arg: files.GetThumbnailBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.GetThumbnailBatchResult>>;
 
     /**
      * Starts returning the contents of a folder. If the result's
@@ -1185,8 +1256,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ListFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesListFolder(arg: files.ListFolderArg): Promise<DropboxResponse<files.ListFolderResult>>;
+    public filesListFolder(arg: files.ListFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.ListFolderResult>>;
 
     /**
      * Once a cursor has been retrieved from listFolder(), use this to paginate
@@ -1199,8 +1271,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ListFolderContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesListFolderContinue(arg: files.ListFolderContinueArg): Promise<DropboxResponse<files.ListFolderResult>>;
+    public filesListFolderContinue(arg: files.ListFolderContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.ListFolderResult>>;
 
     /**
      * A way to quickly get a cursor for the folder's state. Unlike
@@ -1215,8 +1288,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ListFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesListFolderGetLatestCursor(arg: files.ListFolderArg): Promise<DropboxResponse<files.ListFolderGetLatestCursorResult>>;
+    public filesListFolderGetLatestCursor(arg: files.ListFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.ListFolderGetLatestCursorResult>>;
 
     /**
      * A longpoll endpoint to wait for changes on an account. In conjunction
@@ -1231,8 +1305,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ListFolderLongpollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesListFolderLongpoll(arg: files.ListFolderLongpollArg): Promise<DropboxResponse<files.ListFolderLongpollResult>>;
+    public filesListFolderLongpoll(arg: files.ListFolderLongpollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.ListFolderLongpollResult>>;
 
     /**
      * Returns revisions for files based on a file path or a file id. The file
@@ -1251,8 +1326,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.ListRevisionsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesListRevisions(arg: files.ListRevisionsArg): Promise<DropboxResponse<files.ListRevisionsResult>>;
+    public filesListRevisions(arg: files.ListRevisionsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.ListRevisionsResult>>;
 
     /**
      * Lock the files at the given paths. A locked file will be writable only by
@@ -1266,8 +1342,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.LockFileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesLockFileBatch(arg: files.LockFileBatchArg): Promise<DropboxResponse<files.LockFileBatchResult>>;
+    public filesLockFileBatch(arg: files.LockFileBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.LockFileBatchResult>>;
 
     /**
      * Move a file or folder to a different location in the user's Dropbox. If
@@ -1280,8 +1357,9 @@ export class Dropbox {
      * DropboxResponseError<files.RelocationError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMove(arg: files.RelocationArg): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
+    public filesMove(arg: files.RelocationArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadataReference|files.FolderMetadataReference|files.DeletedMetadataReference>>;
 
     /**
      * Move a file or folder to a different location in the user's Dropbox. If
@@ -1294,8 +1372,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RelocationError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMoveV2(arg: files.RelocationArg): Promise<DropboxResponse<files.RelocationResult>>;
+    public filesMoveV2(arg: files.RelocationArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationResult>>;
 
     /**
      * Move multiple files or folders to different locations at once in the
@@ -1310,8 +1389,9 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMoveBatch(arg: files.RelocationBatchArg): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
+    public filesMoveBatch(arg: files.RelocationBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchLaunch>>;
 
     /**
      * Move multiple files or folders to different locations at once in the
@@ -1328,8 +1408,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMoveBatchV2(arg: files.MoveBatchArg): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
+    public filesMoveBatchV2(arg: files.MoveBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchV2Launch>>;
 
     /**
      * Returns the status of an asynchronous job for moveBatch(). If success, it
@@ -1342,8 +1423,9 @@ export class Dropbox {
      * DropboxResponseError<async.PollError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMoveBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
+    public filesMoveBatchCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchJobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for moveBatchV2(). It returns
@@ -1355,8 +1437,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesMoveBatchCheckV2(arg: async.PollArg): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
+    public filesMoveBatchCheckV2(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.RelocationBatchV2JobStatus>>;
 
     /**
      * Creates a new Paper doc with the provided content.
@@ -1367,8 +1450,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.PaperCreateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPaperCreate(arg: files.PaperCreateArg): Promise<DropboxResponse<files.PaperCreateResult>>;
+    public filesPaperCreate(arg: files.PaperCreateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.PaperCreateResult>>;
 
     /**
      * Updates an existing Paper doc with the provided content.
@@ -1379,8 +1463,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.PaperUpdateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPaperUpdate(arg: files.PaperUpdateArg): Promise<DropboxResponse<files.PaperUpdateResult>>;
+    public filesPaperUpdate(arg: files.PaperUpdateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.PaperUpdateResult>>;
 
     /**
      * Permanently delete the file or folder at a given path (see
@@ -1395,8 +1480,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.DeleteError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPermanentlyDelete(arg: files.DeleteArg): Promise<DropboxResponse<void>>;
+    public filesPermanentlyDelete(arg: files.DeleteArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Add property groups to a Dropbox file. See templates/add_for_user or
@@ -1409,8 +1495,9 @@ export class Dropbox {
      * DropboxResponseError<file_properties.AddPropertiesError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPropertiesAdd(arg: file_properties.AddPropertiesArg): Promise<DropboxResponse<void>>;
+    public filesPropertiesAdd(arg: file_properties.AddPropertiesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Overwrite property groups associated with a file. This endpoint should be
@@ -1424,8 +1511,9 @@ export class Dropbox {
      * DropboxResponseError<file_properties.InvalidPropertyGroupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPropertiesOverwrite(arg: file_properties.OverwritePropertyGroupArg): Promise<DropboxResponse<void>>;
+    public filesPropertiesOverwrite(arg: file_properties.OverwritePropertyGroupArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Add, update or remove properties associated with the supplied file and
@@ -1440,8 +1528,9 @@ export class Dropbox {
      * DropboxResponseError<file_properties.UpdatePropertiesError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesPropertiesUpdate(arg: file_properties.UpdatePropertiesArg): Promise<DropboxResponse<void>>;
+    public filesPropertiesUpdate(arg: file_properties.UpdatePropertiesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Restore a specific revision of a file to the given path.
@@ -1452,8 +1541,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RestoreError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesRestore(arg: files.RestoreArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesRestore(arg: files.RestoreArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadata>>;
 
     /**
      * Save the data from a specified URL into a file in user's Dropbox. Note
@@ -1466,8 +1556,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.SaveUrlError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesSaveUrl(arg: files.SaveUrlArg): Promise<DropboxResponse<files.SaveUrlResult>>;
+    public filesSaveUrl(arg: files.SaveUrlArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SaveUrlResult>>;
 
     /**
      * Check the status of a saveUrl() job.
@@ -1478,8 +1569,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesSaveUrlCheckJobStatus(arg: async.PollArg): Promise<DropboxResponse<files.SaveUrlJobStatus>>;
+    public filesSaveUrlCheckJobStatus(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SaveUrlJobStatus>>;
 
     /**
      * Searches for files and folders. Note: Recent changes will be reflected in
@@ -1493,8 +1585,9 @@ export class Dropbox {
      * DropboxResponseError<files.SearchError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesSearch(arg: files.SearchArg): Promise<DropboxResponse<files.SearchResult>>;
+    public filesSearch(arg: files.SearchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SearchResult>>;
 
     /**
      * Searches for files and folders. Note: searchV2() along with
@@ -1509,8 +1602,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.SearchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesSearchV2(arg: files.SearchV2Arg): Promise<DropboxResponse<files.SearchV2Result>>;
+    public filesSearchV2(arg: files.SearchV2Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SearchV2Result>>;
 
     /**
      * Fetches the next page of search results returned from searchV2(). Note:
@@ -1525,8 +1619,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.SearchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesSearchContinueV2(arg: files.SearchV2ContinueArg): Promise<DropboxResponse<files.SearchV2Result>>;
+    public filesSearchContinueV2(arg: files.SearchV2ContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.SearchV2Result>>;
 
     /**
      * Add a tag to an item. A tag is a string. The strings are automatically
@@ -1539,8 +1634,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.AddTagError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesTagsAdd(arg: files.AddTagArg): Promise<DropboxResponse<void>>;
+    public filesTagsAdd(arg: files.AddTagArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Get list of tags assigned to items.
@@ -1551,8 +1647,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.BaseTagError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesTagsGet(arg: files.GetTagsArg): Promise<DropboxResponse<files.GetTagsResult>>;
+    public filesTagsGet(arg: files.GetTagsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.GetTagsResult>>;
 
     /**
      * Remove a tag from an item.
@@ -1563,8 +1660,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.RemoveTagError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesTagsRemove(arg: files.RemoveTagArg): Promise<DropboxResponse<void>>;
+    public filesTagsRemove(arg: files.RemoveTagArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Unlock the files at the given paths. A locked file can only be unlocked
@@ -1578,8 +1676,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.LockFileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUnlockFileBatch(arg: files.UnlockFileBatchArg): Promise<DropboxResponse<files.LockFileBatchResult>>;
+    public filesUnlockFileBatch(arg: files.UnlockFileBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.LockFileBatchResult>>;
 
     /**
      * Create a new file with the contents provided in the request. Do not use
@@ -1596,8 +1695,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.UploadError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUpload(arg: files.UploadArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesUpload(arg: files.UploadArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadata>>;
 
     /**
      * Append more data to an upload session. A single request should not upload
@@ -1615,8 +1715,9 @@ export class Dropbox {
      * DropboxResponseError<files.UploadSessionAppendError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionAppend(arg: files.UploadSessionCursor): Promise<DropboxResponse<void>>;
+    public filesUploadSessionAppend(arg: files.UploadSessionCursor, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Append more data to an upload session. When the parameter close is set,
@@ -1634,8 +1735,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.UploadSessionAppendError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionAppendV2(arg: files.UploadSessionAppendArg): Promise<DropboxResponse<void>>;
+    public filesUploadSessionAppendV2(arg: files.UploadSessionAppendArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Append more data to multiple upload sessions. Each piece of file content
@@ -1656,8 +1758,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.UploadSessionAppendBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionAppendBatch(arg: files.UploadSessionAppendBatchArg): Promise<DropboxResponse<files.UploadSessionAppendBatchResult>>;
+    public filesUploadSessionAppendBatch(arg: files.UploadSessionAppendBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionAppendBatchResult>>;
 
     /**
      * Finish an upload session and save the uploaded data to the given file
@@ -1675,8 +1778,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.UploadSessionFinishError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionFinish(arg: files.UploadSessionFinishArg): Promise<DropboxResponse<files.FileMetadata>>;
+    public filesUploadSessionFinish(arg: files.UploadSessionFinishArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.FileMetadata>>;
 
     /**
      * This route helps you commit many files at once into a user's Dropbox. Use
@@ -1706,8 +1810,9 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionFinishBatch(arg: files.UploadSessionFinishBatchArg): Promise<DropboxResponse<files.UploadSessionFinishBatchLaunch>>;
+    public filesUploadSessionFinishBatch(arg: files.UploadSessionFinishBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionFinishBatchLaunch>>;
 
     /**
      * This route helps you commit many files at once into a user's Dropbox. Use
@@ -1732,8 +1837,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionFinishBatchV2(arg: files.UploadSessionFinishBatchArg): Promise<DropboxResponse<files.UploadSessionFinishBatchResult>>;
+    public filesUploadSessionFinishBatchV2(arg: files.UploadSessionFinishBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionFinishBatchResult>>;
 
     /**
      * Returns the status of an asynchronous job for uploadSessionFinishBatch().
@@ -1745,8 +1851,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionFinishBatchCheck(arg: async.PollArg): Promise<DropboxResponse<files.UploadSessionFinishBatchJobStatus>>;
+    public filesUploadSessionFinishBatchCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionFinishBatchJobStatus>>;
 
     /**
      * Upload sessions allow you to upload a single file in one or more
@@ -1788,8 +1895,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<files.UploadSessionStartError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionStart(arg: files.UploadSessionStartArg): Promise<DropboxResponse<files.UploadSessionStartResult>>;
+    public filesUploadSessionStart(arg: files.UploadSessionStartArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionStartResult>>;
 
     /**
      * Start a batch of upload sessions. See uploadSessionStart(). Calls to this
@@ -1804,8 +1912,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public filesUploadSessionStartBatch(arg: files.UploadSessionStartBatchArg): Promise<DropboxResponse<files.UploadSessionStartBatchResult>>;
+    public filesUploadSessionStartBatch(arg: files.UploadSessionStartBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<files.UploadSessionStartBatchResult>>;
 
     /**
      * This route is used for refreshing the info that is found in the id_token
@@ -1818,8 +1927,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<openid.UserInfoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public openidUserinfo(arg: openid.UserInfoArgs): Promise<DropboxResponse<openid.UserInfoResult>>;
+    public openidUserinfo(arg: openid.UserInfoArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<openid.UserInfoResult>>;
 
     /**
      * Marks the given Paper doc as archived. This action can be performed or
@@ -1839,8 +1949,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsArchive(arg: paper.RefPaperDoc): Promise<DropboxResponse<void>>;
+    public paperDocsArchive(arg: paper.RefPaperDoc, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Creates a new Paper doc with the provided content. Note that this
@@ -1859,8 +1970,9 @@ export class Dropbox {
      * DropboxResponseError<paper.PaperDocCreateError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsCreate(arg: paper.PaperDocCreateArgs): Promise<DropboxResponse<paper.PaperDocCreateUpdateResult>>;
+    public paperDocsCreate(arg: paper.PaperDocCreateArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.PaperDocCreateUpdateResult>>;
 
     /**
      * Exports and downloads Paper doc either as HTML or markdown. Note that
@@ -1879,8 +1991,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsDownload(arg: paper.PaperDocExport): Promise<DropboxResponse<DropboxDownloadResult<paper.PaperDocExportResult>>>;
+    public paperDocsDownload(arg: paper.PaperDocExport, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<paper.PaperDocExportResult>>>;
 
     /**
      * Lists the users who are explicitly invited to the Paper folder in which
@@ -1902,8 +2015,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsFolderUsersList(arg: paper.ListUsersOnFolderArgs): Promise<DropboxResponse<paper.ListUsersOnFolderResponse>>;
+    public paperDocsFolderUsersList(arg: paper.ListUsersOnFolderArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListUsersOnFolderResponse>>;
 
     /**
      * Once a cursor has been retrieved from docsFolderUsersList(), use this to
@@ -1923,8 +2037,9 @@ export class Dropbox {
      * DropboxResponseError<paper.ListUsersCursorError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsFolderUsersListContinue(arg: paper.ListUsersOnFolderContinueArgs): Promise<DropboxResponse<paper.ListUsersOnFolderResponse>>;
+    public paperDocsFolderUsersListContinue(arg: paper.ListUsersOnFolderContinueArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListUsersOnFolderResponse>>;
 
     /**
      * Retrieves folder information for the given Paper doc. This includes: -
@@ -1948,8 +2063,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsGetFolderInfo(arg: paper.RefPaperDoc): Promise<DropboxResponse<paper.FoldersContainingPaperDoc>>;
+    public paperDocsGetFolderInfo(arg: paper.RefPaperDoc, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.FoldersContainingPaperDoc>>;
 
     /**
      * Returns metadata for a Paper doc or Cloud Doc.
@@ -1960,8 +2076,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<paper.DocLookupError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsGetMetadata(arg: paper.GetDocMetadataArg): Promise<DropboxResponse<paper.PaperDocGetMetadataResult>>;
+    public paperDocsGetMetadata(arg: paper.GetDocMetadataArg, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.PaperDocGetMetadataResult>>;
 
     /**
      * Return the list of all Paper docs according to the argument
@@ -1981,8 +2098,9 @@ export class Dropbox {
      * DropboxResponseError<void>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsList(arg: paper.ListPaperDocsArgs): Promise<DropboxResponse<paper.ListPaperDocsResponse>>;
+    public paperDocsList(arg: paper.ListPaperDocsArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListPaperDocsResponse>>;
 
     /**
      * Once a cursor has been retrieved from docsList(), use this to paginate
@@ -2001,8 +2119,9 @@ export class Dropbox {
      * DropboxResponseError<paper.ListDocsCursorError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsListContinue(arg: paper.ListPaperDocsContinueArgs): Promise<DropboxResponse<paper.ListPaperDocsResponse>>;
+    public paperDocsListContinue(arg: paper.ListPaperDocsContinueArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListPaperDocsResponse>>;
 
     /**
      * Permanently deletes the given Paper doc. This operation is final as the
@@ -2022,8 +2141,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsPermanentlyDelete(arg: paper.RefPaperDoc): Promise<DropboxResponse<void>>;
+    public paperDocsPermanentlyDelete(arg: paper.RefPaperDoc, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Gets the default sharing policy for the given Paper doc. Note that this
@@ -2042,8 +2162,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsSharingPolicyGet(arg: paper.RefPaperDoc): Promise<DropboxResponse<paper.SharingPolicy>>;
+    public paperDocsSharingPolicyGet(arg: paper.RefPaperDoc, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.SharingPolicy>>;
 
     /**
      * Sets the default sharing policy for the given Paper doc. The default
@@ -2065,8 +2186,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsSharingPolicySet(arg: paper.PaperDocSharingPolicy): Promise<DropboxResponse<void>>;
+    public paperDocsSharingPolicySet(arg: paper.PaperDocSharingPolicy, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Updates an existing Paper doc with the provided content. Note that this
@@ -2085,8 +2207,9 @@ export class Dropbox {
      * DropboxResponseError<paper.PaperDocUpdateError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsUpdate(arg: paper.PaperDocUpdateArgs): Promise<DropboxResponse<paper.PaperDocCreateUpdateResult>>;
+    public paperDocsUpdate(arg: paper.PaperDocUpdateArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.PaperDocCreateUpdateResult>>;
 
     /**
      * Allows an owner or editor to add users to a Paper doc or change their
@@ -2107,8 +2230,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsUsersAdd(arg: paper.AddPaperDocUser): Promise<DropboxResponse<Array<paper.AddPaperDocUserMemberResult>>>;
+    public paperDocsUsersAdd(arg: paper.AddPaperDocUser, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<paper.AddPaperDocUserMemberResult>>>;
 
     /**
      * Lists all users who visited the Paper doc or users with explicit access.
@@ -2130,8 +2254,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsUsersList(arg: paper.ListUsersOnPaperDocArgs): Promise<DropboxResponse<paper.ListUsersOnPaperDocResponse>>;
+    public paperDocsUsersList(arg: paper.ListUsersOnPaperDocArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListUsersOnPaperDocResponse>>;
 
     /**
      * Once a cursor has been retrieved from docsUsersList(), use this to
@@ -2151,8 +2276,9 @@ export class Dropbox {
      * DropboxResponseError<paper.ListUsersCursorError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsUsersListContinue(arg: paper.ListUsersOnPaperDocContinueArgs): Promise<DropboxResponse<paper.ListUsersOnPaperDocResponse>>;
+    public paperDocsUsersListContinue(arg: paper.ListUsersOnPaperDocContinueArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.ListUsersOnPaperDocResponse>>;
 
     /**
      * Allows an owner or editor to remove users from a Paper doc using their
@@ -2172,8 +2298,9 @@ export class Dropbox {
      * DropboxResponseError<paper.DocLookupError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperDocsUsersRemove(arg: paper.RemovePaperDocUser): Promise<DropboxResponse<void>>;
+    public paperDocsUsersRemove(arg: paper.RemovePaperDocUser, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Create a new Paper folder with the provided info. Note that this endpoint
@@ -2192,8 +2319,9 @@ export class Dropbox {
      * DropboxResponseError<paper.PaperFolderCreateError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public paperFoldersCreate(arg: paper.PaperFolderCreateArg): Promise<DropboxResponse<paper.PaperFolderCreateResult>>;
+    public paperFoldersCreate(arg: paper.PaperFolderCreateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<paper.PaperFolderCreateResult>>;
 
     /**
      * Asynchronous document-to-markdown conversion for supported file formats.
@@ -2208,8 +2336,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetMarkdownAsync(arg: riviera.GetMarkdownArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public rivieraGetMarkdownAsync(arg: riviera.GetMarkdownArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Returns the status or result of specified get_markdown_async task.
@@ -2220,8 +2349,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetMarkdownAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMarkdownAsyncCheckResult>>;
+    public rivieraGetMarkdownAsyncCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<riviera.GetMarkdownAsyncCheckResult>>;
 
     /**
      * Asynchronous file metadata extraction for supported file formats. The
@@ -2243,8 +2373,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetMetadataAsync(arg: riviera.GetMetadataArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public rivieraGetMetadataAsync(arg: riviera.GetMetadataArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Returns the status or result of specified get_metadata_async task.
@@ -2255,8 +2386,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetMetadataAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetMetadataAsyncCheckResult>>;
+    public rivieraGetMetadataAsyncCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<riviera.GetMetadataAsyncCheckResult>>;
 
     /**
      * Asynchronous plain-text extraction from documents. Supported formats
@@ -2274,8 +2406,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetTextAsync(arg: riviera.GetTextArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public rivieraGetTextAsync(arg: riviera.GetTextArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Returns the status or result of specified get_text_async task.
@@ -2286,8 +2419,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetTextAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetTextAsyncCheckResult>>;
+    public rivieraGetTextAsyncCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<riviera.GetTextAsyncCheckResult>>;
 
     /**
      * Asynchronous transcript generation for audio and video files. Supported
@@ -2305,8 +2439,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetTranscriptAsync(arg: riviera.GetTranscriptArgs): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public rivieraGetTranscriptAsync(arg: riviera.GetTranscriptArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Returns the status or result of specified get_transcript_async task.
@@ -2317,8 +2452,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public rivieraGetTranscriptAsyncCheck(arg: async.PollArg): Promise<DropboxResponse<riviera.GetTranscriptAsyncCheckResult>>;
+    public rivieraGetTranscriptAsyncCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<riviera.GetTranscriptAsyncCheckResult>>;
 
     /**
      * Adds specified members to a file.
@@ -2329,8 +2465,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.AddFileMemberError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingAddFileMember(arg: sharing.AddFileMemberArgs): Promise<DropboxResponse<Array<sharing.FileMemberActionResult>>>;
+    public sharingAddFileMember(arg: sharing.AddFileMemberArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<sharing.FileMemberActionResult>>>;
 
     /**
      * Allows an owner or editor (if the ACL update policy allows) of a shared
@@ -2344,8 +2481,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.AddFolderMemberError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingAddFolderMember(arg: sharing.AddFolderMemberArg): Promise<DropboxResponse<void>>;
+    public sharingAddFolderMember(arg: sharing.AddFolderMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Returns the status of an asynchronous job.
@@ -2356,8 +2494,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingCheckJobStatus(arg: async.PollArg): Promise<DropboxResponse<sharing.JobStatus>>;
+    public sharingCheckJobStatus(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.JobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for sharing a folder.
@@ -2368,8 +2507,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingCheckRemoveMemberJobStatus(arg: async.PollArg): Promise<DropboxResponse<sharing.RemoveMemberJobStatus>>;
+    public sharingCheckRemoveMemberJobStatus(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.RemoveMemberJobStatus>>;
 
     /**
      * Returns the status of an asynchronous job for sharing a folder.
@@ -2380,8 +2520,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingCheckShareJobStatus(arg: async.PollArg): Promise<DropboxResponse<sharing.ShareFolderJobStatus>>;
+    public sharingCheckShareJobStatus(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ShareFolderJobStatus>>;
 
     /**
      * Create a shared link. If a shared link already exists for the given path,
@@ -2399,8 +2540,9 @@ export class Dropbox {
      * DropboxResponseError<sharing.CreateSharedLinkError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingCreateSharedLink(arg: sharing.CreateSharedLinkArg): Promise<DropboxResponse<sharing.PathLinkMetadata>>;
+    public sharingCreateSharedLink(arg: sharing.CreateSharedLinkArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.PathLinkMetadata>>;
 
     /**
      * Create a shared link with custom settings. If no settings are given then
@@ -2414,8 +2556,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.CreateSharedLinkWithSettingsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingCreateSharedLinkWithSettings(arg: sharing.CreateSharedLinkWithSettingsArg): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
+    public sharingCreateSharedLinkWithSettings(arg: sharing.CreateSharedLinkWithSettingsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
 
     /**
      * Returns shared file metadata.
@@ -2426,8 +2569,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.GetFileMetadataError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetFileMetadata(arg: sharing.GetFileMetadataArg): Promise<DropboxResponse<sharing.SharedFileMetadata>>;
+    public sharingGetFileMetadata(arg: sharing.GetFileMetadataArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFileMetadata>>;
 
     /**
      * Returns shared file metadata.
@@ -2438,8 +2582,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharingUserError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetFileMetadataBatch(arg: sharing.GetFileMetadataBatchArg): Promise<DropboxResponse<Array<sharing.GetFileMetadataBatchResult>>>;
+    public sharingGetFileMetadataBatch(arg: sharing.GetFileMetadataBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<sharing.GetFileMetadataBatchResult>>>;
 
     /**
      * Returns shared folder metadata by its folder ID.
@@ -2450,8 +2595,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharedFolderAccessError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetFolderMetadata(arg: sharing.GetMetadataArgs): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
+    public sharingGetFolderMetadata(arg: sharing.GetMetadataArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
 
     /**
      * Download the shared link's file from a user's Dropbox. This is a
@@ -2463,8 +2609,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.GetSharedLinkFileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetSharedLinkFile(arg: sharing.GetSharedLinkFileArg): Promise<DropboxResponse<DropboxDownloadResult<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>>;
+    public sharingGetSharedLinkFile(arg: sharing.GetSharedLinkFileArg, options?: DropboxRequestOptions): Promise<DropboxResponse<DropboxDownloadResult<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>>;
 
     /**
      * Get the shared link's metadata.
@@ -2475,8 +2622,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharedLinkMetadataError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetSharedLinkMetadata(arg: sharing.GetSharedLinkMetadataArg): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
+    public sharingGetSharedLinkMetadata(arg: sharing.GetSharedLinkMetadataArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
 
     /**
      * DEPRECATED: Use list_shared_links instead. This endpoint will be retired
@@ -2494,8 +2642,9 @@ export class Dropbox {
      * DropboxResponseError<sharing.GetSharedLinksError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingGetSharedLinks(arg: sharing.GetSharedLinksArg): Promise<DropboxResponse<sharing.GetSharedLinksResult>>;
+    public sharingGetSharedLinks(arg: sharing.GetSharedLinksArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.GetSharedLinksResult>>;
 
     /**
      * Use to obtain the members who have been invited to a file, both inherited
@@ -2507,8 +2656,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFileMembersError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFileMembers(arg: sharing.ListFileMembersArg): Promise<DropboxResponse<sharing.SharedFileMembers>>;
+    public sharingListFileMembers(arg: sharing.ListFileMembersArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFileMembers>>;
 
     /**
      * Get members of multiple files at once. The arguments to this route are
@@ -2523,8 +2673,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharingUserError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFileMembersBatch(arg: sharing.ListFileMembersBatchArg): Promise<DropboxResponse<Array<sharing.ListFileMembersBatchResult>>>;
+    public sharingListFileMembersBatch(arg: sharing.ListFileMembersBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<sharing.ListFileMembersBatchResult>>>;
 
     /**
      * Once a cursor has been retrieved from listFileMembers() or
@@ -2537,8 +2688,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFileMembersContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFileMembersContinue(arg: sharing.ListFileMembersContinueArg): Promise<DropboxResponse<sharing.SharedFileMembers>>;
+    public sharingListFileMembersContinue(arg: sharing.ListFileMembersContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFileMembers>>;
 
     /**
      * Returns shared folder membership by its folder ID.
@@ -2549,8 +2701,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharedFolderAccessError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFolderMembers(arg: sharing.ListFolderMembersArgs): Promise<DropboxResponse<sharing.SharedFolderMembers>>;
+    public sharingListFolderMembers(arg: sharing.ListFolderMembersArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFolderMembers>>;
 
     /**
      * Once a cursor has been retrieved from listFolderMembers(), use this to
@@ -2562,8 +2715,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFolderMembersContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFolderMembersContinue(arg: sharing.ListFolderMembersContinueArg): Promise<DropboxResponse<sharing.SharedFolderMembers>>;
+    public sharingListFolderMembersContinue(arg: sharing.ListFolderMembersContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFolderMembers>>;
 
     /**
      * Return the list of all shared folders the current user has access to.
@@ -2574,8 +2728,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFolders(arg: sharing.ListFoldersArgs): Promise<DropboxResponse<sharing.ListFoldersResult>>;
+    public sharingListFolders(arg: sharing.ListFoldersArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFoldersResult>>;
 
     /**
      * Once a cursor has been retrieved from listFolders(), use this to paginate
@@ -2588,8 +2743,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFoldersContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListFoldersContinue(arg: sharing.ListFoldersContinueArg): Promise<DropboxResponse<sharing.ListFoldersResult>>;
+    public sharingListFoldersContinue(arg: sharing.ListFoldersContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFoldersResult>>;
 
     /**
      * Return the list of all shared folders the current user can mount or
@@ -2601,8 +2757,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListMountableFolders(arg: sharing.ListFoldersArgs): Promise<DropboxResponse<sharing.ListFoldersResult>>;
+    public sharingListMountableFolders(arg: sharing.ListFoldersArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFoldersResult>>;
 
     /**
      * Once a cursor has been retrieved from listMountableFolders(), use this to
@@ -2616,8 +2773,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFoldersContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListMountableFoldersContinue(arg: sharing.ListFoldersContinueArg): Promise<DropboxResponse<sharing.ListFoldersResult>>;
+    public sharingListMountableFoldersContinue(arg: sharing.ListFoldersContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFoldersResult>>;
 
     /**
      * Returns a list of all files shared with current user.
@@ -2628,8 +2786,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SharingUserError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListReceivedFiles(arg: sharing.ListFilesArg): Promise<DropboxResponse<sharing.ListFilesResult>>;
+    public sharingListReceivedFiles(arg: sharing.ListFilesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFilesResult>>;
 
     /**
      * Get more results with a cursor from listReceivedFiles().
@@ -2640,8 +2799,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListFilesContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListReceivedFilesContinue(arg: sharing.ListFilesContinueArg): Promise<DropboxResponse<sharing.ListFilesResult>>;
+    public sharingListReceivedFilesContinue(arg: sharing.ListFilesContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListFilesResult>>;
 
     /**
      * List shared links of this user. If no path is given, returns a list of
@@ -2659,8 +2819,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ListSharedLinksError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingListSharedLinks(arg: sharing.ListSharedLinksArg): Promise<DropboxResponse<sharing.ListSharedLinksResult>>;
+    public sharingListSharedLinks(arg: sharing.ListSharedLinksArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ListSharedLinksResult>>;
 
     /**
      * Modify the shared link's settings. If the requested visibility conflict
@@ -2677,8 +2838,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ModifySharedLinkSettingsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingModifySharedLinkSettings(arg: sharing.ModifySharedLinkSettingsArgs): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
+    public sharingModifySharedLinkSettings(arg: sharing.ModifySharedLinkSettingsArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.FileLinkMetadataReference|sharing.FolderLinkMetadataReference|sharing.SharedLinkMetadataReference>>;
 
     /**
      * The current user mounts the designated folder. Mount a shared folder for
@@ -2691,8 +2853,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.MountFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingMountFolder(arg: sharing.MountFolderArg): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
+    public sharingMountFolder(arg: sharing.MountFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
 
     /**
      * Removes all self-removable access from a file or folder for the current
@@ -2705,8 +2868,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RelinquishAccessError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRelinquishAccess(arg: sharing.RelinquishAccessArg): Promise<DropboxResponse<sharing.RelinquishAccessResult>>;
+    public sharingRelinquishAccess(arg: sharing.RelinquishAccessArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.RelinquishAccessResult>>;
 
     /**
      * The current user relinquishes their membership in the designated file.
@@ -2717,8 +2881,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RelinquishFileMembershipError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRelinquishFileMembership(arg: sharing.RelinquishFileMembershipArg): Promise<DropboxResponse<void>>;
+    public sharingRelinquishFileMembership(arg: sharing.RelinquishFileMembershipArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * The current user relinquishes their membership in the designated shared
@@ -2733,8 +2898,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RelinquishFolderMembershipError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRelinquishFolderMembership(arg: sharing.RelinquishFolderMembershipArg): Promise<DropboxResponse<async.LaunchEmptyResult>>;
+    public sharingRelinquishFolderMembership(arg: sharing.RelinquishFolderMembershipArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchEmptyResult>>;
 
     /**
      * Identical to remove_file_member_2 but with less information returned.
@@ -2746,8 +2912,9 @@ export class Dropbox {
      * DropboxResponseError<sharing.RemoveFileMemberError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRemoveFileMember(arg: sharing.RemoveFileMemberArg): Promise<DropboxResponse<sharing.FileMemberActionIndividualResult>>;
+    public sharingRemoveFileMember(arg: sharing.RemoveFileMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.FileMemberActionIndividualResult>>;
 
     /**
      * Removes a specified member from the file.
@@ -2758,8 +2925,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RemoveFileMemberError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRemoveFileMember2(arg: sharing.RemoveFileMemberArg): Promise<DropboxResponse<sharing.FileMemberRemoveActionResult>>;
+    public sharingRemoveFileMember2(arg: sharing.RemoveFileMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.FileMemberRemoveActionResult>>;
 
     /**
      * Allows an owner or editor (if the ACL update policy allows) of a shared
@@ -2771,8 +2939,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RemoveFolderMemberError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRemoveFolderMember(arg: sharing.RemoveFolderMemberArg): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public sharingRemoveFolderMember(arg: sharing.RemoveFolderMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Revoke a shared link. Note that even after revoking a shared link to a
@@ -2787,8 +2956,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.RevokeSharedLinkError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingRevokeSharedLink(arg: sharing.RevokeSharedLinkArg): Promise<DropboxResponse<void>>;
+    public sharingRevokeSharedLink(arg: sharing.RevokeSharedLinkArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Change the inheritance policy of an existing Shared Folder. Only
@@ -2803,8 +2973,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.SetAccessInheritanceError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingSetAccessInheritance(arg: sharing.SetAccessInheritanceArg): Promise<DropboxResponse<sharing.ShareFolderLaunch>>;
+    public sharingSetAccessInheritance(arg: sharing.SetAccessInheritanceArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ShareFolderLaunch>>;
 
     /**
      * Share a folder with collaborators. Most sharing will be completed
@@ -2820,8 +2991,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.ShareFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingShareFolder(arg: sharing.ShareFolderArg): Promise<DropboxResponse<sharing.ShareFolderLaunch>>;
+    public sharingShareFolder(arg: sharing.ShareFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.ShareFolderLaunch>>;
 
     /**
      * Transfer ownership of a shared folder to a member of the shared folder.
@@ -2834,8 +3006,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.TransferFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingTransferFolder(arg: sharing.TransferFolderArg): Promise<DropboxResponse<void>>;
+    public sharingTransferFolder(arg: sharing.TransferFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * The current user unmounts the designated folder. They can re-mount the
@@ -2847,8 +3020,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UnmountFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUnmountFolder(arg: sharing.UnmountFolderArg): Promise<DropboxResponse<void>>;
+    public sharingUnmountFolder(arg: sharing.UnmountFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Remove all members from this file. Does not remove inherited members.
@@ -2859,8 +3033,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UnshareFileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUnshareFile(arg: sharing.UnshareFileArg): Promise<DropboxResponse<void>>;
+    public sharingUnshareFile(arg: sharing.UnshareFileArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Allows a shared folder owner to unshare the folder. Unshare will not work
@@ -2874,8 +3049,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UnshareFolderError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUnshareFolder(arg: sharing.UnshareFolderArg): Promise<DropboxResponse<async.LaunchEmptyResult>>;
+    public sharingUnshareFolder(arg: sharing.UnshareFolderArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchEmptyResult>>;
 
     /**
      * Changes a member's access on a shared file.
@@ -2886,8 +3062,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.FileMemberActionError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUpdateFileMember(arg: sharing.UpdateFileMemberArgs): Promise<DropboxResponse<sharing.MemberAccessLevelResult>>;
+    public sharingUpdateFileMember(arg: sharing.UpdateFileMemberArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.MemberAccessLevelResult>>;
 
     /**
      * Update the viewer info policy of a file.
@@ -2898,8 +3075,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UpdateFilePolicyError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUpdateFilePolicy(arg: sharing.UpdateFilePolicyArg): Promise<DropboxResponse<sharing.SharedFileMetadata>>;
+    public sharingUpdateFilePolicy(arg: sharing.UpdateFilePolicyArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFileMetadata>>;
 
     /**
      * Allows an owner or editor of a shared folder to update another member's
@@ -2911,8 +3089,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UpdateFolderMemberError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUpdateFolderMember(arg: sharing.UpdateFolderMemberArg): Promise<DropboxResponse<sharing.MemberAccessLevelResult>>;
+    public sharingUpdateFolderMember(arg: sharing.UpdateFolderMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.MemberAccessLevelResult>>;
 
     /**
      * Update the sharing policies for a shared folder. User must have
@@ -2924,8 +3103,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<sharing.UpdateFolderPolicyError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public sharingUpdateFolderPolicy(arg: sharing.UpdateFolderPolicyArg): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
+    public sharingUpdateFolderPolicy(arg: sharing.UpdateFolderPolicyArg, options?: DropboxRequestOptions): Promise<DropboxResponse<sharing.SharedFolderMetadata>>;
 
     /**
      * List all device sessions of a team's member.
@@ -2936,8 +3116,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ListMemberDevicesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamDevicesListMemberDevices(arg: team.ListMemberDevicesArg): Promise<DropboxResponse<team.ListMemberDevicesResult>>;
+    public teamDevicesListMemberDevices(arg: team.ListMemberDevicesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListMemberDevicesResult>>;
 
     /**
      * List all device sessions of a team. Permission : Team member file access.
@@ -2948,8 +3129,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ListMembersDevicesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamDevicesListMembersDevices(arg: team.ListMembersDevicesArg): Promise<DropboxResponse<team.ListMembersDevicesResult>>;
+    public teamDevicesListMembersDevices(arg: team.ListMembersDevicesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListMembersDevicesResult>>;
 
     /**
      * List all device sessions of a team. Permission : Team member file access.
@@ -2961,8 +3143,9 @@ export class Dropbox {
      * DropboxResponseError<team.ListTeamDevicesError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamDevicesListTeamDevices(arg: team.ListTeamDevicesArg): Promise<DropboxResponse<team.ListTeamDevicesResult>>;
+    public teamDevicesListTeamDevices(arg: team.ListTeamDevicesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListTeamDevicesResult>>;
 
     /**
      * Revoke a device session of a team's member.
@@ -2973,8 +3156,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.RevokeDeviceSessionError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamDevicesRevokeDeviceSession(arg: team.RevokeDeviceSessionArg): Promise<DropboxResponse<void>>;
+    public teamDevicesRevokeDeviceSession(arg: team.RevokeDeviceSessionArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Revoke a list of device sessions of team members.
@@ -2985,8 +3169,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.RevokeDeviceSessionBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamDevicesRevokeDeviceSessionBatch(arg: team.RevokeDeviceSessionBatchArg): Promise<DropboxResponse<team.RevokeDeviceSessionBatchResult>>;
+    public teamDevicesRevokeDeviceSessionBatch(arg: team.RevokeDeviceSessionBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.RevokeDeviceSessionBatchResult>>;
 
     /**
      * Get the values for one or more features. This route allows you to check
@@ -2999,8 +3184,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.FeaturesGetValuesBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamFeaturesGetValues(arg: team.FeaturesGetValuesBatchArg): Promise<DropboxResponse<team.FeaturesGetValuesBatchResult>>;
+    public teamFeaturesGetValues(arg: team.FeaturesGetValuesBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.FeaturesGetValuesBatchResult>>;
 
     /**
      * Retrieves information about a team.
@@ -3010,8 +3196,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public teamGetInfo(): Promise<DropboxResponse<team.TeamGetInfoResult>>;
+    public teamGetInfo(options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamGetInfoResult>>;
 
     /**
      * Creates a new, empty group, with a requested name. Permission : Team
@@ -3023,8 +3210,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupCreateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsCreate(arg: team.GroupCreateArg): Promise<DropboxResponse<team.GroupFullInfo>>;
+    public teamGroupsCreate(arg: team.GroupCreateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupFullInfo>>;
 
     /**
      * Deletes a group. The group is deleted immediately. However the revoking
@@ -3038,8 +3226,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupDeleteError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsDelete(arg: team.GroupSelector): Promise<DropboxResponse<async.LaunchEmptyResult>>;
+    public teamGroupsDelete(arg: team.GroupSelector, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchEmptyResult>>;
 
     /**
      * Retrieves information about one or more groups. Note that the optional
@@ -3052,8 +3241,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupsGetInfoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsGetInfo(arg: team.GroupsSelector): Promise<DropboxResponse<team.GroupsGetInfoResult>>;
+    public teamGroupsGetInfo(arg: team.GroupsSelector, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsGetInfoResult>>;
 
     /**
      * Once an async_job_id is returned from groupsDelete(), groupsMembersAdd()
@@ -3067,8 +3257,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupsPollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsJobStatusGet(arg: async.PollArg): Promise<DropboxResponse<async.PollEmptyResult>>;
+    public teamGroupsJobStatusGet(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.PollEmptyResult>>;
 
     /**
      * Lists groups on a team. Permission : Team Information.
@@ -3079,8 +3270,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsList(arg: team.GroupsListArg): Promise<DropboxResponse<team.GroupsListResult>>;
+    public teamGroupsList(arg: team.GroupsListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsListResult>>;
 
     /**
      * Once a cursor has been retrieved from groupsList(), use this to paginate
@@ -3092,8 +3284,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupsListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsListContinue(arg: team.GroupsListContinueArg): Promise<DropboxResponse<team.GroupsListResult>>;
+    public teamGroupsListContinue(arg: team.GroupsListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsListResult>>;
 
     /**
      * Adds members to a group. The members are added immediately. However the
@@ -3107,8 +3300,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupMembersAddError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsMembersAdd(arg: team.GroupMembersAddArg): Promise<DropboxResponse<team.GroupMembersChangeResult>>;
+    public teamGroupsMembersAdd(arg: team.GroupMembersAddArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupMembersChangeResult>>;
 
     /**
      * Lists members of a group. Permission : Team Information.
@@ -3119,8 +3313,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupSelectorError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsMembersList(arg: team.GroupsMembersListArg): Promise<DropboxResponse<team.GroupsMembersListResult>>;
+    public teamGroupsMembersList(arg: team.GroupsMembersListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsMembersListResult>>;
 
     /**
      * Once a cursor has been retrieved from groupsMembersList(), use this to
@@ -3132,8 +3327,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupsMembersListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsMembersListContinue(arg: team.GroupsMembersListContinueArg): Promise<DropboxResponse<team.GroupsMembersListResult>>;
+    public teamGroupsMembersListContinue(arg: team.GroupsMembersListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsMembersListResult>>;
 
     /**
      * Removes members from a group. The members are removed immediately.
@@ -3149,8 +3345,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupMembersRemoveError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsMembersRemove(arg: team.GroupMembersRemoveArg): Promise<DropboxResponse<team.GroupMembersChangeResult>>;
+    public teamGroupsMembersRemove(arg: team.GroupMembersRemoveArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupMembersChangeResult>>;
 
     /**
      * Sets a member's access type in a group. Permission : Team member
@@ -3162,8 +3359,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupMemberSetAccessTypeError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsMembersSetAccessType(arg: team.GroupMembersSetAccessTypeArg): Promise<DropboxResponse<team.GroupsGetInfoResult>>;
+    public teamGroupsMembersSetAccessType(arg: team.GroupMembersSetAccessTypeArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupsGetInfoResult>>;
 
     /**
      * Updates a group's name and/or external ID. Permission : Team member
@@ -3175,8 +3373,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.GroupUpdateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamGroupsUpdate(arg: team.GroupUpdateArgs): Promise<DropboxResponse<team.GroupFullInfo>>;
+    public teamGroupsUpdate(arg: team.GroupUpdateArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GroupFullInfo>>;
 
     /**
      * Creates new legal hold policy. Note: Legal Holds is a paid add-on. Not
@@ -3188,8 +3387,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyCreateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsCreatePolicy(arg: team.LegalHoldsPolicyCreateArg): Promise<DropboxResponse<team.LegalHoldsPolicyCreateResult>>;
+    public teamLegalHoldsCreatePolicy(arg: team.LegalHoldsPolicyCreateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsPolicyCreateResult>>;
 
     /**
      * Gets a legal hold by Id. Note: Legal Holds is a paid add-on. Not all
@@ -3201,8 +3401,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsGetPolicyError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsGetPolicy(arg: team.LegalHoldsGetPolicyArg): Promise<DropboxResponse<team.LegalHoldsGetPolicyResult>>;
+    public teamLegalHoldsGetPolicy(arg: team.LegalHoldsGetPolicyArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsGetPolicyResult>>;
 
     /**
      * List the file metadata that's under the hold. Note: Legal Holds is a paid
@@ -3215,8 +3416,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListHeldRevisionsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsListHeldRevisions(arg: team.LegalHoldsListHeldRevisionsArg): Promise<DropboxResponse<team.LegalHoldsListHeldRevisionResult>>;
+    public teamLegalHoldsListHeldRevisions(arg: team.LegalHoldsListHeldRevisionsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsListHeldRevisionResult>>;
 
     /**
      * Continue listing the file metadata that's under the hold. Note: Legal
@@ -3229,8 +3431,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListHeldRevisionsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsListHeldRevisionsContinue(arg: team.LegalHoldsListHeldRevisionsContinueArg): Promise<DropboxResponse<team.LegalHoldsListHeldRevisionResult>>;
+    public teamLegalHoldsListHeldRevisionsContinue(arg: team.LegalHoldsListHeldRevisionsContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsListHeldRevisionResult>>;
 
     /**
      * Lists legal holds on a team. Note: Legal Holds is a paid add-on. Not all
@@ -3242,8 +3445,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsListPoliciesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsListPolicies(arg: team.LegalHoldsListPoliciesArg): Promise<DropboxResponse<team.LegalHoldsListPoliciesResult>>;
+    public teamLegalHoldsListPolicies(arg: team.LegalHoldsListPoliciesArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsListPoliciesResult>>;
 
     /**
      * Releases a legal hold by Id. Note: Legal Holds is a paid add-on. Not all
@@ -3255,8 +3459,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyReleaseError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsReleasePolicy(arg: team.LegalHoldsPolicyReleaseArg): Promise<DropboxResponse<void>>;
+    public teamLegalHoldsReleasePolicy(arg: team.LegalHoldsPolicyReleaseArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Updates a legal hold. Note: Legal Holds is a paid add-on. Not all teams
@@ -3268,8 +3473,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.LegalHoldsPolicyUpdateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLegalHoldsUpdatePolicy(arg: team.LegalHoldsPolicyUpdateArg): Promise<DropboxResponse<team.LegalHoldsPolicyUpdateResult>>;
+    public teamLegalHoldsUpdatePolicy(arg: team.LegalHoldsPolicyUpdateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.LegalHoldsPolicyUpdateResult>>;
 
     /**
      * List all linked applications of the team member. Note, this endpoint does
@@ -3281,8 +3487,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ListMemberAppsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLinkedAppsListMemberLinkedApps(arg: team.ListMemberAppsArg): Promise<DropboxResponse<team.ListMemberAppsResult>>;
+    public teamLinkedAppsListMemberLinkedApps(arg: team.ListMemberAppsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListMemberAppsResult>>;
 
     /**
      * List all applications linked to the team members' accounts. Note, this
@@ -3294,8 +3501,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ListMembersAppsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLinkedAppsListMembersLinkedApps(arg: team.ListMembersAppsArg): Promise<DropboxResponse<team.ListMembersAppsResult>>;
+    public teamLinkedAppsListMembersLinkedApps(arg: team.ListMembersAppsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListMembersAppsResult>>;
 
     /**
      * List all applications linked to the team members' accounts. Note, this
@@ -3308,8 +3516,9 @@ export class Dropbox {
      * DropboxResponseError<team.ListTeamAppsError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLinkedAppsListTeamLinkedApps(arg: team.ListTeamAppsArg): Promise<DropboxResponse<team.ListTeamAppsResult>>;
+    public teamLinkedAppsListTeamLinkedApps(arg: team.ListTeamAppsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ListTeamAppsResult>>;
 
     /**
      * Revoke a linked application of the team member.
@@ -3320,8 +3529,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.RevokeLinkedAppError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLinkedAppsRevokeLinkedApp(arg: team.RevokeLinkedApiAppArg): Promise<DropboxResponse<void>>;
+    public teamLinkedAppsRevokeLinkedApp(arg: team.RevokeLinkedApiAppArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Revoke a list of linked applications of the team members.
@@ -3332,8 +3542,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.RevokeLinkedAppBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLinkedAppsRevokeLinkedAppBatch(arg: team.RevokeLinkedApiAppBatchArg): Promise<DropboxResponse<team.RevokeLinkedAppBatchResult>>;
+    public teamLinkedAppsRevokeLinkedAppBatch(arg: team.RevokeLinkedApiAppBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.RevokeLinkedAppBatchResult>>;
 
     /**
      * Add users to member space limits excluded users list.
@@ -3344,8 +3555,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ExcludedUsersUpdateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsExcludedUsersAdd(arg: team.ExcludedUsersUpdateArg): Promise<DropboxResponse<team.ExcludedUsersUpdateResult>>;
+    public teamMemberSpaceLimitsExcludedUsersAdd(arg: team.ExcludedUsersUpdateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ExcludedUsersUpdateResult>>;
 
     /**
      * List member space limits excluded users.
@@ -3356,8 +3568,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ExcludedUsersListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsExcludedUsersList(arg: team.ExcludedUsersListArg): Promise<DropboxResponse<team.ExcludedUsersListResult>>;
+    public teamMemberSpaceLimitsExcludedUsersList(arg: team.ExcludedUsersListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ExcludedUsersListResult>>;
 
     /**
      * Continue listing member space limits excluded users.
@@ -3368,8 +3581,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ExcludedUsersListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsExcludedUsersListContinue(arg: team.ExcludedUsersListContinueArg): Promise<DropboxResponse<team.ExcludedUsersListResult>>;
+    public teamMemberSpaceLimitsExcludedUsersListContinue(arg: team.ExcludedUsersListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ExcludedUsersListResult>>;
 
     /**
      * Remove users from member space limits excluded users list.
@@ -3380,8 +3594,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.ExcludedUsersUpdateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsExcludedUsersRemove(arg: team.ExcludedUsersUpdateArg): Promise<DropboxResponse<team.ExcludedUsersUpdateResult>>;
+    public teamMemberSpaceLimitsExcludedUsersRemove(arg: team.ExcludedUsersUpdateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ExcludedUsersUpdateResult>>;
 
     /**
      * Get users custom quota. A maximum of 1000 members can be specified in a
@@ -3395,8 +3610,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.CustomQuotaError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsGetCustomQuota(arg: team.CustomQuotaUsersArg): Promise<DropboxResponse<Array<team.CustomQuotaResult>>>;
+    public teamMemberSpaceLimitsGetCustomQuota(arg: team.CustomQuotaUsersArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<team.CustomQuotaResult>>>;
 
     /**
      * Remove users custom quota. A maximum of 1000 members can be specified in
@@ -3410,8 +3626,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.CustomQuotaError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsRemoveCustomQuota(arg: team.CustomQuotaUsersArg): Promise<DropboxResponse<Array<team.RemoveCustomQuotaResult>>>;
+    public teamMemberSpaceLimitsRemoveCustomQuota(arg: team.CustomQuotaUsersArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<team.RemoveCustomQuotaResult>>>;
 
     /**
      * Set users custom quota. Custom quota has to be at least 2GB. A maximum of
@@ -3426,8 +3643,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.SetCustomQuotaError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMemberSpaceLimitsSetCustomQuota(arg: team.SetCustomQuotaArg): Promise<DropboxResponse<Array<team.CustomQuotaResult>>>;
+    public teamMemberSpaceLimitsSetCustomQuota(arg: team.SetCustomQuotaArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<team.CustomQuotaResult>>>;
 
     /**
      * Adds members to a team. Permission : Team member management A maximum of
@@ -3448,8 +3666,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersAdd(arg: team.MembersAddArg): Promise<DropboxResponse<team.MembersAddLaunch>>;
+    public teamMembersAdd(arg: team.MembersAddArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersAddLaunch>>;
 
     /**
      * Adds members to a team. Permission : Team member management A maximum of
@@ -3467,8 +3686,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersAddV2(arg: team.MembersAddV2Arg): Promise<DropboxResponse<team.MembersAddLaunchV2Result>>;
+    public teamMembersAddV2(arg: team.MembersAddV2Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersAddLaunchV2Result>>;
 
     /**
      * Once an async_job_id is returned from membersAdd() , use this to poll the
@@ -3480,8 +3700,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersAddJobStatusGet(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatus>>;
+    public teamMembersAddJobStatusGet(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersAddJobStatus>>;
 
     /**
      * Once an async_job_id is returned from membersAddV2() , use this to poll
@@ -3494,8 +3715,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersAddJobStatusGetV2(arg: async.PollArg): Promise<DropboxResponse<team.MembersAddJobStatusV2Result>>;
+    public teamMembersAddJobStatusGetV2(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersAddJobStatusV2Result>>;
 
     /**
      * Launch a bulk suspend job. The server enforces a maximum of 500 members.
@@ -3506,8 +3728,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.BulkSuspendError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersBulkSuspend(arg: team.BulkSuspendArg): Promise<DropboxResponse<async.LaunchResultBase>>;
+    public teamMembersBulkSuspend(arg: team.BulkSuspendArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchResultBase>>;
 
     /**
      * Poll a previously launched bulk suspend job.
@@ -3518,8 +3741,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersBulkSuspendJobStatusCheck(arg: async.PollArg): Promise<DropboxResponse<team.BulkSuspendJobStatus>>;
+    public teamMembersBulkSuspendJobStatusCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.BulkSuspendJobStatus>>;
 
     /**
      * Permanently delete the files of a user who has been removed from the
@@ -3534,8 +3758,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersDeleteFormerMemberFilesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersDeleteFormerMemberFiles(arg: team.MembersFormerMemberArg): Promise<DropboxResponse<void>>;
+    public teamMembersDeleteFormerMemberFiles(arg: team.MembersFormerMemberArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Deletes a team member's profile photo. Permission : Team member
@@ -3547,8 +3772,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersDeleteProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersDeleteProfilePhoto(arg: team.MembersDeleteProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
+    public teamMembersDeleteProfilePhoto(arg: team.MembersDeleteProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
      * Deletes a team member's profile photo. Permission : Team member
@@ -3560,8 +3786,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersDeleteProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersDeleteProfilePhotoV2(arg: team.MembersDeleteProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
+    public teamMembersDeleteProfilePhotoV2(arg: team.MembersDeleteProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
 
     /**
      * Get available TeamMemberRoles for the connected team. To be used with
@@ -3572,8 +3799,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersGetAvailableTeamMemberRoles(): Promise<DropboxResponse<team.MembersGetAvailableTeamMemberRolesResult>>;
+    public teamMembersGetAvailableTeamMemberRoles(options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersGetAvailableTeamMemberRolesResult>>;
 
     /**
      * Returns information about multiple team members. Permission : Team
@@ -3586,8 +3814,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersGetInfoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersGetInfo(arg: team.MembersGetInfoArgs): Promise<DropboxResponse<team.MembersGetInfoResult>>;
+    public teamMembersGetInfo(arg: team.MembersGetInfoArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersGetInfoResult>>;
 
     /**
      * Returns information about multiple team members. Permission : Team
@@ -3600,8 +3829,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersGetInfoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersGetInfoV2(arg: team.MembersGetInfoV2Arg): Promise<DropboxResponse<team.MembersGetInfoV2Result>>;
+    public teamMembersGetInfoV2(arg: team.MembersGetInfoV2Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersGetInfoV2Result>>;
 
     /**
      * Lists members of a team. Permission : Team information.
@@ -3612,8 +3842,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersList(arg: team.MembersListArg): Promise<DropboxResponse<team.MembersListResult>>;
+    public teamMembersList(arg: team.MembersListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersListResult>>;
 
     /**
      * Lists members of a team. Permission : Team information.
@@ -3624,8 +3855,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersListV2(arg: team.MembersListArg): Promise<DropboxResponse<team.MembersListV2Result>>;
+    public teamMembersListV2(arg: team.MembersListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersListV2Result>>;
 
     /**
      * Once a cursor has been retrieved from membersList(), use this to paginate
@@ -3637,8 +3869,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersListContinue(arg: team.MembersListContinueArg): Promise<DropboxResponse<team.MembersListResult>>;
+    public teamMembersListContinue(arg: team.MembersListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersListResult>>;
 
     /**
      * Once a cursor has been retrieved from membersListV2(), use this to
@@ -3650,8 +3883,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersListContinueV2(arg: team.MembersListContinueArg): Promise<DropboxResponse<team.MembersListV2Result>>;
+    public teamMembersListContinueV2(arg: team.MembersListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersListV2Result>>;
 
     /**
      * Moves removed member's files to a different member. This endpoint
@@ -3666,8 +3900,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersTransferFormerMembersFilesError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersMoveFormerMemberFiles(arg: team.MembersDataTransferArg): Promise<DropboxResponse<async.LaunchEmptyResult>>;
+    public teamMembersMoveFormerMemberFiles(arg: team.MembersDataTransferArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchEmptyResult>>;
 
     /**
      * Once an async_job_id is returned from membersMoveFormerMemberFiles() ,
@@ -3680,8 +3915,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersMoveFormerMemberFilesJobStatusCheck(arg: async.PollArg): Promise<DropboxResponse<async.PollEmptyResult>>;
+    public teamMembersMoveFormerMemberFilesJobStatusCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.PollEmptyResult>>;
 
     /**
      * Recover a deleted member. Permission : Team member management Exactly one
@@ -3694,8 +3930,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersRecoverError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersRecover(arg: team.MembersRecoverArg): Promise<DropboxResponse<void>>;
+    public teamMembersRecover(arg: team.MembersRecoverArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Removes a member from a team. Permission : Team member management Exactly
@@ -3718,8 +3955,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersRemoveError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersRemove(arg: team.MembersRemoveArg): Promise<DropboxResponse<async.LaunchEmptyResult>>;
+    public teamMembersRemove(arg: team.MembersRemoveArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.LaunchEmptyResult>>;
 
     /**
      * Once an async_job_id is returned from membersRemove() , use this to poll
@@ -3732,8 +3970,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersRemoveJobStatusGet(arg: async.PollArg): Promise<DropboxResponse<async.PollEmptyResult>>;
+    public teamMembersRemoveJobStatusGet(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<async.PollEmptyResult>>;
 
     /**
      * Add secondary emails to users. Permission : Team member management.
@@ -3747,8 +3986,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.AddSecondaryEmailsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSecondaryEmailsAdd(arg: team.AddSecondaryEmailsArg): Promise<DropboxResponse<team.AddSecondaryEmailsResult>>;
+    public teamMembersSecondaryEmailsAdd(arg: team.AddSecondaryEmailsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.AddSecondaryEmailsResult>>;
 
     /**
      * Delete secondary emails from users Permission : Team member management.
@@ -3761,8 +4001,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSecondaryEmailsDelete(arg: team.DeleteSecondaryEmailsArg): Promise<DropboxResponse<team.DeleteSecondaryEmailsResult>>;
+    public teamMembersSecondaryEmailsDelete(arg: team.DeleteSecondaryEmailsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.DeleteSecondaryEmailsResult>>;
 
     /**
      * Resend secondary email verification emails. Permission : Team member
@@ -3774,8 +4015,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSecondaryEmailsResendVerificationEmails(arg: team.ResendVerificationEmailArg): Promise<DropboxResponse<team.ResendVerificationEmailResult>>;
+    public teamMembersSecondaryEmailsResendVerificationEmails(arg: team.ResendVerificationEmailArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.ResendVerificationEmailResult>>;
 
     /**
      * Sends welcome email to pending team member. Permission : Team member
@@ -3789,8 +4031,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSendWelcomeError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSendWelcomeEmail(arg: team.UserSelectorArg): Promise<DropboxResponse<void>>;
+    public teamMembersSendWelcomeEmail(arg: team.UserSelectorArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Updates a team member's permissions. Permission : Team member management.
@@ -3801,8 +4044,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetPermissionsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetAdminPermissions(arg: team.MembersSetPermissionsArg): Promise<DropboxResponse<team.MembersSetPermissionsResult>>;
+    public teamMembersSetAdminPermissions(arg: team.MembersSetPermissionsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersSetPermissionsResult>>;
 
     /**
      * Updates a team member's permissions. Permission : Team member management.
@@ -3813,8 +4057,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetPermissions2Error>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetAdminPermissionsV2(arg: team.MembersSetPermissions2Arg): Promise<DropboxResponse<team.MembersSetPermissions2Result>>;
+    public teamMembersSetAdminPermissionsV2(arg: team.MembersSetPermissions2Arg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.MembersSetPermissions2Result>>;
 
     /**
      * Updates a team member's profile. Permission : Team member management.
@@ -3825,8 +4070,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetProfileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetProfile(arg: team.MembersSetProfileArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
+    public teamMembersSetProfile(arg: team.MembersSetProfileArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
      * Updates a team member's profile. Permission : Team member management.
@@ -3837,8 +4083,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetProfileError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetProfileV2(arg: team.MembersSetProfileArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
+    public teamMembersSetProfileV2(arg: team.MembersSetProfileArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
 
     /**
      * Updates a team member's profile photo. Permission : Team member
@@ -3850,8 +4097,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetProfilePhoto(arg: team.MembersSetProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfo>>;
+    public teamMembersSetProfilePhoto(arg: team.MembersSetProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfo>>;
 
     /**
      * Updates a team member's profile photo. Permission : Team member
@@ -3863,8 +4111,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSetProfilePhotoError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSetProfilePhotoV2(arg: team.MembersSetProfilePhotoArg): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
+    public teamMembersSetProfilePhotoV2(arg: team.MembersSetProfilePhotoArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamMemberInfoV2Result>>;
 
     /**
      * Suspend a member from a team. Permission : Team member management Exactly
@@ -3877,8 +4126,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersSuspendError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersSuspend(arg: team.MembersDeactivateArg): Promise<DropboxResponse<void>>;
+    public teamMembersSuspend(arg: team.MembersDeactivateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Unsuspend a member from a team. Permission : Team member management
@@ -3891,8 +4141,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.MembersUnsuspendError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamMembersUnsuspend(arg: team.MembersUnsuspendArg): Promise<DropboxResponse<void>>;
+    public teamMembersUnsuspend(arg: team.MembersUnsuspendArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Returns a list of all team-accessible namespaces. This list includes team
@@ -3908,8 +4159,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamNamespacesListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamNamespacesList(arg: team.TeamNamespacesListArg): Promise<DropboxResponse<team.TeamNamespacesListResult>>;
+    public teamNamespacesList(arg: team.TeamNamespacesListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamNamespacesListResult>>;
 
     /**
      * Once a cursor has been retrieved from namespacesList(), use this to
@@ -3922,8 +4174,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamNamespacesListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamNamespacesListContinue(arg: team.TeamNamespacesListContinueArg): Promise<DropboxResponse<team.TeamNamespacesListResult>>;
+    public teamNamespacesListContinue(arg: team.TeamNamespacesListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamNamespacesListResult>>;
 
     /**
      * Permission : Team member file access.
@@ -3935,8 +4188,9 @@ export class Dropbox {
      * DropboxResponseError<file_properties.ModifyTemplateError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamPropertiesTemplateAdd(arg: file_properties.AddTemplateArg): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
+    public teamPropertiesTemplateAdd(arg: file_properties.AddTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.AddTemplateResult>>;
 
     /**
      * Permission : Team member file access. The scope for the route is
@@ -3949,8 +4203,9 @@ export class Dropbox {
      * DropboxResponseError<file_properties.TemplateError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamPropertiesTemplateGet(arg: file_properties.GetTemplateArg): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
+    public teamPropertiesTemplateGet(arg: file_properties.GetTemplateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<file_properties.GetTemplateResult>>;
 
     /**
      * Retrieves reporting data about a team's user activity. Deprecated: Will
@@ -3963,8 +4218,9 @@ export class Dropbox {
      * DropboxResponseError<team.DateRangeError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamReportsGetActivity(arg: team.DateRange): Promise<DropboxResponse<team.GetActivityReport>>;
+    public teamReportsGetActivity(arg: team.DateRange, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GetActivityReport>>;
 
     /**
      * Retrieves reporting data about a team's linked devices. Deprecated: Will
@@ -3977,8 +4233,9 @@ export class Dropbox {
      * DropboxResponseError<team.DateRangeError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamReportsGetDevices(arg: team.DateRange): Promise<DropboxResponse<team.GetDevicesReport>>;
+    public teamReportsGetDevices(arg: team.DateRange, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GetDevicesReport>>;
 
     /**
      * Retrieves reporting data about a team's membership. Deprecated: Will be
@@ -3991,8 +4248,9 @@ export class Dropbox {
      * DropboxResponseError<team.DateRangeError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamReportsGetMembership(arg: team.DateRange): Promise<DropboxResponse<team.GetMembershipReport>>;
+    public teamReportsGetMembership(arg: team.DateRange, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GetMembershipReport>>;
 
     /**
      * Retrieves reporting data about a team's storage usage. Deprecated: Will
@@ -4005,8 +4263,9 @@ export class Dropbox {
      * DropboxResponseError<team.DateRangeError>.
      * @deprecated
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamReportsGetStorage(arg: team.DateRange): Promise<DropboxResponse<team.GetStorageReport>>;
+    public teamReportsGetStorage(arg: team.DateRange, options?: DropboxRequestOptions): Promise<DropboxResponse<team.GetStorageReport>>;
 
     /**
      * Endpoint adds Approve List entries. Changes are effective immediately.
@@ -4021,8 +4280,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.SharingAllowlistAddError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamSharingAllowlistAdd(arg: team.SharingAllowlistAddArgs): Promise<DropboxResponse<team.SharingAllowlistAddResponse>>;
+    public teamSharingAllowlistAdd(arg: team.SharingAllowlistAddArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<team.SharingAllowlistAddResponse>>;
 
     /**
      * Lists Approve List entries for given team, from newest to oldest,
@@ -4036,8 +4296,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.SharingAllowlistListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamSharingAllowlistList(arg: team.SharingAllowlistListArg): Promise<DropboxResponse<team.SharingAllowlistListResponse>>;
+    public teamSharingAllowlistList(arg: team.SharingAllowlistListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.SharingAllowlistListResponse>>;
 
     /**
      * Lists entries associated with given team, starting from a the cursor. See
@@ -4049,8 +4310,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.SharingAllowlistListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamSharingAllowlistListContinue(arg: team.SharingAllowlistListContinueArg): Promise<DropboxResponse<team.SharingAllowlistListResponse>>;
+    public teamSharingAllowlistListContinue(arg: team.SharingAllowlistListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.SharingAllowlistListResponse>>;
 
     /**
      * Endpoint removes Approve List entries. Changes are effective immediately.
@@ -4065,8 +4327,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.SharingAllowlistRemoveError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamSharingAllowlistRemove(arg: team.SharingAllowlistRemoveArgs): Promise<DropboxResponse<team.SharingAllowlistRemoveResponse>>;
+    public teamSharingAllowlistRemove(arg: team.SharingAllowlistRemoveArgs, options?: DropboxRequestOptions): Promise<DropboxResponse<team.SharingAllowlistRemoveResponse>>;
 
     /**
      * Sets an archived team folder's status to active. Permission : Team member
@@ -4078,8 +4341,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderActivateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderActivate(arg: team.TeamFolderIdArg): Promise<DropboxResponse<team.TeamFolderMetadata>>;
+    public teamTeamFolderActivate(arg: team.TeamFolderIdArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderMetadata>>;
 
     /**
      * Sets an active team folder's status to archived and removes all folder
@@ -4095,8 +4359,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderArchiveError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderArchive(arg: team.TeamFolderArchiveArg): Promise<DropboxResponse<team.TeamFolderArchiveLaunch>>;
+    public teamTeamFolderArchive(arg: team.TeamFolderArchiveArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderArchiveLaunch>>;
 
     /**
      * Returns the status of an asynchronous job for archiving a team folder.
@@ -4112,8 +4377,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<async.PollError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderArchiveCheck(arg: async.PollArg): Promise<DropboxResponse<team.TeamFolderArchiveJobStatus>>;
+    public teamTeamFolderArchiveCheck(arg: async.PollArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderArchiveJobStatus>>;
 
     /**
      * Creates a new, active, team folder with no members. This endpoint can
@@ -4126,8 +4392,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderCreateError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderCreate(arg: team.TeamFolderCreateArg): Promise<DropboxResponse<team.TeamFolderMetadata>>;
+    public teamTeamFolderCreate(arg: team.TeamFolderCreateArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderMetadata>>;
 
     /**
      * Retrieves metadata for team folders. Permission : Team member file
@@ -4139,8 +4406,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderGetInfo(arg: team.TeamFolderIdListArg): Promise<DropboxResponse<Array<team.TeamFolderGetInfoItem>>>;
+    public teamTeamFolderGetInfo(arg: team.TeamFolderIdListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<Array<team.TeamFolderGetInfoItem>>>;
 
     /**
      * Lists all team folders. Permission : Team member file access.
@@ -4151,8 +4419,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderListError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderList(arg: team.TeamFolderListArg): Promise<DropboxResponse<team.TeamFolderListResult>>;
+    public teamTeamFolderList(arg: team.TeamFolderListArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderListResult>>;
 
     /**
      * Once a cursor has been retrieved from teamFolderList(), use this to
@@ -4164,8 +4433,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderListContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderListContinue(arg: team.TeamFolderListContinueArg): Promise<DropboxResponse<team.TeamFolderListResult>>;
+    public teamTeamFolderListContinue(arg: team.TeamFolderListContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderListResult>>;
 
     /**
      * Permanently deletes an archived team folder. This endpoint cannot be used
@@ -4178,8 +4448,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderPermanentlyDeleteError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderPermanentlyDelete(arg: team.TeamFolderIdArg): Promise<DropboxResponse<void>>;
+    public teamTeamFolderPermanentlyDelete(arg: team.TeamFolderIdArg, options?: DropboxRequestOptions): Promise<DropboxResponse<void>>;
 
     /**
      * Changes an active team folder's name. Permission : Team member file
@@ -4191,8 +4462,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderRenameError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderRename(arg: team.TeamFolderRenameArg): Promise<DropboxResponse<team.TeamFolderMetadata>>;
+    public teamTeamFolderRename(arg: team.TeamFolderRenameArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderMetadata>>;
 
     /**
      * Sets an inactive team folder's status to active. Permission: Team member
@@ -4204,8 +4476,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderRestoreError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderRestore(arg: team.TeamFolderIdArg): Promise<DropboxResponse<team.TeamFolderMetadata>>;
+    public teamTeamFolderRestore(arg: team.TeamFolderIdArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderMetadata>>;
 
     /**
      * Updates the sync settings on a team folder or its contents.  Use of this
@@ -4217,8 +4490,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TeamFolderUpdateSyncSettingsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamTeamFolderUpdateSyncSettings(arg: team.TeamFolderUpdateSyncSettingsArg): Promise<DropboxResponse<team.TeamFolderMetadata>>;
+    public teamTeamFolderUpdateSyncSettings(arg: team.TeamFolderUpdateSyncSettingsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team.TeamFolderMetadata>>;
 
     /**
      * Returns the member profile of the admin who generated the team access
@@ -4229,8 +4503,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team.TokenGetAuthenticatedAdminError>.
+     * @param options Optional transport settings for this request.
      */
-    public teamTokenGetAuthenticatedAdmin(): Promise<DropboxResponse<team.TokenGetAuthenticatedAdminResult>>;
+    public teamTokenGetAuthenticatedAdmin(options?: DropboxRequestOptions): Promise<DropboxResponse<team.TokenGetAuthenticatedAdminResult>>;
 
     /**
      * Retrieves team events. If the result's GetTeamEventsResult.has_more field
@@ -4250,8 +4525,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team_log.GetTeamEventsError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLogGetEvents(arg: team_log.GetTeamEventsArg): Promise<DropboxResponse<team_log.GetTeamEventsResult>>;
+    public teamLogGetEvents(arg: team_log.GetTeamEventsArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team_log.GetTeamEventsResult>>;
 
     /**
      * Once a cursor has been retrieved from getEvents(), use this to paginate
@@ -4263,8 +4539,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<team_log.GetTeamEventsContinueError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public teamLogGetEventsContinue(arg: team_log.GetTeamEventsContinueArg): Promise<DropboxResponse<team_log.GetTeamEventsResult>>;
+    public teamLogGetEventsContinue(arg: team_log.GetTeamEventsContinueArg, options?: DropboxRequestOptions): Promise<DropboxResponse<team_log.GetTeamEventsResult>>;
 
     /**
      * Get a list of feature values that may be configured for the current
@@ -4276,8 +4553,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<users.UserFeaturesGetValuesBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public usersFeaturesGetValues(arg: users.UserFeaturesGetValuesBatchArg): Promise<DropboxResponse<users.UserFeaturesGetValuesBatchResult>>;
+    public usersFeaturesGetValues(arg: users.UserFeaturesGetValuesBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<users.UserFeaturesGetValuesBatchResult>>;
 
     /**
      * Get information about a user's account.
@@ -4288,8 +4566,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<users.GetAccountError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public usersGetAccount(arg: users.GetAccountArg): Promise<DropboxResponse<users.BasicAccount>>;
+    public usersGetAccount(arg: users.GetAccountArg, options?: DropboxRequestOptions): Promise<DropboxResponse<users.BasicAccount>>;
 
     /**
      * Get information about multiple user accounts. At most 300 accounts may be
@@ -4301,8 +4580,9 @@ export class Dropbox {
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<users.GetAccountBatchError>.
      * @param arg The request parameters.
+     * @param options Optional transport settings for this request.
      */
-    public usersGetAccountBatch(arg: users.GetAccountBatchArg): Promise<DropboxResponse<users.GetAccountBatchResult>>;
+    public usersGetAccountBatch(arg: users.GetAccountBatchArg, options?: DropboxRequestOptions): Promise<DropboxResponse<users.GetAccountBatchResult>>;
 
     /**
      * Get information about the current user's account.
@@ -4312,8 +4592,9 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public usersGetCurrentAccount(): Promise<DropboxResponse<users.FullAccount>>;
+    public usersGetCurrentAccount(options?: DropboxRequestOptions): Promise<DropboxResponse<users.FullAccount>>;
 
     /**
      * Get the space usage information for the current user's account.
@@ -4323,6 +4604,7 @@ export class Dropbox {
      *
      * When an error occurs, the route rejects the promise with type
      * DropboxResponseError<void>.
+     * @param options Optional transport settings for this request.
      */
-    public usersGetSpaceUsage(): Promise<DropboxResponse<users.SpaceUsage>>;
+    public usersGetSpaceUsage(options?: DropboxRequestOptions): Promise<DropboxResponse<users.SpaceUsage>>;
 }


### PR DESCRIPTION
### Summary
This change adds support for optional per-request transport options to the JavaScript SDK.

Generated route methods now accept an optional options parameter, which is forwarded to the transport layer. The SDK currently uses this to pass an AbortSignal to fetch, enabling request cancellation.

Example:
```
const controller = new AbortController();
await dbx.filesDownload(
  { path: '/example.txt' },
  { signal: controller.signal },
);
// Cancel the request if needed.
controller.abort();
```

### Motivation

Applications often need to cancel in-flight requests, for example when a user navigates away, retries an operation, or no longer needs the result.

This change provides a generic mechanism for passing transport-level options without changing generated API request types.

### Implementation

* Update the JavaScript route generator to emit an optional options parameter for generated route methods.
* Forward the options parameter through the request pipeline.
* Pass options.signal to the underlying fetch request when provided.

Existing behavior is unchanged when options is omitted.