### PR TITLE
Add requests timeout

### DIFF
--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -9,6 +9,9 @@ export * from './dropbox_types';
 export interface DropboxRequestOptions {
   /** An AbortSignal used to cancel the request. */
   signal?: AbortSignal;
+
+  /** Maximum request duration in milliseconds. */
+  timeout?: number;
 }
 
 /** Binary download content returned by the SDK in Node.js environments. */

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -21,6 +21,20 @@ const b64 = typeof btoa === 'undefined'
   : btoa;
 
 /**
+ * Returns the AbortSignal to use for a request, combining a user-provided
+ * signal with an optional timeout.
+ */
+function buildRequestSignal({ signal, timeout } = {}) {
+  if (timeout == null) {
+    return signal;
+  }
+
+  return signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(timeout)])
+    : AbortSignal.timeout(timeout);
+}
+
+/**
  * @class Dropbox
  * @classdesc The Dropbox SDK class that provides methods to read, write and
  * create files or folders in a user or team's Dropbox.
@@ -92,13 +106,10 @@ export default class Dropbox {
       .then(() => {
         const fetchOptions = {
           method: 'POST',
-          body: (body) ? JSON.stringify(body) : null,
+          body: body ? JSON.stringify(body) : null,
           headers: {},
+          signal: buildRequestSignal(options),
         };
-
-        if (options && options.signal) {
-          fetchOptions.signal = options.signal;
-        }
 
         if (body) {
           fetchOptions.headers['Content-Type'] = 'application/json';
@@ -124,11 +135,8 @@ export default class Dropbox {
           headers: {
             'Dropbox-API-Arg': httpHeaderSafeJson(args),
           },
+          signal: buildRequestSignal(options),
         };
-
-        if (options && options.signal) {
-          fetchOptions.signal = options.signal;
-        }
 
         this.setAuthHeaders(auth, fetchOptions);
         this.setCommonHeaders(fetchOptions);
@@ -161,11 +169,8 @@ export default class Dropbox {
             'Content-Type': 'application/octet-stream',
             'Dropbox-API-Arg': httpHeaderSafeJson(requestArgs),
           },
+          signal: buildRequestSignal(options),
         };
-
-        if (options && options.signal) {
-          fetchOptions.signal = options.signal;
-        }
 
         if (contents && typeof contents.pipe === 'function') {
           fetchOptions.duplex = 'half';

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -98,6 +98,57 @@ describe('Dropbox', () => {
       chai.assert.deepEqual({}, dbx.rpcRequest.getCall(0).args[1]);
     });
 
+    it('passes a timeout signal to fetch', () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({ fetch: fetchStub });
+
+      return dbx.rpcRequest(
+        'path',
+        {},
+        USER_AUTH,
+        'api',
+        { timeout: 1000 },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.instanceOf(fetchOptions.signal, AbortSignal);
+        chai.assert.isFalse(fetchOptions.signal.aborted);
+      });
+    });
+
+    it('combines a request signal with a timeout', () => {
+      const controller = new AbortController();
+
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({ fetch: fetchStub });
+
+      return dbx.rpcRequest(
+        'path',
+        {},
+        USER_AUTH,
+        'api',
+        {
+          signal: controller.signal,
+          timeout: 1000,
+        },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        controller.abort();
+        chai.assert.isTrue(fetchOptions.signal.aborted);
+      });
+    });
+
     it('passes request signal through a generated route', () => {
       const controller = new AbortController();
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,9 @@ export * from './dropbox_types';
 export interface DropboxRequestOptions {
   /** An AbortSignal used to cancel the request. */
   signal?: AbortSignal;
+
+  /** Maximum request duration in milliseconds. */
+  timeout?: number;
 }
 
 /** Binary download content returned by the SDK in Node.js environments. */


### PR DESCRIPTION
## Summary

Add support for request timeouts to the JavaScript SDK.

This change extends `DropboxRequestOptions` with an optional `timeout` field and uses the platform `AbortSignal` APIs to combine timeout-based cancellation with an optional user-provided `AbortSignal`.

Example:

```js
const controller = new AbortController();
await dbx.filesUpload(
  {
    path: '/test.txt',
    contents,
  },
  {
    signal: controller.signal,
    timeout: 30_000,
  },
);
```

Changes
* add timeout?: number to DropboxRequestOptions
* support timeout cancellation for RPC, upload, and download requests
* combine timeout and user cancellation using AbortSignal.any()
* preserve existing AbortSignal behavior