### PR TITLE
Add custom request headers and resumable concurrent downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ in both JavaScript and TypeScript, with additional Node.js OAuth examples.
 
 - **Other Examples**
     - Basic - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/basic), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/basic) ] - A simple example that takes in a token and fetches files from your Dropbox account.
+    - Backend Download - [ [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/backend-download) ] - An example showing resumable backend downloads to local storage.
     - Download - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/download), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/download) ] - An example showing how to download a shared file.
     - Team As User - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/team-as-user), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/team-as-user) ] - An example showing how to act as a user.
     - Team - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/team), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/team) ] - An example showing how to use the team functionality and list team devices.

--- a/examples/javascript/backend-download/README.md
+++ b/examples/javascript/backend-download/README.md
@@ -1,0 +1,66 @@
+# Backend Download Example
+
+This example downloads a Dropbox file to local storage from a Node.js backend.
+It uses the `downloadFile` helper, which writes to `localPath + ".part"` first,
+resumes from that partial file with range requests, validates the final size,
+verifies Dropbox `content_hash` metadata when present, and renames the partial
+file only after validation succeeds.
+
+## Run
+
+Build the SDK from the repository root first:
+
+```sh
+npm install
+npm run build
+```
+
+Then run the example:
+
+```sh
+cd examples/javascript/backend-download
+npm install
+DROPBOX_ACCESS_TOKEN=YOUR_ACCESS_TOKEN \
+DROPBOX_DOWNLOAD_PATH=/large-file.bin \
+LOCAL_DOWNLOAD_PATH=large-file.bin \
+node download_example.js
+```
+
+For fresh downloads, set `PARALLEL_DOWNLOADS` to opt in to parallel ranged
+requests:
+
+```sh
+PARALLEL_DOWNLOADS=4 node download_example.js
+```
+
+The helper retries transient failures such as network errors, `408`, `429`, and
+`5xx` responses with exponential backoff. Deterministic errors such as
+permission failures, invalid metadata, and content hash mismatches fail without
+retry. Numeric options such as `parallelDownloads`, `maxAttempts`, `retryDelay`,
+and `timeout` must be positive integers.
+
+Partial downloads are retained only while the helper is retrying internally.
+If `downloadFile()` ultimately fails, the `.part` file is removed before the
+error is returned.
+
+## Browser Range Requests
+
+The `downloadFile` helper is Node.js-only because it writes to local filesystem
+paths. In browsers, use `dbx.filesDownload({ path })` and read
+`response.result.fileBlob`; that non-range flow is the better fit for ordinary
+browser downloads.
+
+Browser applications can request a byte range when they need to assemble chunks
+themselves:
+
+```js
+const { result } = await dbx.filesDownload(
+  { path: '/large-file.bin' },
+  { extraHeaders: { Range: 'bytes=0-1048575' } },
+);
+
+const chunk = await result.fileBlob.arrayBuffer();
+```
+
+Range requests in browsers do not provide the same local `.part` file resume
+semantics as the Node.js helper.

--- a/examples/javascript/backend-download/download_example.js
+++ b/examples/javascript/backend-download/download_example.js
@@ -1,0 +1,43 @@
+// Standalone backend example for downloading a Dropbox file to local storage.
+// Build the SDK from the repository root first with `npm run build`.
+
+const { Dropbox, downloadFile } = require('dropbox'); // eslint-disable-line import/no-unresolved
+
+const {
+  DROPBOX_ACCESS_TOKEN,
+  DROPBOX_DOWNLOAD_PATH,
+  LOCAL_DOWNLOAD_PATH,
+  PARALLEL_DOWNLOADS,
+} = process.env;
+
+if (!DROPBOX_ACCESS_TOKEN) {
+  throw new Error('Set DROPBOX_ACCESS_TOKEN before running this example.');
+}
+
+if (!DROPBOX_DOWNLOAD_PATH) {
+  throw new Error('Set DROPBOX_DOWNLOAD_PATH to the Dropbox file path to download.');
+}
+
+const dbx = new Dropbox({
+  accessToken: DROPBOX_ACCESS_TOKEN,
+});
+
+const localPath = LOCAL_DOWNLOAD_PATH || DROPBOX_DOWNLOAD_PATH.split('/').pop();
+const parallelDownloads = Number(PARALLEL_DOWNLOADS || 1);
+
+downloadFile(dbx, DROPBOX_DOWNLOAD_PATH, localPath, {
+  parallelDownloads,
+  progress: ({ bytesWritten, totalBytes, resumedFrom }) => {
+    const total = totalBytes || 'unknown';
+    console.log(`${bytesWritten}/${total} bytes, resumed from ${resumedFrom}`);
+  },
+})
+  .then((result) => {
+    console.log(
+      `downloaded ${result.metadata.name} to ${localPath}, resumed from ${result.resumedFrom}`,
+    );
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/examples/javascript/backend-download/package-lock.json
+++ b/examples/javascript/backend-download/package-lock.json
@@ -1,0 +1,63 @@
+{
+  "name": "backend-download",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend-download",
+      "version": "1.0.0",
+      "dependencies": {
+        "dropbox": "file:../../../"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "../../..": {
+      "name": "dropbox",
+      "version": "10.42.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/cli": "^7.29.7",
+        "@babel/core": "^7.29.7",
+        "@babel/preset-env": "^7.29.7",
+        "@babel/register": "^7.28.6",
+        "@testing-library/dom": "^7.24.5",
+        "@types/node": "^22.20.1",
+        "@typescript-eslint/eslint-plugin": "^8.65.0",
+        "@typescript-eslint/parser": "^8.65.0",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+        "chai": "^4.2.0",
+        "chai-as-promised": "^7.1.1",
+        "cross-env": "^7.0.2",
+        "eslint": "^8.57.1",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-plugin-import": "^2.32.0",
+        "express": "^5.2.1",
+        "express-urlrewrite": "^1.3.0",
+        "gh-pages": "^3.1.0",
+        "ink-docstrap": "^1.3.2",
+        "jsdoc": "^3.6.6",
+        "jsdom": "^16.4.0",
+        "mocha": "^11.7.6",
+        "nyc": "^15.1.0",
+        "prompt": "^1.0.0",
+        "rollup": "^2.28.2",
+        "rollup-endpoint": "^0.2.2",
+        "rollup-plugin-babel": "^4.4.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "sinon": "^9.0.3",
+        "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/dropbox": {
+      "resolved": "../../..",
+      "link": true
+    }
+  }
+}

--- a/examples/javascript/backend-download/package.json
+++ b/examples/javascript/backend-download/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "backend-download",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "dropbox": "file:../../../"
+  }
+}

--- a/generator/typescript/index.d.tstemplate
+++ b/generator/typescript/index.d.tstemplate
@@ -12,6 +12,9 @@ export interface DropboxRequestOptions {
 
   /** Maximum request duration in milliseconds. */
   timeout?: number;
+
+  /** Additional HTTP headers for this request. */
+  extraHeaders?: Record<string, string>;
 }
 
 /** Binary download content returned by the SDK in Node.js environments. */
@@ -34,6 +37,59 @@ export type DropboxDownloadResult<T> = T & (
   | { fileBinary: DropboxFileBinary; fileBlob?: never }
   | { fileBinary?: never; fileBlob: DropboxFileBlob }
 );
+
+/** Progress reported by the local file download helper. */
+export interface DropboxFileDownloadProgress {
+  /** Cumulative bytes written to local storage. */
+  bytesWritten: number;
+
+  /** Expected total bytes from Dropbox metadata, when known. */
+  totalBytes: number;
+
+  /** Byte offset from an existing .part file. */
+  resumedFrom: number;
+}
+
+export interface DropboxFileDownloaderOptions {
+  /** Maximum number of download attempts. Defaults to 3. */
+  maxAttempts?: number;
+
+  /** Number of parallel ranged downloads for fresh downloads. Defaults to 1. */
+  parallelDownloads?: number;
+
+  /** Initial retry delay in milliseconds. Defaults to 500. */
+  retryDelay?: number;
+
+  /** Receives cumulative download progress updates. */
+  progress?: (progress: DropboxFileDownloadProgress) => void;
+
+  /** An AbortSignal used to cancel Dropbox requests. */
+  signal?: AbortSignal;
+
+  /** Maximum duration for each Dropbox request in milliseconds. Must be a positive integer. */
+  timeout?: number;
+}
+
+export interface DropboxFileDownloadResult {
+  /** Metadata returned by filesDownload. */
+  metadata: files.FileMetadata;
+
+  /** Byte offset used to resume from an existing .part file. */
+  resumedFrom: number;
+}
+
+export class DropboxFileDownloader {
+  constructor(client: Dropbox, options?: DropboxFileDownloaderOptions);
+
+  downloadFile(remotePath: string, localPath: string): Promise<DropboxFileDownloadResult>;
+}
+
+export function downloadFile(
+  client: Dropbox,
+  remotePath: string,
+  localPath: string,
+  options?: DropboxFileDownloaderOptions,
+): Promise<DropboxFileDownloadResult>;
 
 export interface DropboxAuthOptions {
   // An access token for making authenticated requests.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { default as Dropbox } from './src/dropbox.js';
 export { default as DropboxAuth } from './src/auth.js';
+export { DropboxFileDownloader, downloadFile } from './src/filedownload.js';
 export { DropboxResponse } from './src/response.js';
 export { DropboxResponseError } from './src/error.js';

--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -20,6 +20,12 @@ const b64 = typeof btoa === 'undefined'
   ? (str) => Buffer.from(str).toString('base64')
   : btoa;
 
+const PROTECTED_HEADERS = new Set([
+  'authorization',
+  'content-type',
+  'dropbox-api-arg',
+]);
+
 /**
  * Returns the AbortSignal to use for a request, combining a user-provided
  * signal with an optional timeout.
@@ -32,6 +38,18 @@ function buildRequestSignal({ signal, timeout } = {}) {
   return signal
     ? AbortSignal.any([signal, AbortSignal.timeout(timeout)])
     : AbortSignal.timeout(timeout);
+}
+
+function setExtraHeaders(options, fetchOptions) {
+  if (!options || !options.extraHeaders) {
+    return;
+  }
+
+  Object.entries(options.extraHeaders).forEach(([name, value]) => {
+    if (!PROTECTED_HEADERS.has(name.toLowerCase())) {
+      fetchOptions.headers[name] = value;
+    }
+  });
 }
 
 /**
@@ -111,6 +129,8 @@ export default class Dropbox {
           signal: buildRequestSignal(options),
         };
 
+        setExtraHeaders(options, fetchOptions);
+
         if (body) {
           fetchOptions.headers['Content-Type'] = 'application/json';
         }
@@ -132,11 +152,13 @@ export default class Dropbox {
       .then(() => {
         const fetchOptions = {
           method: 'POST',
-          headers: {
-            'Dropbox-API-Arg': httpHeaderSafeJson(args),
-          },
+          headers: {},
           signal: buildRequestSignal(options),
         };
+
+        setExtraHeaders(options, fetchOptions);
+
+        fetchOptions.headers['Dropbox-API-Arg'] = httpHeaderSafeJson(args);
 
         this.setAuthHeaders(auth, fetchOptions);
         this.setCommonHeaders(fetchOptions);
@@ -165,16 +187,18 @@ export default class Dropbox {
         const fetchOptions = {
           body: contents,
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/octet-stream',
-            'Dropbox-API-Arg': httpHeaderSafeJson(requestArgs),
-          },
+          headers: {},
           signal: buildRequestSignal(options),
         };
 
         if (contents && typeof contents.pipe === 'function') {
           fetchOptions.duplex = 'half';
         }
+
+        setExtraHeaders(options, fetchOptions);
+
+        fetchOptions.headers['Content-Type'] = 'application/octet-stream';
+        fetchOptions.headers['Dropbox-API-Arg'] = httpHeaderSafeJson(requestArgs);
 
         this.setAuthHeaders(auth, fetchOptions);
         this.setCommonHeaders(fetchOptions);

--- a/src/filedownload.js
+++ b/src/filedownload.js
@@ -1,0 +1,701 @@
+import { USER_AUTH } from './constants.js';
+import { DropboxResponseError } from './error.js';
+import { baseApiUrl, httpHeaderSafeJson } from './utils.js';
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY = 500;
+const RETRYABLE_5XX_STATUSES = new Set([500, 502, 503, 504]);
+const BLOCK_SIZE = 4 * 1024 * 1024;
+let nodeRuntime;
+
+function requireNodeModule(moduleName) {
+  if (typeof require === 'function') { // eslint-disable-line no-undef
+    // eslint-disable-next-line global-require, import/no-dynamic-require, no-undef
+    return Promise.resolve(require(moduleName)); // eslint-disable-line no-undef
+  }
+
+  // eslint-disable-next-line no-new-func
+  return Function('moduleName', 'return import(moduleName)')(moduleName);
+}
+
+async function computeContentHashFromFile(runtime, filePath) {
+  const { crypto, fs } = runtime;
+  const overallHasher = crypto.createHash('sha256');
+  let blockHasher = crypto.createHash('sha256');
+  let blockBytes = 0;
+
+  return new Promise((resolve, reject) => {
+    fs.createReadStream(filePath, { highWaterMark: BLOCK_SIZE })
+      .on('data', (chunk) => {
+        let offset = 0;
+        while (offset < chunk.length) {
+          const length = Math.min(BLOCK_SIZE - blockBytes, chunk.length - offset);
+          blockHasher.update(chunk.subarray(offset, offset + length));
+          blockBytes += length;
+          offset += length;
+
+          if (blockBytes === BLOCK_SIZE) {
+            overallHasher.update(blockHasher.digest());
+            blockHasher = crypto.createHash('sha256');
+            blockBytes = 0;
+          }
+        }
+      })
+      .on('error', reject)
+      .on('end', () => {
+        if (blockBytes > 0) {
+          overallHasher.update(blockHasher.digest());
+        }
+
+        resolve(overallHasher.digest('hex'));
+      });
+  });
+}
+
+async function getNodeRuntime() {
+  if (nodeRuntime) {
+    return nodeRuntime;
+  }
+
+  if (
+    typeof process === 'undefined'
+    || !process.versions
+    || !process.versions.node
+  ) {
+    throw new Error(
+      'downloadFile is only supported in Node.js. In browsers, use filesDownload() and read result.fileBlob.',
+    );
+  }
+
+  const [
+    fsModule,
+    streamModule,
+    streamPromisesModule,
+    cryptoModule,
+  ] = await Promise.all([
+    requireNodeModule('fs'),
+    requireNodeModule('stream'),
+    requireNodeModule('stream/promises'),
+    requireNodeModule('crypto'),
+  ]);
+
+  nodeRuntime = {
+    fs: fsModule.default || fsModule,
+    crypto: cryptoModule.default || cryptoModule,
+    Readable: streamModule.Readable,
+    Transform: streamModule.Transform,
+    Writable: streamModule.Writable,
+    pipeline: streamPromisesModule.pipeline,
+  };
+
+  return nodeRuntime;
+}
+
+function partFileSize(fs, partPath) {
+  try {
+    return fs.statSync(partPath).size;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return 0;
+    }
+    throw error;
+  }
+}
+
+function rangeHeader(offset, length) {
+  if (length === undefined) {
+    return `bytes=${offset}-`;
+  }
+  return `bytes=${offset}-${offset + length - 1}`;
+}
+
+function parseContentRange(header) {
+  const match = /^bytes (\d+)-(\d+)\/(\d+|\*)$/.exec(header || '');
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    start: Number(match[1]),
+    end: Number(match[2]),
+  };
+}
+
+function validateRangeResponse(res, range) {
+  if (!range) {
+    return;
+  }
+
+  if (res.status !== 206) {
+    throw new Error(`range request returned HTTP ${res.status}, expected 206`);
+  }
+
+  const contentRange = parseContentRange(res.headers.get('content-range'));
+  if (!contentRange) {
+    throw new Error('range request response missing valid Content-Range');
+  }
+
+  const expectedEnd = range.length === undefined
+    ? contentRange.end
+    : range.offset + range.length - 1;
+
+  if (
+    contentRange.start !== range.offset
+    || contentRange.end !== expectedEnd
+  ) {
+    throw new Error(
+      `range request returned Content-Range bytes ${contentRange.start}-${contentRange.end}, expected ${range.offset}-${expectedEnd}`,
+    );
+  }
+}
+
+function validatePositiveInteger(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer`);
+  }
+}
+
+function buildRequestSignal({ signal, timeout } = {}) {
+  if (timeout == null) {
+    return signal;
+  }
+
+  return signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(timeout)])
+    : AbortSignal.timeout(timeout);
+}
+
+async function throwAsResponseError(res) {
+  const data = await res.text();
+  let errorObject;
+  try {
+    errorObject = JSON.parse(data);
+  } catch {
+    errorObject = data;
+  }
+
+  throw new DropboxResponseError(res.status, res.headers, errorObject);
+}
+
+function isRetryableError(error) {
+  if (error instanceof DropboxResponseError) {
+    return (
+      error.status === 408
+      || error.status === 429
+      || RETRYABLE_5XX_STATUSES.has(error.status)
+    );
+  }
+
+  return !(
+    error.message
+    && (
+      error.message.startsWith('remote file changed')
+      || error.message.startsWith('range request')
+      || error.message.startsWith('incomplete download')
+      || error.message.startsWith('content hash mismatch')
+      || error.message === 'download response body is nil'
+      || error.message === 'downloadFile requires a Dropbox client instance'
+      || error.message.startsWith('downloadFile is only supported')
+    )
+  );
+}
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    let timeout;
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason || new Error('download aborted'));
+    };
+    const done = () => {
+      if (signal) {
+        signal.removeEventListener('abort', abort);
+      }
+      resolve();
+    };
+
+    timeout = setTimeout(done, ms);
+    if (!signal) {
+      return;
+    }
+
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
+
+function metadataSize(metadata) {
+  return metadata && typeof metadata.size === 'number' ? metadata.size : 0;
+}
+
+function metadataResult(response) {
+  return response && response.result ? response.result : response;
+}
+
+function validateRevision(expectedRev, metadata) {
+  if (!expectedRev || !metadata || !metadata.rev) {
+    return;
+  }
+  if (metadata.rev !== expectedRev) {
+    throw new Error(
+      `remote file changed during retry: got rev "${metadata.rev}", expected "${expectedRev}"`,
+    );
+  }
+}
+
+async function validatePartFile(runtime, partPath, metadata) {
+  if (!metadata) {
+    return;
+  }
+
+  const { fs } = runtime;
+  const stat = fs.statSync(partPath);
+  if (stat.size !== metadata.size) {
+    throw new Error(
+      `incomplete download: got ${stat.size} bytes, expected ${metadata.size}`,
+    );
+  }
+
+  if (!metadata.content_hash) {
+    return;
+  }
+
+  const hash = await computeContentHashFromFile(runtime, partPath);
+  if (hash !== metadata.content_hash) {
+    throw new Error(
+      `content hash mismatch: got "${hash}", expected "${metadata.content_hash}"`,
+    );
+  }
+}
+
+function withMetadata(error, metadata) {
+  error.metadata = metadata; // eslint-disable-line no-param-reassign
+  return error;
+}
+
+function progressTransform(runtime, tracker) {
+  return new runtime.Transform({
+    transform(chunk, encoding, callback) {
+      tracker.add(chunk.length);
+      callback(null, chunk);
+    },
+  });
+}
+
+function writeAtStream(runtime, fd, offset) {
+  let position = offset;
+  const { fs } = runtime;
+
+  return new runtime.Writable({
+    write(chunk, encoding, callback) {
+      const writeRemaining = (chunkOffset, remaining, targetPosition) => {
+        fs.write(
+          fd,
+          chunk,
+          chunkOffset,
+          remaining,
+          targetPosition,
+          (error, bytesWritten) => {
+            if (error) {
+              callback(error);
+              return;
+            }
+
+            if (bytesWritten === 0 && remaining > 0) {
+              callback(new Error('fs.write wrote 0 bytes'));
+              return;
+            }
+
+            if (bytesWritten < remaining) {
+              writeRemaining(
+                chunkOffset + bytesWritten,
+                remaining - bytesWritten,
+                targetPosition + bytesWritten,
+              );
+              return;
+            }
+
+            position = targetPosition + bytesWritten;
+            callback();
+          },
+        );
+      };
+
+      if (chunk.length === 0) {
+        callback();
+        return;
+      }
+
+      writeRemaining(0, chunk.length, position);
+    },
+  });
+}
+
+async function writeRangeBody(runtime, body, tracker, fd, range) {
+  let received = 0;
+  const counter = new runtime.Transform({
+    transform(chunk, encoding, callback) {
+      received += chunk.length;
+      tracker.add(chunk.length);
+      callback(null, chunk);
+    },
+  });
+
+  await runtime.pipeline(
+    body,
+    counter,
+    writeAtStream(runtime, fd, range.offset),
+  );
+
+  if (range.length !== undefined && received !== range.length) {
+    throw new Error(
+      `range request body length mismatch: received ${received} bytes, expected ${range.length}`,
+    );
+  }
+}
+
+function splitRanges(offset, length, parts) {
+  if (length <= 0) {
+    return [];
+  }
+  if (parts <= 1) {
+    return [{ offset, length }];
+  }
+
+  const actualParts = Math.min(parts, length);
+  const ranges = [];
+  const partSize = Math.floor(length / actualParts);
+  let remainder = length % actualParts;
+  let position = offset;
+
+  for (let i = 0; i < actualParts; i += 1) {
+    const size = partSize + (remainder > 0 ? 1 : 0);
+    ranges.push({ offset: position, length: size });
+    position += size;
+    remainder -= 1;
+  }
+
+  return ranges;
+}
+
+function createProgressTracker(written, total, resumedFrom, progress) {
+  return {
+    written,
+    add(bytes) {
+      if (bytes <= 0) {
+        return;
+      }
+
+      this.written += bytes;
+
+      if (!progress) {
+        return;
+      }
+
+      progress({
+        bytesWritten: this.written,
+        totalBytes: total,
+        resumedFrom,
+      });
+    },
+  };
+}
+
+export class DropboxFileDownloader {
+  constructor(client, options = {}) {
+    const maxAttempts = options.maxAttempts === undefined
+      ? DEFAULT_MAX_ATTEMPTS
+      : options.maxAttempts;
+    const parallelDownloads = options.parallelDownloads === undefined
+      ? 1
+      : options.parallelDownloads;
+    const retryDelay = options.retryDelay === undefined
+      ? DEFAULT_RETRY_DELAY
+      : options.retryDelay;
+
+    validatePositiveInteger('maxAttempts', maxAttempts);
+    validatePositiveInteger('parallelDownloads', parallelDownloads);
+    validatePositiveInteger('retryDelay', retryDelay);
+    if (options.timeout !== undefined) {
+      validatePositiveInteger('timeout', options.timeout);
+    }
+
+    this.client = client;
+    this.maxAttempts = maxAttempts;
+    this.parallelDownloads = parallelDownloads;
+    this.retryDelay = retryDelay;
+    this.delay = options.delay || delay;
+    this.progress = options.progress;
+    this.signal = options.signal;
+    this.timeout = options.timeout;
+  }
+
+  async rawDownload(remotePath, range, signal = this.signal) {
+    if (!this.client.auth || !this.client.fetch) {
+      throw new Error('downloadFile requires a Dropbox client instance');
+    }
+
+    await this.client.auth.checkAndRefreshAccessToken();
+
+    const fetchOptions = {
+      method: 'POST',
+      headers: {
+        'Dropbox-API-Arg': httpHeaderSafeJson({ path: remotePath }),
+      },
+      signal: buildRequestSignal({
+        signal,
+        timeout: this.timeout,
+      }),
+    };
+
+    if (range) {
+      fetchOptions.headers.Range = rangeHeader(range.offset, range.length);
+    }
+
+    this.client.setAuthHeaders(USER_AUTH, fetchOptions);
+    this.client.setCommonHeaders(fetchOptions);
+
+    const res = await this.client.fetch(
+      `${baseApiUrl(
+        'content',
+        this.client.domain,
+        this.client.domainDelimiter,
+      )}files/download`,
+      fetchOptions,
+    );
+
+    if (!res.ok) {
+      await throwAsResponseError(res);
+    }
+
+    validateRangeResponse(res, range);
+
+    if (!res.body) {
+      throw new Error('download response body is nil');
+    }
+
+    return {
+      metadata: JSON.parse(res.headers.get('dropbox-api-result')),
+      body: (await getNodeRuntime()).Readable.fromWeb(res.body),
+    };
+  }
+
+  async fetchMetadata(remotePath) {
+    if (typeof this.client.filesGetMetadata !== 'function') {
+      throw new Error('downloadFile requires a Dropbox client instance');
+    }
+
+    const response = await this.client.filesGetMetadata(
+      { path: remotePath },
+      {
+        signal: this.signal,
+        timeout: this.timeout,
+      },
+    );
+
+    return metadataResult(response);
+  }
+
+  async downloadFileAttempt(remotePath, localPath, expectedRev) {
+    const runtime = await getNodeRuntime();
+    const { fs, pipeline } = runtime;
+    const partPath = `${localPath}.part`;
+    const offset = partFileSize(fs, partPath);
+
+    if (offset === 0 && this.parallelDownloads > 1) {
+      return this.downloadFileParallel(remotePath, localPath, partPath, expectedRev);
+    }
+
+    const response = await this.rawDownload(
+      remotePath,
+      offset > 0 ? { offset } : undefined,
+    );
+    const { metadata } = response;
+    try {
+      validateRevision(expectedRev, metadata);
+    } catch (error) {
+      fs.rmSync(partPath, { force: true });
+      throw withMetadata(error, metadata);
+    }
+
+    const tracker = createProgressTracker(
+      offset,
+      metadataSize(metadata),
+      offset,
+      this.progress,
+    );
+
+    try {
+      await pipeline(
+        response.body,
+        progressTransform(runtime, tracker),
+        fs.createWriteStream(partPath, { flags: offset > 0 ? 'a' : 'w' }),
+      );
+    } catch (error) {
+      throw withMetadata(error, metadata);
+    }
+
+    try {
+      await validatePartFile(runtime, partPath, metadata);
+      fs.renameSync(partPath, localPath);
+    } catch (error) {
+      fs.rmSync(partPath, { force: true });
+      throw withMetadata(error, metadata);
+    }
+
+    return {
+      metadata,
+      resumedFrom: offset,
+    };
+  }
+
+  async downloadFileParallel(remotePath, localPath, partPath, expectedRev) {
+    const runtime = await getNodeRuntime();
+    const { fs } = runtime;
+    const metadata = await this.fetchMetadata(remotePath);
+    try {
+      validateRevision(expectedRev, metadata);
+    } catch (error) {
+      fs.rmSync(partPath, { force: true });
+      throw withMetadata(error, metadata);
+    }
+
+    const total = metadataSize(metadata);
+    const tracker = createProgressTracker(0, total, 0, this.progress);
+
+    fs.writeFileSync(partPath, Buffer.alloc(0));
+    fs.truncateSync(partPath, total);
+
+    if (total > 0) {
+      const fd = fs.openSync(partPath, 'r+');
+      try {
+        const ranges = splitRanges(
+          0,
+          total,
+          this.parallelDownloads,
+        );
+
+        const controller = new AbortController();
+        const signal = this.signal
+          ? AbortSignal.any([
+            this.signal,
+            controller.signal,
+          ])
+          : controller.signal;
+
+        let firstError;
+        const workers = ranges.map(async (range) => {
+          try {
+            const result = await this.rawDownload(
+              remotePath,
+              range,
+              signal,
+            );
+
+            validateRevision(metadata.rev, result.metadata);
+            await writeRangeBody(
+              runtime,
+              result.body,
+              tracker,
+              fd,
+              range,
+            );
+          } catch (error) {
+            if (!firstError) {
+              firstError = error;
+              controller.abort(error);
+            }
+            throw error;
+          }
+        });
+
+        await Promise.allSettled(workers);
+
+        if (firstError) {
+          throw firstError;
+        }
+      } catch (error) {
+        fs.closeSync(fd);
+        fs.rmSync(partPath, { force: true });
+        throw withMetadata(error, metadata);
+      }
+      fs.closeSync(fd);
+    }
+
+    try {
+      await validatePartFile(runtime, partPath, metadata);
+      fs.renameSync(partPath, localPath);
+    } catch (error) {
+      fs.rmSync(partPath, { force: true });
+      throw withMetadata(error, metadata);
+    }
+
+    return {
+      metadata,
+      resumedFrom: 0,
+    };
+  }
+
+  async downloadFile(remotePath, localPath) {
+    const runtime = await getNodeRuntime();
+    const partPath = `${localPath}.part`;
+    let lastError;
+    let expectedRev = '';
+
+    try {
+      /* eslint-disable no-await-in-loop */
+      for (let attempt = 0; attempt < this.maxAttempts; attempt += 1) {
+        try {
+          return await this.downloadFileAttempt(
+            remotePath,
+            localPath,
+            expectedRev,
+          );
+        } catch (error) {
+          if (!expectedRev && error.metadata && error.metadata.rev) {
+            expectedRev = error.metadata.rev;
+          }
+
+          if (this.signal && this.signal.aborted) {
+            throw this.signal.reason || error;
+          }
+
+          if (!isRetryableError(error)) {
+            throw error;
+          }
+
+          lastError = error;
+
+          if (attempt < this.maxAttempts - 1) {
+            await this.delay(
+              this.retryDelay * (2 ** attempt),
+              this.signal,
+            );
+          }
+        }
+      }
+      /* eslint-enable no-await-in-loop */
+
+      throw lastError;
+    } catch (error) {
+      try {
+        runtime.fs.rmSync(partPath, { force: true });
+      } catch (cleanupError) {
+        if (error && typeof error === 'object') {
+          error.cleanupError = cleanupError;
+        }
+      }
+      throw error;
+    }
+  }
+}
+
+export function downloadFile(client, remotePath, localPath, options = {}) {
+  return new DropboxFileDownloader(client, options)
+    .downloadFile(remotePath, localPath);
+}

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -1,10 +1,11 @@
 import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
 import { Readable } from 'stream';
 
 import chai from 'chai';
 
-import { Dropbox, DropboxAuth } from '../../index.js';
+import { Dropbox, DropboxAuth, downloadFile } from '../../index.js';
 import { DropboxResponse } from '../../src/response.js';
 import { DropboxResponseError } from '../../src/error.js';
 
@@ -72,6 +73,56 @@ for (const appType in appInfo) {
               done();
             })
             .catch(done);
+        });
+
+        it('downloadFile helper resumes a live file from a part file', (done) => {
+          const prefix = 'already downloaded ';
+          const suffix = 'and resumed with a range request\n';
+          const contents = prefix + suffix;
+          const uploadPath = `/dropbox-sdk-js-download-helper-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`;
+          const localDirPromise = fs.mkdtemp(path.join(os.tmpdir(), 'dropbox-sdk-js-download-helper-'));
+          let uploaded = false;
+          let localDir;
+          let localPath;
+          let testError;
+
+          const cleanup = () => Promise.all([
+            uploaded ? dbx.filesDeleteV2({ path: uploadPath }) : Promise.resolve(),
+            localDir ? fs.rm(localDir, { recursive: true, force: true }) : Promise.resolve(),
+          ]);
+
+          localDirPromise
+            .then((dir) => {
+              localDir = dir;
+              localPath = path.join(localDir, 'download.txt');
+              return dbx.filesUpload({ path: uploadPath, contents });
+            })
+            .then(() => {
+              uploaded = true;
+              return fs.writeFile(`${localPath}.part`, prefix);
+            })
+            .then(() => downloadFile(dbx, uploadPath, localPath, {
+              progress: ({ bytesWritten, totalBytes, resumedFrom }) => {
+                chai.assert.isAtLeast(bytesWritten, prefix.length);
+                chai.assert.equal(totalBytes, contents.length);
+                chai.assert.equal(resumedFrom, prefix.length);
+              },
+            }))
+            .then((result) => {
+              chai.assert.equal(result.resumedFrom, prefix.length);
+              chai.assert.equal(result.metadata.path_display, uploadPath);
+              chai.assert.equal(result.metadata.size, contents.length);
+              return fs.readFile(localPath, 'utf8');
+            })
+            .then((downloaded) => {
+              chai.assert.equal(downloaded, contents);
+            })
+            .catch((error) => {
+              testError = error;
+            })
+            .then(cleanup)
+            .then(() => done(testError))
+            .catch((cleanupError) => done(testError || cleanupError));
         });
       });
 

--- a/test/types/types_test.js
+++ b/test/types/types_test.js
@@ -99,3 +99,18 @@ dropbox.sharingGetSharedLinkFile({ url: 'https://www.dropbox.com/example' })
         fileBlob.text();
     }
 });
+var fileDownloader = new Dropbox.DropboxFileDownloader(dropbox, {
+    maxAttempts: 2,
+    parallelDownloads: 4,
+    retryDelay: 1000,
+    progress: function (progress) {
+        var bytesWritten = progress.bytesWritten, totalBytes = progress.totalBytes, resumedFrom = progress.resumedFrom;
+    },
+});
+fileDownloader.downloadFile('/test.txt', '/tmp/test.txt')
+    .then(function (result) {
+    var metadata = result.metadata, resumedFrom = result.resumedFrom;
+});
+Dropbox.downloadFile(dropbox, '/test.txt', '/tmp/test.txt', {
+    timeout: 1000,
+});

--- a/test/types/types_test.ts
+++ b/test/types/types_test.ts
@@ -116,3 +116,28 @@ dropbox.sharingGetSharedLinkFile({ url: 'https://www.dropbox.com/example' })
       fileBlob.text();
     }
   });
+
+const fileDownloader = new Dropbox.DropboxFileDownloader(dropbox, {
+  maxAttempts: 2,
+  parallelDownloads: 4,
+  retryDelay: 1000,
+  progress: (progress: Dropbox.DropboxFileDownloadProgress) => {
+    const {
+      bytesWritten,
+      totalBytes,
+      resumedFrom,
+    }: Dropbox.DropboxFileDownloadProgress = progress;
+  },
+});
+
+fileDownloader.downloadFile('/test.txt', '/tmp/test.txt')
+  .then((result: Dropbox.DropboxFileDownloadResult) => {
+    const {
+      metadata,
+      resumedFrom,
+    }: Dropbox.DropboxFileDownloadResult = result;
+  });
+
+Dropbox.downloadFile(dropbox, '/test.txt', '/tmp/test.txt', {
+  timeout: 1000,
+});

--- a/test/unit/dropbox.js
+++ b/test/unit/dropbox.js
@@ -149,6 +149,50 @@ describe('Dropbox', () => {
       });
     });
 
+    it('adds per-request headers to RPC requests', () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => 'application/json',
+        },
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      return dbx.rpcRequest(
+        'path',
+        { value: true },
+        USER_AUTH,
+        'api',
+        {
+          extraHeaders: {
+            'X-Test-Header': 'test-value',
+            'Content-Type': 'incorrect',
+            'content-type': 'incorrect-lowercase',
+          },
+        },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+
+        chai.assert.strictEqual(
+          fetchOptions.headers['X-Test-Header'],
+          'test-value',
+        );
+
+        chai.assert.strictEqual(
+          fetchOptions.headers['Content-Type'],
+          'application/json',
+        );
+
+        chai.assert.isUndefined(fetchOptions.headers['content-type']);
+      });
+    });
+
     it('passes request signal through a generated route', () => {
       const controller = new AbortController();
 
@@ -222,6 +266,60 @@ describe('Dropbox', () => {
           fetchStub.firstCall.args[1].headers['Dropbox-API-Arg'],
         );
         chai.assert.notProperty(requestArgs, 'content_hash');
+      });
+    });
+
+    it('adds per-request headers to upload requests', () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: {
+          get: () => 'application/json',
+        },
+        text: () => Promise.resolve('{}'),
+      });
+
+      const dbx = new Dropbox({
+        accessToken: 'token',
+        fetch: fetchStub,
+        autoContentHash: false,
+      });
+
+      return dbx.uploadRequest(
+        'path',
+        {
+          contents: Buffer.from('test'),
+        },
+        USER_AUTH,
+        'content',
+        {
+          extraHeaders: {
+            'X-Test-Header': 'test-value',
+            'Content-Type': 'incorrect',
+            'content-type': 'incorrect-lowercase',
+            'Dropbox-API-Arg': 'incorrect',
+            'dropbox-api-arg': 'incorrect-lowercase',
+          },
+        },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(
+          fetchOptions.headers['X-Test-Header'],
+          'test-value',
+        );
+
+        chai.assert.strictEqual(
+          fetchOptions.headers['Content-Type'],
+          'application/octet-stream',
+        );
+
+        chai.assert.notEqual(
+          fetchOptions.headers['Dropbox-API-Arg'],
+          'incorrect',
+        );
+
+        chai.assert.isUndefined(fetchOptions.headers['content-type']);
+        chai.assert.isUndefined(fetchOptions.headers['dropbox-api-arg']);
       });
     });
 
@@ -461,6 +559,59 @@ describe('Dropbox', () => {
       chai.assert.isTrue(downloadSpy.calledOnce);
       chai.assert.equal('path', dbx.downloadRequest.getCall(0).args[0]);
       chai.assert.deepEqual({}, dbx.downloadRequest.getCall(0).args[1]);
+    });
+
+    it('adds per-request headers to download requests', () => {
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        headers: {
+          get: (name) => (
+            name === 'dropbox-api-result' ? '{}' : null
+          ),
+        },
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      });
+
+      const dbx = new Dropbox({
+        accessToken: 'token',
+        fetch: fetchStub,
+      });
+
+      return dbx.downloadRequest(
+        'path',
+        { path: '/test.txt' },
+        USER_AUTH,
+        'content',
+        {
+          extraHeaders: {
+            Range: 'bytes=0-99',
+            Authorization: 'incorrect',
+            authorization: 'incorrect-lowercase',
+            'Dropbox-API-Arg': 'incorrect',
+            'dropbox-api-arg': 'incorrect-lowercase',
+          },
+        },
+      ).then(() => {
+        const fetchOptions = fetchStub.firstCall.args[1];
+        chai.assert.strictEqual(
+          fetchOptions.headers.Range,
+          'bytes=0-99',
+        );
+
+        chai.assert.strictEqual(
+          fetchOptions.headers.Authorization,
+          'Bearer token',
+        );
+
+        chai.assert.notEqual(
+          fetchOptions.headers['Dropbox-API-Arg'],
+          'incorrect',
+        );
+
+        chai.assert.isUndefined(fetchOptions.headers.authorization);
+        chai.assert.isUndefined(fetchOptions.headers['dropbox-api-arg']);
+      });
     });
 
     it('passes request signal to download fetch', () => {

--- a/test/unit/filedownload.js
+++ b/test/unit/filedownload.js
@@ -1,0 +1,683 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Readable } from 'stream';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  DropboxFileDownloader,
+  downloadFile,
+} from '../../src/filedownload.js';
+import { contentHash } from '../../src/content-hasher.js';
+import { DropboxResponseError } from '../../src/error.js';
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dropbox-filedownload-'));
+}
+
+function parseRange(header) {
+  if (!header) {
+    return null;
+  }
+
+  const match = /^bytes=(\d+)-(\d+)?$/.exec(header);
+  const start = Number(match[1]);
+  const end = match[2] === undefined ? null : Number(match[2]);
+
+  return { start, end };
+}
+
+function contentRangeHeader(header, dataLength, totalSize) {
+  const range = parseRange(header);
+  if (!range) {
+    return null;
+  }
+
+  const end = range.end === null
+    ? range.start + dataLength - 1
+    : range.end;
+
+  return `bytes ${range.start}-${end}/${totalSize}`;
+}
+
+function downloadResponse(data, metadata = {}, range = null) {
+  const body = typeof data === 'string' ? Buffer.from(data) : data;
+  const fullMetadata = {
+    name: 'file.bin',
+    rev: 'rev1',
+    size: body.length,
+    ...metadata,
+  };
+  const headers = {
+    'dropbox-api-result': JSON.stringify(fullMetadata),
+  };
+  if (range) {
+    headers['content-range'] = contentRangeHeader(
+      range,
+      body.length,
+      fullMetadata.size,
+    );
+  }
+
+  return Promise.resolve(new Response(body, {
+    status: range ? 206 : 200,
+    headers,
+  }));
+}
+
+function failingResponse(data, error) {
+  const metadata = {
+    name: 'file.bin',
+    rev: 'rev1',
+    size: 11,
+  };
+  let sent = false;
+  const stream = new Readable({
+    read() {
+      if (!sent) {
+        sent = true;
+        this.push(Buffer.from(data));
+        setTimeout(() => this.destroy(error), 10);
+      }
+    },
+  });
+
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    headers: {
+      get(header) {
+        return header === 'dropbox-api-result'
+          ? JSON.stringify(metadata)
+          : null;
+      },
+    },
+    body: Readable.toWeb(stream),
+  });
+}
+
+function client(fetch) {
+  return {
+    auth: {
+      checkAndRefreshAccessToken: sinon.stub().resolves(),
+      getAccessToken: () => 'token',
+    },
+    fetch,
+    setAuthHeaders(auth, fetchOptions) {
+      fetchOptions.headers.Authorization = 'Bearer token';
+    },
+    setCommonHeaders() {},
+  };
+}
+
+function fetchRange(options) {
+  return options && options.headers && options.headers.Range;
+}
+
+function rangedDownloadResponse(data, metadata, options) {
+  return downloadResponse(data, metadata, fetchRange(options));
+}
+
+function metadataResponse(metadata = {}) {
+  return Promise.resolve({
+    result: {
+      name: 'file.bin',
+      rev: 'rev1',
+      size: 0,
+      ...metadata,
+    },
+  });
+}
+
+describe('DropboxFileDownloader', () => {
+  it('rejects invalid numeric options', () => {
+    const dbx = client(sinon.stub());
+
+    [
+      { maxAttempts: 0 },
+      { maxAttempts: 2.5 },
+      { maxAttempts: Infinity },
+      { maxAttempts: '2' },
+      { parallelDownloads: 0 },
+      { parallelDownloads: 2.5 },
+      { parallelDownloads: Infinity },
+      { parallelDownloads: '2' },
+      { retryDelay: 0 },
+      { retryDelay: 1.5 },
+      { retryDelay: Infinity },
+      { retryDelay: '1' },
+      { timeout: 0 },
+      { timeout: 1.5 },
+      { timeout: Infinity },
+      { timeout: '1' },
+    ].forEach((options) => {
+      expect(() => new DropboxFileDownloader(dbx, options)).to.throw(
+        'must be a positive integer',
+      );
+    });
+  });
+
+  it('downloads a fresh file through the convenience helper', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub().returns(downloadResponse('hello'));
+    const dbx = client(fetch);
+
+    const result = await downloadFile(dbx, '/file.bin', localPath);
+
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello');
+    expect(result.resumedFrom).to.equal(0);
+    expect(fetchRange(fetch.firstCall.args[1])).to.equal(undefined);
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+  });
+
+  it('resumes from an existing part file with a range request', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    fs.writeFileSync(`${localPath}.part`, 'hello ');
+
+    const fetch = sinon.stub().callsFake((url, options) => (
+      rangedDownloadResponse('world', { size: 11 }, options)
+    ));
+    const dbx = client(fetch);
+
+    const result = await new DropboxFileDownloader(dbx)
+      .downloadFile('/file.bin', localPath);
+
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello world');
+    expect(result.resumedFrom).to.equal(6);
+    expect(fetchRange(fetch.firstCall.args[1])).to.equal('bytes=6-');
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+  });
+
+  it('retries failed body reads and resumes from the part file', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub();
+    fetch.onFirstCall().returns(failingResponse('hello ', new Error('connection reset')));
+    fetch.onSecondCall().callsFake((url, options) => (
+      rangedDownloadResponse('world', { size: 11 }, options)
+    ));
+    const delays = [];
+    const dbx = client(fetch);
+
+    const result = await new DropboxFileDownloader(dbx, {
+      delay: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    }).downloadFile('/file.bin', localPath);
+
+    expect(fetch.callCount).to.equal(2);
+    expect(delays).to.deep.equal([500]);
+    expect(fetchRange(fetch.secondCall.args[1])).to.equal('bytes=6-');
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello world');
+    expect(result.resumedFrom).to.equal(6);
+  });
+
+  it('retries transient Dropbox responses with exponential backoff', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub();
+    fetch.onFirstCall().rejects(new DropboxResponseError(429, {}, 'rate limit'));
+    fetch.onSecondCall().rejects(new DropboxResponseError(503, {}, 'unavailable'));
+    fetch.onThirdCall().returns(downloadResponse('hello'));
+    const delays = [];
+
+    await new DropboxFileDownloader(client(fetch), {
+      retryDelay: 10,
+      delay: (ms) => {
+        delays.push(ms);
+        return Promise.resolve();
+      },
+    }).downloadFile('/file.bin', localPath);
+
+    expect(fetch.callCount).to.equal(3);
+    expect(delays).to.deep.equal([10, 20]);
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello');
+  });
+
+  it('aborts during retry backoff without waiting for the delay', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub().rejects(
+      new DropboxResponseError(503, {}, 'unavailable'),
+    );
+    const controller = new AbortController();
+    const abortReason = new Error('cancelled during backoff');
+    const started = Date.now();
+    const download = new DropboxFileDownloader(client(fetch), {
+      maxAttempts: 2,
+      retryDelay: 60000,
+      signal: controller.signal,
+    }).downloadFile('/file.bin', localPath);
+
+    setTimeout(() => controller.abort(abortReason), 0);
+
+    try {
+      await download;
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error).to.equal(abortReason);
+    }
+
+    expect(Date.now() - started).to.be.lessThan(1000);
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('does not retry deterministic Dropbox responses', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub().rejects(
+      new DropboxResponseError(403, {}, 'forbidden'),
+    );
+
+    try {
+      await new DropboxFileDownloader(client(fetch))
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(DropboxResponseError);
+      expect(error.status).to.equal(403);
+    }
+
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('does not retry non-transient server responses', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub().rejects(
+      new DropboxResponseError(501, {}, 'not implemented'),
+    );
+
+    try {
+      await new DropboxFileDownloader(client(fetch))
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error).to.be.instanceOf(DropboxResponseError);
+      expect(error.status).to.equal(501);
+    }
+
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('rejects resumed downloads when the server ignores Range', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    fs.writeFileSync(`${localPath}.part`, 'hello ');
+    const dbx = client(sinon.stub().returns(downloadResponse('hello world', {
+      size: 11,
+    })));
+
+    try {
+      await new DropboxFileDownloader(dbx, { maxAttempts: 1 })
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('expected 206');
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+    expect(fs.existsSync(localPath)).to.equal(false);
+  });
+
+  it('validates the final size and removes invalid part files', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const dbx = client(sinon.stub().returns(downloadResponse('short', { size: 10 })));
+
+    try {
+      await new DropboxFileDownloader(dbx, { maxAttempts: 1 })
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('incomplete download');
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+    expect(fs.existsSync(localPath)).to.equal(false);
+  });
+
+  it('validates Dropbox content_hash metadata', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const dbx = client(sinon.stub().returns(downloadResponse('hello', {
+      content_hash: contentHash(Buffer.from('different')),
+    })));
+
+    try {
+      await new DropboxFileDownloader(dbx, { maxAttempts: 1 })
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('content hash mismatch');
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+  });
+
+  it('validates Dropbox content_hash without reading the whole file into memory', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'hello world';
+    const dbx = client(sinon.stub().returns(downloadResponse(payload, {
+      content_hash: contentHash(Buffer.from(payload)),
+    })));
+    const readFileSync = sinon.stub(fs, 'readFileSync').throws(
+      new Error('unexpected whole-file read'),
+    );
+
+    try {
+      await new DropboxFileDownloader(dbx)
+        .downloadFile('/file.bin', localPath);
+    } finally {
+      readFileSync.restore();
+    }
+
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal(payload);
+  });
+
+  it('does not retry content hash mismatches', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub().returns(downloadResponse('hello', {
+      content_hash: contentHash(Buffer.from('different')),
+    }));
+
+    try {
+      await new DropboxFileDownloader(client(fetch))
+        .downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('content hash mismatch');
+    }
+
+    expect(fetch.callCount).to.equal(1);
+  });
+
+  it('reports cumulative progress', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const updates = [];
+    const dbx = client(sinon.stub().returns(downloadResponse('hello')));
+
+    await new DropboxFileDownloader(dbx, {
+      progress: (progress) => updates.push(progress),
+    }).downloadFile('/file.bin', localPath);
+
+    expect(updates).to.deep.equal([{
+      bytesWritten: 5,
+      totalBytes: 5,
+      resumedFrom: 0,
+    }]);
+  });
+
+  it('uses ranged requests for parallel fresh downloads', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'hello world';
+    const fetch = sinon.stub().callsFake((url, options) => {
+      const header = fetchRange(options);
+      const match = /^bytes=(\d+)-(\d+)$/.exec(header);
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+
+      return rangedDownloadResponse(payload.slice(start, end + 1), {
+        size: payload.length,
+        content_hash: contentHash(Buffer.from(payload)),
+      }, options);
+    });
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub().returns(metadataResponse({
+      size: payload.length,
+      content_hash: contentHash(Buffer.from(payload)),
+    }));
+
+    await new DropboxFileDownloader(dbx, { parallelDownloads: 3 })
+      .downloadFile('/file.bin', localPath);
+
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal(payload);
+    expect(dbx.filesGetMetadata.calledOnceWith(
+      { path: '/file.bin' },
+      { signal: undefined, timeout: undefined },
+    )).to.equal(true);
+    expect(fetch.getCalls().map((call) => fetchRange(call.args[1])).sort())
+      .to.deep.equal([
+        'bytes=0-3',
+        'bytes=4-7',
+        'bytes=8-10',
+      ]);
+  });
+
+  it('downloads an empty file in parallel mode without a range request', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub();
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub().returns(metadataResponse({
+      size: 0,
+      content_hash: contentHash(Buffer.alloc(0)),
+    }));
+
+    const result = await new DropboxFileDownloader(dbx, { parallelDownloads: 2 })
+      .downloadFile('/file.bin', localPath);
+
+    expect(fs.existsSync(localPath)).to.equal(true);
+    expect(fs.readFileSync(localPath)).to.have.length(0);
+    expect(fetch.callCount).to.equal(0);
+    expect(result.metadata.size).to.equal(0);
+  });
+
+  it('rejects a parallel range body that ends before the advertised length', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'hello world';
+    const fetch = sinon.stub().callsFake((url, options) => {
+      const header = fetchRange(options);
+      const match = /^bytes=(\d+)-(\d+)$/.exec(header);
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+
+      const shouldTruncate = header === 'bytes=4-7';
+      const data = shouldTruncate
+        ? payload.slice(start, end)
+        : payload.slice(start, end + 1);
+
+      return rangedDownloadResponse(data, {
+        size: payload.length,
+      }, options);
+    });
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub().returns(metadataResponse({
+      size: payload.length,
+    }));
+
+    try {
+      await new DropboxFileDownloader(dbx, {
+        maxAttempts: 1,
+        parallelDownloads: 3,
+      }).downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain(
+        'range request body length mismatch: received 3 bytes, expected 4',
+      );
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+    expect(fs.existsSync(localPath)).to.equal(false);
+  });
+
+  it('pins parallel retries to the first response revision', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'hello world';
+    const fetch = sinon.stub().callsFake((url, options) => {
+      const header = fetchRange(options);
+      if (fetch.callCount === 1) {
+        return rangedDownloadResponse(payload.slice(0, 1), {
+          rev: 'rev1',
+          size: payload.length,
+          content_hash: contentHash(Buffer.from(payload)),
+        }, options);
+      }
+      if (fetch.callCount <= 4) {
+        throw new DropboxResponseError(503, {}, 'unavailable');
+      }
+      if (header === 'bytes=0-0') {
+        return rangedDownloadResponse(payload.slice(0, 1), {
+          rev: 'rev2',
+          size: payload.length,
+          content_hash: contentHash(Buffer.from(payload)),
+        }, options);
+      }
+      throw new Error(`unexpected range ${header}`);
+    });
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub();
+    dbx.filesGetMetadata.onFirstCall().returns(metadataResponse({
+      rev: 'rev1',
+      size: payload.length,
+      content_hash: contentHash(Buffer.from(payload)),
+    }));
+    dbx.filesGetMetadata.onSecondCall().returns(metadataResponse({
+      rev: 'rev2',
+      size: payload.length,
+      content_hash: contentHash(Buffer.from(payload)),
+    }));
+
+    try {
+      await new DropboxFileDownloader(dbx, {
+        parallelDownloads: 3,
+        delay: () => Promise.resolve(),
+      }).downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain(
+        'remote file changed during retry: got rev "rev2", expected "rev1"',
+      );
+    }
+
+    expect(fetch.getCalls().map((call) => fetchRange(call.args[1])))
+      .to.deep.equal([
+        'bytes=0-3',
+        'bytes=4-7',
+        'bytes=8-10',
+      ]);
+    expect(dbx.filesGetMetadata.callCount).to.equal(2);
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+    expect(fs.existsSync(localPath)).to.equal(false);
+  });
+
+  it('removes the part file when a parallel range is ignored', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'hello world';
+    const fetch = sinon.stub().callsFake((url, options) => {
+      const header = fetchRange(options);
+
+      if (header === 'bytes=0-0') {
+        return rangedDownloadResponse(payload.slice(0, 1), {
+          size: payload.length,
+          content_hash: contentHash(Buffer.from(payload)),
+        }, options);
+      }
+
+      return downloadResponse(payload, {
+        size: payload.length,
+        content_hash: contentHash(Buffer.from(payload)),
+      });
+    });
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub().returns(metadataResponse({
+      size: payload.length,
+      content_hash: contentHash(Buffer.from(payload)),
+    }));
+
+    try {
+      await new DropboxFileDownloader(dbx, {
+        maxAttempts: 1,
+        parallelDownloads: 3,
+      }).downloadFile('/file.bin', localPath);
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('expected 206');
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+    expect(fs.existsSync(localPath)).to.equal(false);
+  });
+
+  it('handles partial fs.write completions during parallel downloads', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const payload = 'partial writes still produce the complete file';
+    const fetch = sinon.stub().callsFake((url, options) => {
+      const header = fetchRange(options);
+      const match = /^bytes=(\d+)-(\d+)$/.exec(header);
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+
+      return rangedDownloadResponse(payload.slice(start, end + 1), {
+        size: payload.length,
+        content_hash: contentHash(Buffer.from(payload)),
+      }, options);
+    });
+    const write = fs.write.bind(fs);
+    const writeStub = sinon.stub(fs, 'write').callsFake((
+      fd,
+      buffer,
+      offset,
+      length,
+      position,
+      callback,
+    ) => write(
+      fd,
+      buffer,
+      offset,
+      Math.max(1, Math.ceil(length / 2)),
+      position,
+      callback,
+    ));
+    const dbx = client(fetch);
+    dbx.filesGetMetadata = sinon.stub().returns(metadataResponse({
+      size: payload.length,
+      content_hash: contentHash(Buffer.from(payload)),
+    }));
+
+    try {
+      await new DropboxFileDownloader(dbx, { parallelDownloads: 4 })
+        .downloadFile('/file.bin', localPath);
+    } finally {
+      writeStub.restore();
+    }
+
+    expect(fs.readFileSync(localPath, 'utf8')).to.equal(payload);
+    expect(writeStub.callCount).to.be.greaterThan(fetch.callCount);
+  });
+
+  it('removes the part file when the remote revision changes', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    fs.writeFileSync(`${localPath}.part`, 'hello ');
+    const dbx = client(sinon.stub().callsFake((url, options) => (
+      rangedDownloadResponse('world', {
+        rev: 'rev2',
+        size: 11,
+      }, options)
+    )));
+
+    try {
+      await new DropboxFileDownloader(dbx)
+        .downloadFileAttempt('/file.bin', localPath, 'rev1');
+      throw new Error('expected download to fail');
+    } catch (error) {
+      expect(error.message).to.contain('remote file changed');
+    }
+
+    expect(fs.existsSync(`${localPath}.part`)).to.equal(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,9 @@ export interface DropboxRequestOptions {
 
   /** Maximum request duration in milliseconds. */
   timeout?: number;
+
+  /** Additional HTTP headers for this request. */
+  extraHeaders?: Record<string, string>;
 }
 
 /** Binary download content returned by the SDK in Node.js environments. */
@@ -35,6 +38,59 @@ export type DropboxDownloadResult<T> = T & (
   | { fileBinary: DropboxFileBinary; fileBlob?: never }
   | { fileBinary?: never; fileBlob: DropboxFileBlob }
 );
+
+/** Progress reported by the local file download helper. */
+export interface DropboxFileDownloadProgress {
+  /** Cumulative bytes written to local storage. */
+  bytesWritten: number;
+
+  /** Expected total bytes from Dropbox metadata, when known. */
+  totalBytes: number;
+
+  /** Byte offset from an existing .part file. */
+  resumedFrom: number;
+}
+
+export interface DropboxFileDownloaderOptions {
+  /** Maximum number of download attempts. Defaults to 3. */
+  maxAttempts?: number;
+
+  /** Number of parallel ranged downloads for fresh downloads. Defaults to 1. */
+  parallelDownloads?: number;
+
+  /** Initial retry delay in milliseconds. Defaults to 500. */
+  retryDelay?: number;
+
+  /** Receives cumulative download progress updates. */
+  progress?: (progress: DropboxFileDownloadProgress) => void;
+
+  /** An AbortSignal used to cancel Dropbox requests. */
+  signal?: AbortSignal;
+
+  /** Maximum duration for each Dropbox request in milliseconds. Must be a positive integer. */
+  timeout?: number;
+}
+
+export interface DropboxFileDownloadResult {
+  /** Metadata returned by filesDownload. */
+  metadata: files.FileMetadata;
+
+  /** Byte offset used to resume from an existing .part file. */
+  resumedFrom: number;
+}
+
+export class DropboxFileDownloader {
+  constructor(client: Dropbox, options?: DropboxFileDownloaderOptions);
+
+  downloadFile(remotePath: string, localPath: string): Promise<DropboxFileDownloadResult>;
+}
+
+export function downloadFile(
+  client: Dropbox,
+  remotePath: string,
+  localPath: string,
+  options?: DropboxFileDownloaderOptions,
+): Promise<DropboxFileDownloadResult>;
 
 export interface DropboxAuthOptions {
   // An access token for making authenticated requests.


### PR DESCRIPTION
### Summary

This PR adds support for per-request HTTP headers and introduces a Node.js helper for reliable file downloads.

The new extraHeaders option allows callers to provide headers such as Range on individual SDK requests while preventing overrides of SDK-managed headers.

It also adds a public downloadFile helper for Node.js that supports resumable downloads, concurrent byte ranges, retries, integrity validation, and progress reporting.

#### Changes

##### Per-request headers

* Add extraHeaders?: Record<string, string> to DropboxRequestOptions
* Apply custom headers to RPC, upload, and download requests
* Preserve SDK-managed headers case-insensitively:
    * Authorization
    * Content-Type
    * Dropbox-API-Arg
* Add JavaScript and TypeScript coverage

Example:
```javascript
const result = await dbx.filesDownload(
  { path: '/large-file.bin' },
  {
    extraHeaders: {
      Range: 'bytes=0-1048575',
    },
  },
);
```

##### Node.js download helper

* Add downloadFile and DropboxFileDownloader as public exports
* Write downloads to localPath + ".part" before finalizing
* Resume existing partial downloads with range requests
* Support bounded concurrent range downloads
* Validate 206 Partial Content responses
* Validate Content-Range and response body lengths
* Pin retries to the original file revision
* Retry transient failures with exponential backoff
* Support cancellation and per-request timeouts
* Report cumulative progress
* Handle partial fs.write() completions
* Verify the final file size
* Verify Dropbox content_hash using streaming reads
* Support empty files
* Clean up invalid partial files safely

Example:
```javascript
const { Dropbox, downloadFile } = require('dropbox');

const dbx = new Dropbox({
  accessToken: process.env.DROPBOX_ACCESS_TOKEN,
});

await downloadFile(
  dbx,
  '/large-file.bin',
  'large-file.bin',
  {
    parallelDownloads: 4,
    progress: ({ bytesWritten, totalBytes, resumedFrom }) => {
      console.log({
        bytesWritten,
        totalBytes,
        resumedFrom,
      });
    },
  },
);
```