### PR TITLE
Add resilient file transfer helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,55 @@ in both JavaScript and TypeScript, with additional Node.js OAuth examples.
     - Team - [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/team), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/team) ] - An example showing how to use the team functionality and list team devices.
     - Upload [ [TS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/typescript/upload), [JS](https://github.com/dropbox/dropbox-sdk-js/tree/main/examples/javascript/upload) ] - An example showing how to upload a file to Dropbox.
 
+## Reliable file transfers
+
+For Node.js applications that need resumable local downloads or retrying uploads,
+the SDK exports file transfer helpers alongside the generated API methods.
+
+```js
+const {
+  Dropbox,
+  DropboxFileUploader,
+  bytesUpload,
+  downloadFile,
+  fileUpload,
+  readerUpload,
+  sizedReaderUpload,
+} = require('dropbox');
+
+const dbx = new Dropbox({ accessToken: process.env.DROPBOX_ACCESS_TOKEN });
+
+await downloadFile(dbx, '/large-file.bin', './large-file.bin', {
+  parallelDownloads: 4,
+  progress: ({ bytesWritten, totalBytes }) => {
+    console.log(`${bytesWritten}/${totalBytes}`);
+  },
+});
+
+const uploader = new DropboxFileUploader(dbx, {
+  progress: ({ bytesCommitted, totalBytes }) => {
+    console.log(`${bytesCommitted}/${totalBytes}`);
+  },
+});
+
+await uploader.upload(
+  await fileUpload('./large-file.bin'),
+  { path: '/large-file.bin', mode: { '.tag': 'overwrite' } },
+);
+
+await uploader.upload(
+  bytesUpload('hello from the Dropbox SDK\n'),
+  { path: '/hello.txt' },
+);
+```
+
+Downloads write to `localPath + ".part"` and rename the file after validating
+the final size and Dropbox `content_hash` metadata when present. Uploads retry
+transient failures at the individual session request, reconcile committed
+offsets after lost responses, and use upload sessions for every source. Pass
+`parallelUploads` for repeatable byte or file sources, or use `readerUpload()`
+and `sizedReaderUpload()` for one-shot Node readable streams.
+
 ## Getting Help
 
 If you find a bug, please see [CONTRIBUTING.md][contributing] for information on how to report it.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
 export { default as Dropbox } from './src/dropbox.js';
 export { default as DropboxAuth } from './src/auth.js';
 export { DropboxFileDownloader, downloadFile } from './src/filedownload.js';
+export {
+  DropboxFileUploader,
+  bytesUpload,
+  fileUpload,
+  readerUpload,
+  sizedReaderUpload,
+  uploadFile,
+} from './src/filetransfer.js';
 export { DropboxResponse } from './src/response.js';
 export { DropboxResponseError } from './src/error.js';

--- a/src/filedownload.js
+++ b/src/filedownload.js
@@ -3,8 +3,8 @@ import { DropboxResponseError } from './error.js';
 import { baseApiUrl, httpHeaderSafeJson } from './utils.js';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_RETRY_DELAY = 500;
-const RETRYABLE_5XX_STATUSES = new Set([500, 502, 503, 504]);
+const DEFAULT_RETRY_DELAY = 200;
+const MAX_RETRY_DELAY = 5000;
 const BLOCK_SIZE = 4 * 1024 * 1024;
 let nodeRuntime;
 
@@ -183,7 +183,7 @@ function isRetryableError(error) {
     return (
       error.status === 408
       || error.status === 429
-      || RETRYABLE_5XX_STATUSES.has(error.status)
+      || (error.status >= 500 && error.status <= 599)
     );
   }
 
@@ -214,6 +214,20 @@ function retryAfter(error) {
   }
 
   return Number(value) * 1000;
+}
+
+function getRetryDelay(error, attempt, baseDelay) {
+  const rateLimitDelay = retryAfter(error);
+  if (rateLimitDelay !== null) {
+    return rateLimitDelay;
+  }
+
+  const maximum = Math.min(
+    baseDelay * (2 ** attempt),
+    MAX_RETRY_DELAY,
+  );
+  const half = maximum / 2;
+  return Math.floor(half + Math.random() * (half + 1));
 }
 
 function delay(ms, signal) {
@@ -688,7 +702,7 @@ export class DropboxFileDownloader {
 
           if (attempt < this.maxAttempts - 1) {
             await this.delay(
-              retryAfter(error) || this.retryDelay * (2 ** attempt),
+              getRetryDelay(error, attempt, this.retryDelay),
               this.signal,
             );
           }

--- a/src/filedownload.js
+++ b/src/filedownload.js
@@ -201,6 +201,21 @@ function isRetryableError(error) {
   );
 }
 
+function retryAfter(error) {
+  if (!(error instanceof DropboxResponseError) || !error.headers) {
+    return null;
+  }
+
+  const value = typeof error.headers.get === 'function'
+    ? error.headers.get('retry-after')
+    : error.headers['retry-after'] || error.headers['Retry-After'];
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  return Number(value) * 1000;
+}
+
 function delay(ms, signal) {
   return new Promise((resolve, reject) => {
     let timeout;
@@ -673,7 +688,7 @@ export class DropboxFileDownloader {
 
           if (attempt < this.maxAttempts - 1) {
             await this.delay(
-              this.retryDelay * (2 ** attempt),
+              retryAfter(error) || this.retryDelay * (2 ** attempt),
               this.signal,
             );
           }

--- a/src/filetransfer.js
+++ b/src/filetransfer.js
@@ -2,7 +2,8 @@ import { DropboxFileDownloader, downloadFile } from './filedownload.js';
 import { DropboxResponseError } from './error.js';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
-const DEFAULT_RETRY_DELAY = 500;
+const DEFAULT_RETRY_DELAY = 200;
+const MAX_RETRY_DELAY = 5000;
 const DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024;
 const CONCURRENT_CHUNK_SIZE = 4 * 1024 * 1024;
 
@@ -153,12 +154,37 @@ function retryAfter(error) {
   return Number(value) * 1000;
 }
 
+function retryDelay(error, attempt, baseDelay) {
+  const rateLimitDelay = retryAfter(error);
+  if (rateLimitDelay !== null) {
+    return rateLimitDelay;
+  }
+
+  const maximum = Math.min(
+    baseDelay * (2 ** attempt),
+    MAX_RETRY_DELAY,
+  );
+  const half = maximum / 2;
+  return Math.floor(half + Math.random() * (half + 1));
+}
+
 function isRetryableError(error) {
   if (error && error.uploadSessionRetry) return true;
   if (error instanceof DropboxResponseError) {
-    return error.status === 408 || error.status === 429 || error.status >= 500;
+    return error.status === 408
+      || error.status === 429
+      || (error.status >= 500 && error.status <= 599);
   }
-  return !(error && (error.name === 'AbortError' || error.message === 'upload client is required'));
+  if (!error || error.name === 'AbortError') return false;
+  const code = error.code || (error.cause && error.cause.code);
+  if (typeof code === 'string' && /^(EAI_AGAIN|ECONN|ENET|EHOST|ETIMEDOUT|UND_ERR_)/.test(code)) {
+    return true;
+  }
+  return error instanceof TypeError && (
+    error.message === 'fetch failed'
+    || error.message === 'Failed to fetch'
+    || error.message === 'NetworkError when attempting to fetch resource.'
+  );
 }
 
 function correctOffset(error) {
@@ -306,7 +332,7 @@ export class DropboxFileUploader {
         if (attempt < this.maxAttempts - 1) {
           // eslint-disable-next-line no-await-in-loop
           await this.delay(
-            retryAfter(error) || this.retryDelay * (2 ** attempt),
+            retryDelay(error, attempt, this.retryDelay),
             this.signal,
           );
         }

--- a/src/filetransfer.js
+++ b/src/filetransfer.js
@@ -200,6 +200,16 @@ function correctOffset(error) {
   return visit(error.error);
 }
 
+function isClosedSession(error) {
+  if (!(error instanceof DropboxResponseError) || !error.error) return false;
+  const visit = (value) => {
+    if (!value || typeof value !== 'object') return false;
+    if (value['.tag'] === 'closed') return true;
+    return Object.keys(value).some((key) => visit(value[key]));
+  };
+  return visit(error.error);
+}
+
 function resultOf(response) {
   return response && response.result ? response.result : response;
 }
@@ -300,7 +310,7 @@ export class DropboxFileUploader {
     this.delay = options.delay || delay;
   }
 
-  requestOptions() { return { signal: this.signal, timeout: this.timeout }; }
+  requestOptions(signal = this.signal) { return { signal, timeout: this.timeout }; }
 
   validate(source, commitInfo) {
     if (!this.client || typeof this.client.filesUploadSessionStart !== 'function'
@@ -320,20 +330,20 @@ export class DropboxFileUploader {
     if (this.progress && bytesCommitted > 0) this.progress({ bytesCommitted, totalBytes });
   }
 
-  async retry(operation) {
+  async retry(operation, signal = this.signal) {
     let lastError;
     for (let attempt = 0; attempt < this.maxAttempts; attempt += 1) {
       try { // eslint-disable-line no-await-in-loop
         return await operation(); // eslint-disable-line no-await-in-loop
       } catch (error) {
-        if (this.signal && this.signal.aborted) throw this.signal.reason || error;
+        if (signal && signal.aborted) throw signal.reason || error;
         if (!isRetryableError(error)) throw error;
         lastError = error;
         if (attempt < this.maxAttempts - 1) {
           // eslint-disable-next-line no-await-in-loop
           await this.delay(
             retryDelay(error, attempt, this.retryDelay),
-            this.signal,
+            signal,
           );
         }
       }
@@ -351,16 +361,17 @@ export class DropboxFileUploader {
     return sessionId;
   }
 
-  async append(sessionId, offset, contents, close = false) {
+  async append(sessionId, offset, contents, close = false, signal = this.signal) {
     const expectedOffset = offset + contents.byteLength;
     return this.retry(async () => {
       try {
         await this.client.filesUploadSessionAppendV2({
           cursor: { session_id: sessionId, offset }, close, contents,
-        }, this.requestOptions());
+        }, this.requestOptions(signal));
       } catch (error) {
         const actual = correctOffset(error);
         if (actual === expectedOffset) return;
+        if (close && isClosedSession(error)) return;
         if (actual === offset) {
           error.uploadSessionRetry = true; // eslint-disable-line no-param-reassign
         }
@@ -369,7 +380,7 @@ export class DropboxFileUploader {
         }
         throw error;
       }
-    });
+    }, signal);
   }
 
   async finish(sessionId, offset, commit, contents) {
@@ -451,21 +462,47 @@ export class DropboxFileUploader {
     }
     const finalRange = ranges.pop();
     let committed = 0;
+    const controller = new AbortController();
+    const signal = this.signal
+      ? AbortSignal.any([this.signal, controller.signal])
+      : controller.signal;
+    let firstError;
+    const stop = (error) => {
+      if (!firstError) {
+        firstError = error;
+        controller.abort(error);
+      }
+    };
     const uploadRange = async (range, close) => {
+      if (firstError) throw firstError;
       const bytes = await rangedChunk(source, range.offset, range.length);
-      await this.append(sessionId, range.offset, bytes, close);
+      if (firstError) throw firstError;
+      await this.append(sessionId, range.offset, bytes, close, signal);
+      if (firstError) throw firstError;
       committed += range.length;
       this.report(committed, source.size);
     };
     const workerCount = Math.min(this.parallelUploads, ranges.length);
     const workers = Array.from({ length: workerCount }, async () => {
-      while (ranges.length) {
-        // eslint-disable-next-line no-await-in-loop
-        await uploadRange(ranges.shift(), false);
+      while (!firstError && ranges.length) {
+        const range = ranges.shift();
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await uploadRange(range, false);
+        } catch (error) {
+          stop(error);
+          return;
+        }
       }
     });
-    await Promise.all(workers);
-    await uploadRange(finalRange, true);
+    await Promise.allSettled(workers);
+    if (firstError) throw firstError;
+    try {
+      await uploadRange(finalRange, true);
+    } catch (error) {
+      stop(error);
+      throw firstError;
+    }
     if (committed !== source.size) {
       throw new Error(`incomplete upload: committed ${committed} of ${source.size} bytes`);
     }

--- a/src/filetransfer.js
+++ b/src/filetransfer.js
@@ -1,0 +1,460 @@
+import { DropboxFileDownloader, downloadFile } from './filedownload.js';
+import { DropboxResponseError } from './error.js';
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY = 500;
+const DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024;
+const CONCURRENT_CHUNK_SIZE = 4 * 1024 * 1024;
+
+let nodeRuntime;
+
+function requireNodeModule(moduleName) {
+  if (typeof require === 'function') { // eslint-disable-line no-undef
+    // eslint-disable-next-line global-require, import/no-dynamic-require, no-undef
+    return Promise.resolve(require(moduleName)); // eslint-disable-line no-undef
+  }
+  // eslint-disable-next-line no-new-func
+  return Function('moduleName', 'return import(moduleName)')(moduleName);
+}
+
+async function getNodeRuntime() {
+  if (nodeRuntime) return nodeRuntime;
+  if (typeof process === 'undefined' || !process.versions || !process.versions.node) {
+    throw new Error('fileUpload is only supported in Node.js');
+  }
+  const fsModule = await requireNodeModule('fs');
+  nodeRuntime = { fs: fsModule.default || fsModule };
+  return nodeRuntime;
+}
+
+function validatePositiveInteger(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive integer`);
+  }
+}
+
+function emptyContents() {
+  return new Uint8Array(0);
+}
+
+function isBlob(value) {
+  return typeof Blob !== 'undefined' && value instanceof Blob;
+}
+
+function toUint8Array(value) {
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return null;
+}
+
+async function contentsToBytes(contents) {
+  const bytes = toUint8Array(contents);
+  if (bytes) return bytes;
+  if (isBlob(contents)) return new Uint8Array(await contents.arrayBuffer());
+  if (contents && typeof contents[Symbol.asyncIterator] === 'function') {
+    const chunks = [];
+    let length = 0;
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const chunk of contents) {
+      const value = toUint8Array(chunk);
+      if (!value) throw new TypeError('upload source yielded non-byte content');
+      chunks.push(value);
+      length += value.byteLength;
+    }
+    const result = new Uint8Array(length);
+    let offset = 0;
+    chunks.forEach((chunk) => { result.set(chunk, offset); offset += chunk.byteLength; });
+    return result;
+  }
+  throw new TypeError('upload source must provide byte content');
+}
+
+function validateRange(size, offset, length) {
+  if (!Number.isInteger(offset) || !Number.isInteger(length) || offset < 0 || length < 0
+    || offset > size || length > size - offset) {
+    throw new RangeError(`range [${offset},${offset + length}) exceeds source size ${size}`);
+  }
+}
+
+function sourceReadError(offset, error) {
+  return new Error(`upload source read failed at offset ${offset}: ${error.message}`);
+}
+
+export function bytesUpload(contents) {
+  const normalized = typeof contents === 'string'
+    ? new TextEncoder().encode(contents)
+    : contents;
+  if (isBlob(normalized)) {
+    return {
+      size: normalized.size,
+      async read(offset, length) {
+        validateRange(normalized.size, offset, length);
+        return normalized.slice(offset, offset + length);
+      },
+    };
+  }
+  const bytes = toUint8Array(normalized);
+  if (!bytes) throw new TypeError('bytesUpload contents must be byte content, a Blob, or a string');
+  return {
+    size: bytes.byteLength,
+    async read(offset, length) {
+      validateRange(bytes.byteLength, offset, length);
+      return bytes.subarray(offset, offset + length);
+    },
+  };
+}
+
+export async function fileUpload(filePath) {
+  const { fs } = await getNodeRuntime();
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) throw new Error(`upload source is not a regular file: ${filePath}`);
+  return {
+    size: stat.size,
+    async read(offset, length) {
+      validateRange(stat.size, offset, length);
+      const current = fs.statSync(filePath);
+      if (current.size !== stat.size) {
+        throw new Error(`upload source size changed: got ${current.size} bytes, expected ${stat.size}`);
+      }
+      if (length === 0) return emptyContents();
+      return fs.createReadStream(filePath, { start: offset, end: offset + length - 1 });
+    },
+  };
+}
+
+export function readerUpload(reader) {
+  if (!reader) throw new TypeError('upload reader is required');
+  let opened = false;
+  return {
+    async open() {
+      if (opened) throw new Error('upload source has already been opened');
+      opened = true;
+      return reader;
+    },
+  };
+}
+
+export function sizedReaderUpload(reader, size) {
+  if (!Number.isInteger(size) || size < 0) throw new TypeError('upload size must be a non-negative integer');
+  return { ...readerUpload(reader), size };
+}
+
+function retryAfter(error) {
+  if (!(error instanceof DropboxResponseError) || !error.headers) return null;
+  const value = typeof error.headers.get === 'function'
+    ? error.headers.get('retry-after')
+    : error.headers['retry-after'] || error.headers['Retry-After'];
+  if (!value || !/^\d+$/.test(value)) return null;
+  return Number(value) * 1000;
+}
+
+function isRetryableError(error) {
+  if (error && error.uploadSessionRetry) return true;
+  if (error instanceof DropboxResponseError) {
+    return error.status === 408 || error.status === 429 || error.status >= 500;
+  }
+  return !(error && (error.name === 'AbortError' || error.message === 'upload client is required'));
+}
+
+function correctOffset(error) {
+  if (!(error instanceof DropboxResponseError) || !error.error) return null;
+  const visit = (value) => {
+    if (!value || typeof value !== 'object') return null;
+    if (Number.isInteger(value.correct_offset)) return value.correct_offset;
+    return Object.keys(value).reduce(
+      (found, key) => (found === null ? visit(value[key]) : found),
+      null,
+    );
+  };
+  return visit(error.error);
+}
+
+function resultOf(response) {
+  return response && response.result ? response.result : response;
+}
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    if (!signal) return;
+    const abort = () => { clearTimeout(timer); reject(signal.reason || new Error('upload aborted')); };
+    if (signal.aborted) abort();
+    else signal.addEventListener('abort', abort, { once: true });
+  });
+}
+
+function isRangedSource(source) {
+  return source && Number.isInteger(source.size) && source.size >= 0 && typeof source.read === 'function';
+}
+
+function isSequentialSource(source) {
+  return source && typeof source.open === 'function';
+}
+
+async function rangedChunk(source, offset, length) {
+  try {
+    const bytes = await contentsToBytes(await source.read(offset, length));
+    if (bytes.byteLength !== length) {
+      throw new Error(`got ${bytes.byteLength} bytes, expected ${length}`);
+    }
+    return bytes;
+  } catch (error) {
+    throw sourceReadError(offset, error);
+  }
+}
+
+async function sequentialChunks(source, chunkSize) {
+  const reader = await source.open();
+  if (!reader) {
+    throw new TypeError('upload reader must be an async iterable');
+  }
+  let iterator;
+  if (typeof reader[Symbol.asyncIterator] === 'function') {
+    iterator = reader[Symbol.asyncIterator]();
+  } else if (typeof reader.getReader === 'function') {
+    const streamReader = reader.getReader();
+    iterator = {
+      next: () => streamReader.read(),
+    };
+  } else {
+    throw new TypeError('upload reader must be an async iterable');
+  }
+  let pending = emptyContents();
+  let done = false;
+  return async () => {
+    const chunks = [];
+    let length = 0;
+    while (length < chunkSize && !done) {
+      if (pending.byteLength === 0) {
+        // eslint-disable-next-line no-await-in-loop
+        const next = await iterator.next();
+        done = next.done;
+        if (done) break;
+        pending = toUint8Array(next.value);
+        if (!pending) throw new TypeError('upload source yielded non-byte content');
+      }
+      const take = Math.min(chunkSize - length, pending.byteLength);
+      chunks.push(pending.subarray(0, take));
+      pending = pending.subarray(take);
+      length += take;
+    }
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    chunks.forEach((chunk) => { bytes.set(chunk, offset); offset += chunk.byteLength; });
+    return { bytes, done: done && pending.byteLength === 0 };
+  };
+}
+
+export class DropboxFileUploader {
+  constructor(client, options = {}) {
+    const maxAttempts = options.maxAttempts === undefined || options.maxAttempts <= 0
+      ? DEFAULT_MAX_ATTEMPTS : options.maxAttempts;
+    const chunkSize = options.chunkSize === undefined ? DEFAULT_CHUNK_SIZE : options.chunkSize;
+    validatePositiveInteger('maxAttempts', maxAttempts);
+    validatePositiveInteger('chunkSize', chunkSize);
+    if (options.parallelUploads !== undefined
+      && (!Number.isInteger(options.parallelUploads) || options.parallelUploads < 0)) {
+      throw new TypeError('parallelUploads must be a non-negative integer');
+    }
+    this.client = client;
+    this.maxAttempts = maxAttempts;
+    this.chunkSize = chunkSize;
+    this.parallelUploads = options.parallelUploads > 1 ? options.parallelUploads : 1;
+    this.retryDelay = options.retryDelay === undefined ? DEFAULT_RETRY_DELAY : options.retryDelay;
+    validatePositiveInteger('retryDelay', this.retryDelay);
+    if (options.timeout !== undefined) validatePositiveInteger('timeout', options.timeout);
+    this.progress = options.progress;
+    this.signal = options.signal;
+    this.timeout = options.timeout;
+    this.delay = options.delay || delay;
+  }
+
+  requestOptions() { return { signal: this.signal, timeout: this.timeout }; }
+
+  validate(source, commitInfo) {
+    if (!this.client || typeof this.client.filesUploadSessionStart !== 'function'
+      || typeof this.client.filesUploadSessionAppendV2 !== 'function'
+      || typeof this.client.filesUploadSessionFinish !== 'function') {
+      throw new Error('upload client is required');
+    }
+    if (!isRangedSource(source) && !isSequentialSource(source)) {
+      throw new TypeError('upload source must provide read(offset, length) or open()');
+    }
+    if (!commitInfo) throw new TypeError('upload commit info is required');
+    if (!commitInfo.path) throw new TypeError('upload destination path is required');
+    if (this.parallelUploads > 1 && !isRangedSource(source)) throw new TypeError('parallel uploads require a ranged upload source');
+  }
+
+  report(bytesCommitted, totalBytes) {
+    if (this.progress && bytesCommitted > 0) this.progress({ bytesCommitted, totalBytes });
+  }
+
+  async retry(operation) {
+    let lastError;
+    for (let attempt = 0; attempt < this.maxAttempts; attempt += 1) {
+      try { // eslint-disable-line no-await-in-loop
+        return await operation(); // eslint-disable-line no-await-in-loop
+      } catch (error) {
+        if (this.signal && this.signal.aborted) throw this.signal.reason || error;
+        if (!isRetryableError(error)) throw error;
+        lastError = error;
+        if (attempt < this.maxAttempts - 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await this.delay(
+            retryAfter(error) || this.retryDelay * (2 ** attempt),
+            this.signal,
+          );
+        }
+      }
+    }
+    throw lastError;
+  }
+
+  async start(concurrent) {
+    const response = await this.retry(() => this.client.filesUploadSessionStart({
+      contents: emptyContents(),
+      ...(concurrent ? { session_type: { '.tag': 'concurrent' } } : {}),
+    }, this.requestOptions()));
+    const sessionId = resultOf(response) && resultOf(response).session_id;
+    if (!sessionId) throw new Error('upload session id is empty');
+    return sessionId;
+  }
+
+  async append(sessionId, offset, contents, close = false) {
+    const expectedOffset = offset + contents.byteLength;
+    return this.retry(async () => {
+      try {
+        await this.client.filesUploadSessionAppendV2({
+          cursor: { session_id: sessionId, offset }, close, contents,
+        }, this.requestOptions());
+      } catch (error) {
+        const actual = correctOffset(error);
+        if (actual === expectedOffset) return;
+        if (actual === offset) {
+          error.uploadSessionRetry = true; // eslint-disable-line no-param-reassign
+        }
+        if (actual !== null && actual !== offset) {
+          throw new Error(`upload session offset mismatch: got ${actual}, expected ${offset} or ${expectedOffset}`);
+        }
+        throw error;
+      }
+    });
+  }
+
+  async finish(sessionId, offset, commit, contents) {
+    let currentOffset = offset;
+    let currentContents = contents;
+    return this.retry(async () => {
+      try {
+        const response = await this.client.filesUploadSessionFinish({
+          cursor: { session_id: sessionId, offset: currentOffset },
+          commit,
+          contents: currentContents,
+        }, this.requestOptions());
+        return resultOf(response);
+      } catch (error) {
+        const actual = correctOffset(error);
+        const expected = currentOffset + currentContents.byteLength;
+        if (actual === expected) {
+          currentOffset = actual;
+          currentContents = emptyContents();
+          error.uploadSessionRetry = true; // eslint-disable-line no-param-reassign
+        } else if (actual === currentOffset) {
+          error.uploadSessionRetry = true; // eslint-disable-line no-param-reassign
+        } else if (actual !== null) {
+          throw new Error(`upload session offset mismatch: got ${actual}, expected ${currentOffset} or ${expected}`);
+        }
+        throw error;
+      }
+    });
+  }
+
+  async uploadSequential(source, commit) {
+    let total = -1;
+    if (isRangedSource(source) || Number.isInteger(source.size)) total = source.size;
+    const sessionId = await this.start(false);
+    let offset = 0;
+    const next = isRangedSource(source)
+      ? async () => {
+        const length = Math.min(this.chunkSize, source.size - offset);
+        return {
+          bytes: await rangedChunk(source, offset, length),
+          done: offset + length === source.size,
+        };
+      }
+      : await sequentialChunks(source, this.chunkSize);
+    for (;;) {
+      // eslint-disable-next-line no-await-in-loop
+      const chunk = await next();
+      if (total >= 0 && offset + chunk.bytes.byteLength > total) {
+        throw new Error(`read upload content: got more than declared size ${total}`);
+      }
+      if (chunk.done) {
+        if (total >= 0 && offset + chunk.bytes.byteLength !== total) {
+          throw new Error(
+            `read upload content: got ${offset + chunk.bytes.byteLength} bytes, expected ${total}`,
+          );
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const metadata = await this.finish(sessionId, offset, commit, chunk.bytes);
+        this.report(offset + chunk.bytes.byteLength, total);
+        return { metadata };
+      }
+      if (chunk.bytes.byteLength === 0) throw new Error('read upload content: no progress');
+      // eslint-disable-next-line no-await-in-loop
+      await this.append(sessionId, offset, chunk.bytes);
+      offset += chunk.bytes.byteLength;
+      this.report(offset, total);
+    }
+  }
+
+  async uploadParallel(source, commit) {
+    if (source.size === 0) return this.uploadSequential(source, commit);
+    if (this.chunkSize % CONCURRENT_CHUNK_SIZE !== 0) {
+      throw new TypeError(`chunkSize must be a multiple of ${CONCURRENT_CHUNK_SIZE} for parallel uploads`);
+    }
+    const sessionId = await this.start(true);
+    const ranges = [];
+    for (let offset = 0; offset < source.size; offset += this.chunkSize) {
+      ranges.push({ offset, length: Math.min(this.chunkSize, source.size - offset) });
+    }
+    const finalRange = ranges.pop();
+    let committed = 0;
+    const uploadRange = async (range, close) => {
+      const bytes = await rangedChunk(source, range.offset, range.length);
+      await this.append(sessionId, range.offset, bytes, close);
+      committed += range.length;
+      this.report(committed, source.size);
+    };
+    const workerCount = Math.min(this.parallelUploads, ranges.length);
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (ranges.length) {
+        // eslint-disable-next-line no-await-in-loop
+        await uploadRange(ranges.shift(), false);
+      }
+    });
+    await Promise.all(workers);
+    await uploadRange(finalRange, true);
+    if (committed !== source.size) {
+      throw new Error(`incomplete upload: committed ${committed} of ${source.size} bytes`);
+    }
+    return { metadata: await this.finish(sessionId, source.size, commit, emptyContents()) };
+  }
+
+  upload(source, commitInfo) {
+    this.validate(source, commitInfo);
+    if (this.parallelUploads > 1) return this.uploadParallel(source, commitInfo);
+    return this.uploadSequential(source, commitInfo);
+  }
+}
+
+export function uploadFile(client, source, commitInfo, options = {}) {
+  return new DropboxFileUploader(client, options).upload(source, commitInfo);
+}
+
+export { DropboxFileDownloader, downloadFile };

--- a/test/integration/user.js
+++ b/test/integration/user.js
@@ -5,7 +5,14 @@ import { Readable } from 'stream';
 
 import chai from 'chai';
 
-import { Dropbox, DropboxAuth, downloadFile } from '../../index.js';
+import {
+  Dropbox,
+  DropboxAuth,
+  DropboxFileUploader,
+  bytesUpload,
+  downloadFile,
+  readerUpload,
+} from '../../index.js';
 import { DropboxResponse } from '../../src/response.js';
 import { DropboxResponseError } from '../../src/error.js';
 
@@ -175,6 +182,40 @@ for (const appType in appInfo) {
             .then(cleanup)
             .then(() => done(testError))
             .catch((cleanupError) => done(testError || cleanupError));
+        });
+
+        it('file transfer uploader supports sequential and concurrent sessions', async () => {
+          const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          const sequentialPath = `/dropbox-sdk-js-transfer-sequential-${suffix}.txt`;
+          const concurrentPath = `/dropbox-sdk-js-transfer-concurrent-${suffix}.bin`;
+          const sequentialContents = Buffer.from('file transfer reader upload\n');
+          const concurrentContents = Buffer.alloc(8 * 1024 * 1024 + 1, 97);
+
+          try {
+            const sequentialUploader = new DropboxFileUploader(dbx, { chunkSize: 4 });
+            await sequentialUploader.upload(
+              readerUpload(Readable.from([sequentialContents])),
+              { path: sequentialPath },
+            );
+            const sequentialDownload = await dbx.filesDownload({ path: sequentialPath });
+            chai.assert.deepEqual(sequentialDownload.result.fileBinary, sequentialContents);
+
+            const concurrentUploader = new DropboxFileUploader(dbx, {
+              chunkSize: 4 * 1024 * 1024,
+              parallelUploads: 2,
+            });
+            await concurrentUploader.upload(
+              bytesUpload(concurrentContents),
+              { path: concurrentPath },
+            );
+            const concurrentDownload = await dbx.filesDownload({ path: concurrentPath });
+            chai.assert.deepEqual(concurrentDownload.result.fileBinary, concurrentContents);
+          } finally {
+            await Promise.allSettled([
+              dbx.filesDeleteV2({ path: sequentialPath }),
+              dbx.filesDeleteV2({ path: concurrentPath }),
+            ]);
+          }
         });
       });
 

--- a/test/types/types_test.js
+++ b/test/types/types_test.js
@@ -114,3 +114,15 @@ fileDownloader.downloadFile('/test.txt', '/tmp/test.txt')
 Dropbox.downloadFile(dropbox, '/test.txt', '/tmp/test.txt', {
     timeout: 1000,
 });
+var uploadSource = Dropbox.bytesUpload('upload content');
+var fileUploader = new Dropbox.DropboxFileUploader(dropbox, {
+    parallelUploads: 2,
+    progress: function (progress) {
+        var bytesCommitted = progress.bytesCommitted, totalBytes = progress.totalBytes;
+    },
+});
+fileUploader.upload(uploadSource, { path: '/upload.txt' })
+    .then(function (result) { return result.metadata; });
+var uploadReader = {};
+Dropbox.readerUpload(uploadReader);
+Dropbox.sizedReaderUpload(uploadReader, 3);

--- a/test/types/types_test.ts
+++ b/test/types/types_test.ts
@@ -141,3 +141,19 @@ fileDownloader.downloadFile('/test.txt', '/tmp/test.txt')
 Dropbox.downloadFile(dropbox, '/test.txt', '/tmp/test.txt', {
   timeout: 1000,
 });
+
+const uploadSource = Dropbox.bytesUpload('upload content');
+const fileUploader = new Dropbox.DropboxFileUploader(dropbox, {
+  parallelUploads: 2,
+  progress: (progress: Dropbox.DropboxFileUploadProgress) => {
+    const { bytesCommitted, totalBytes }: Dropbox.DropboxFileUploadProgress = progress;
+  },
+});
+
+fileUploader.upload(uploadSource, { path: '/upload.txt' })
+  .then((result: Dropbox.DropboxFileUploadResult) => result.metadata);
+
+const uploadReader = {} as AsyncIterable<Uint8Array>;
+
+Dropbox.readerUpload(uploadReader);
+Dropbox.sizedReaderUpload(uploadReader, 3);

--- a/test/unit/filedownload.js
+++ b/test/unit/filedownload.js
@@ -238,6 +238,23 @@ describe('DropboxFileDownloader', () => {
     expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello');
   });
 
+  it('honors Retry-After for rate-limited downloads', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub();
+    fetch.onFirstCall().rejects(new DropboxResponseError(429, {
+      get: (name) => (name === 'retry-after' ? '7' : null),
+    }, 'rate limit'));
+    fetch.onSecondCall().returns(downloadResponse('hello'));
+    const delays = [];
+
+    await new DropboxFileDownloader(client(fetch), {
+      delay: (value) => { delays.push(value); return Promise.resolve(); },
+    }).downloadFile('/file.bin', localPath);
+
+    expect(delays).to.deep.equal([7000]);
+  });
+
   it('aborts during retry backoff without waiting for the delay', async () => {
     const dir = tempDir();
     const localPath = path.join(dir, 'file.bin');

--- a/test/unit/filedownload.js
+++ b/test/unit/filedownload.js
@@ -210,7 +210,7 @@ describe('DropboxFileDownloader', () => {
     }).downloadFile('/file.bin', localPath);
 
     expect(fetch.callCount).to.equal(2);
-    expect(delays).to.deep.equal([500]);
+    expect(delays[0]).to.be.within(100, 200);
     expect(fetchRange(fetch.secondCall.args[1])).to.equal('bytes=6-');
     expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello world');
     expect(result.resumedFrom).to.equal(6);
@@ -234,7 +234,8 @@ describe('DropboxFileDownloader', () => {
     }).downloadFile('/file.bin', localPath);
 
     expect(fetch.callCount).to.equal(3);
-    expect(delays).to.deep.equal([10, 20]);
+    expect(delays[0]).to.be.within(5, 10);
+    expect(delays[1]).to.be.within(10, 20);
     expect(fs.readFileSync(localPath, 'utf8')).to.equal('hello');
   });
 
@@ -253,6 +254,20 @@ describe('DropboxFileDownloader', () => {
     }).downloadFile('/file.bin', localPath);
 
     expect(delays).to.deep.equal([7000]);
+  });
+
+  it('retries every 5xx Dropbox response', async () => {
+    const dir = tempDir();
+    const localPath = path.join(dir, 'file.bin');
+    const fetch = sinon.stub();
+    fetch.onFirstCall().rejects(new DropboxResponseError(599, {}, 'server error'));
+    fetch.onSecondCall().returns(downloadResponse('hello'));
+
+    await new DropboxFileDownloader(client(fetch), {
+      delay: () => Promise.resolve(),
+    }).downloadFile('/file.bin', localPath);
+
+    expect(fetch.callCount).to.equal(2);
   });
 
   it('aborts during retry backoff without waiting for the delay', async () => {
@@ -302,11 +317,11 @@ describe('DropboxFileDownloader', () => {
     expect(fetch.callCount).to.equal(1);
   });
 
-  it('does not retry non-transient server responses', async () => {
+  it('does not retry responses outside the 5xx range', async () => {
     const dir = tempDir();
     const localPath = path.join(dir, 'file.bin');
     const fetch = sinon.stub().rejects(
-      new DropboxResponseError(501, {}, 'not implemented'),
+      new DropboxResponseError(600, {}, 'out of range'),
     );
 
     try {
@@ -315,7 +330,7 @@ describe('DropboxFileDownloader', () => {
       throw new Error('expected download to fail');
     } catch (error) {
       expect(error).to.be.instanceOf(DropboxResponseError);
-      expect(error.status).to.equal(501);
+      expect(error.status).to.equal(600);
     }
 
     expect(fetch.callCount).to.equal(1);

--- a/test/unit/filetransfer.js
+++ b/test/unit/filetransfer.js
@@ -205,6 +205,83 @@ describe('DropboxFileUploader', () => {
     expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('');
   });
 
+  it('finishes after a lost response from the final concurrent append', async () => {
+    const dbx = client();
+    const data = Buffer.alloc(8 * 1024 * 1024 + 1, 97);
+    dbx.filesUploadSessionAppendV2.onThirdCall().rejects(new TypeError('fetch failed'));
+    dbx.filesUploadSessionAppendV2.onCall(3).rejects(new DropboxResponseError(409, {}, {
+      '.tag': 'lookup_failed',
+      lookup_failed: { '.tag': 'closed' },
+    }));
+
+    const result = await new DropboxFileUploader(dbx, {
+      parallelUploads: 2,
+      chunkSize: 4 * 1024 * 1024,
+      delay: () => Promise.resolve(),
+    }).upload(bytesUpload(data), { path: '/parallel.bin' });
+
+    expect(result.metadata.name).to.equal('file.bin');
+    expect(dbx.filesUploadSessionAppendV2.callCount).to.equal(4);
+    expect(dbx.filesUploadSessionAppendV2.thirdCall.args[0].close).to.equal(true);
+    expect(dbx.filesUploadSessionAppendV2.getCall(3).args[0].close).to.equal(true);
+    expect(dbx.filesUploadSessionFinish.calledOnce).to.equal(true);
+  });
+
+  it('stops parallel workers after the first failure', async () => {
+    const dbx = client();
+    const chunkSize = 4 * 1024 * 1024;
+    const failure = new Error('append failed');
+    let releaseSecondRead;
+    let secondReadStarted;
+    const secondRead = new Promise((resolve) => { releaseSecondRead = resolve; });
+    const source = {
+      size: chunkSize * 4,
+      read: (offset, length) => {
+        if (offset === 0) return Buffer.alloc(length);
+        if (offset === chunkSize) {
+          secondReadStarted = true;
+          return secondRead.then(() => Buffer.alloc(length));
+        }
+        throw new Error(`unexpected read at ${offset}`);
+      },
+    };
+    dbx.filesUploadSessionAppendV2.callsFake(({ cursor }) => {
+      if (cursor.offset === 0) return Promise.reject(failure);
+      return Promise.resolve();
+    });
+    const progress = [];
+    const upload = new DropboxFileUploader(dbx, {
+      parallelUploads: 2,
+      chunkSize,
+      progress: (value) => progress.push(value),
+    }).upload(source, { path: '/parallel.bin' });
+
+    while (!secondReadStarted) { // eslint-disable-line no-await-in-loop
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    while (!dbx.filesUploadSessionAppendV2.called) { // eslint-disable-line no-await-in-loop
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    const { signal } = dbx.filesUploadSessionAppendV2.firstCall.args[1];
+    while (!signal.aborted) { // eslint-disable-line no-await-in-loop
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+    }
+    releaseSecondRead();
+
+    try {
+      await upload;
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error).to.equal(failure);
+    }
+    expect(dbx.filesUploadSessionAppendV2.calledOnce).to.equal(true);
+    expect(progress).to.deep.equal([]);
+    expect(dbx.filesUploadSessionFinish.called).to.equal(false);
+  });
+
   it('treats parallelUploads below two as sequential', async () => {
     const dbx = client();
     await new DropboxFileUploader(dbx, { parallelUploads: 0 })

--- a/test/unit/filetransfer.js
+++ b/test/unit/filetransfer.js
@@ -87,7 +87,80 @@ describe('DropboxFileUploader', () => {
     expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('hello');
     expect(bytes(dbx.filesUploadSessionFinish.secondCall.args[0].contents)).to.equal('');
     expect(dbx.filesUploadSessionFinish.secondCall.args[0].cursor.offset).to.equal(5);
-    expect(delays).to.deep.equal([500]);
+    expect(delays[0]).to.be.within(100, 200);
+  });
+
+  it('retries browser-style network failures but not arbitrary TypeErrors', async () => {
+    const retryingClient = client();
+    retryingClient.filesUploadSessionStart.onFirstCall().rejects(new TypeError('fetch failed'));
+    const delays = [];
+
+    await new DropboxFileUploader(retryingClient, {
+      delay: (value) => { delays.push(value); return Promise.resolve(); },
+    }).upload(bytesUpload('hello'), { path: '/retry.txt' });
+
+    expect(retryingClient.filesUploadSessionStart.callCount).to.equal(2);
+    expect(delays[0]).to.be.within(100, 200);
+
+    const failingClient = client();
+    failingClient.filesUploadSessionStart.rejects(new TypeError('invalid upload configuration'));
+    try {
+      await new DropboxFileUploader(failingClient).upload(bytesUpload('hello'), { path: '/failure.txt' });
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error.message).to.equal('invalid upload configuration');
+    }
+    expect(failingClient.filesUploadSessionStart.calledOnce).to.equal(true);
+  });
+
+  it('honors Retry-After and bounds jittered exponential retry delays', async () => {
+    const rateLimitedClient = client();
+    rateLimitedClient.filesUploadSessionStart.onFirstCall().rejects(
+      new DropboxResponseError(429, { get: () => '7' }, 'rate limit'),
+    );
+    const rateLimitDelays = [];
+    await new DropboxFileUploader(rateLimitedClient, {
+      delay: (value) => { rateLimitDelays.push(value); return Promise.resolve(); },
+    }).upload(bytesUpload('hello'), { path: '/rate-limit.txt' });
+    expect(rateLimitDelays).to.deep.equal([7000]);
+
+    const retryingClient = client();
+    retryingClient.filesUploadSessionStart.rejects(new DropboxResponseError(503, {}, 'unavailable'));
+    const delays = [];
+    try {
+      await new DropboxFileUploader(retryingClient, {
+        maxAttempts: 7,
+        delay: (value) => { delays.push(value); return Promise.resolve(); },
+      }).upload(bytesUpload('hello'), { path: '/backoff.txt' });
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error.status).to.equal(503);
+    }
+    [
+      [100, 200], [200, 400], [400, 800], [800, 1600], [1600, 3200], [2500, 5000],
+    ].forEach(([minimum, maximum], index) => {
+      expect(delays[index]).to.be.within(minimum, maximum);
+    });
+  });
+
+  it('aborts upload retry backoff promptly', async () => {
+    const dbx = client();
+    dbx.filesUploadSessionStart.rejects(new DropboxResponseError(503, {}, 'unavailable'));
+    const controller = new AbortController();
+    const reason = new Error('cancelled');
+    const upload = new DropboxFileUploader(dbx, {
+      signal: controller.signal,
+      maxAttempts: 2,
+    }).upload(bytesUpload('hello'), { path: '/abort.txt' });
+    setTimeout(() => controller.abort(reason), 0);
+
+    try {
+      await upload;
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error).to.equal(reason);
+    }
+    expect(dbx.filesUploadSessionStart.calledOnce).to.equal(true);
   });
 
   it('supports unknown-size one-shot streams', async () => {

--- a/test/unit/filetransfer.js
+++ b/test/unit/filetransfer.js
@@ -1,0 +1,162 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  DropboxFileUploader,
+  bytesUpload,
+  fileUpload,
+  readerUpload,
+  sizedReaderUpload,
+} from '../../src/filetransfer.js';
+import { DropboxResponse } from '../../src/response.js';
+import { DropboxResponseError } from '../../src/error.js';
+
+function client() {
+  return {
+    filesUploadSessionStart: sinon.stub().resolves(new DropboxResponse(200, {}, { session_id: 'session-1' })),
+    filesUploadSessionAppendV2: sinon.stub().resolves(new DropboxResponse(200, {}, undefined)),
+    filesUploadSessionFinish: sinon.stub().resolves(new DropboxResponse(200, {}, { name: 'file.bin', size: 0 })),
+  };
+}
+
+function bytes(value) {
+  return Buffer.from(value).toString('utf8');
+}
+
+async function streamBytes(stream) {
+  const chunks = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+describe('DropboxFileUploader', () => {
+  it('uploads byte sources through a sequential session', async () => {
+    const dbx = client();
+    dbx.filesUploadSessionFinish.resolves(new DropboxResponse(200, {}, { name: 'data.bin' }));
+    const progress = [];
+
+    const result = await new DropboxFileUploader(dbx, {
+      chunkSize: 4,
+      progress: (value) => progress.push(value),
+    }).upload(bytesUpload('abcdefghij'), { path: '/data.bin' });
+
+    expect(result.metadata.name).to.equal('data.bin');
+    expect(bytes(dbx.filesUploadSessionStart.firstCall.args[0].contents)).to.equal('');
+    expect(bytes(dbx.filesUploadSessionAppendV2.firstCall.args[0].contents)).to.equal('abcd');
+    expect(bytes(dbx.filesUploadSessionAppendV2.secondCall.args[0].contents)).to.equal('efgh');
+    expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('ij');
+    expect(progress).to.deep.equal([
+      { bytesCommitted: 4, totalBytes: 10 },
+      { bytesCommitted: 8, totalBytes: 10 },
+      { bytesCommitted: 10, totalBytes: 10 },
+    ]);
+  });
+
+  it('treats an already committed append as successful', async () => {
+    const dbx = client();
+    dbx.filesUploadSessionAppendV2.rejects(new DropboxResponseError(409, {}, {
+      '.tag': 'incorrect_offset', correct_offset: 4,
+    }));
+
+    await new DropboxFileUploader(dbx, { chunkSize: 4, maxAttempts: 2 })
+      .upload(bytesUpload('abcdef'), { path: '/data.bin' });
+
+    expect(dbx.filesUploadSessionAppendV2.calledOnce).to.equal(true);
+    expect(dbx.filesUploadSessionFinish.firstCall.args[0].cursor.offset).to.equal(4);
+  });
+
+  it('retries a finish with an empty body after its data was committed', async () => {
+    const dbx = client();
+    dbx.filesUploadSessionFinish.onFirstCall().rejects(new DropboxResponseError(409, {}, {
+      '.tag': 'lookup_failed',
+      lookup_failed: { '.tag': 'incorrect_offset', incorrect_offset: { correct_offset: 5 } },
+    }));
+    dbx.filesUploadSessionFinish.onSecondCall().resolves(new DropboxResponse(200, {}, { name: 'data.bin' }));
+    const delays = [];
+
+    await new DropboxFileUploader(dbx, {
+      maxAttempts: 2,
+      delay: (value) => { delays.push(value); return Promise.resolve(); },
+    }).upload(bytesUpload('hello'), { path: '/data.bin' });
+
+    expect(dbx.filesUploadSessionFinish.callCount).to.equal(2);
+    expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('hello');
+    expect(bytes(dbx.filesUploadSessionFinish.secondCall.args[0].contents)).to.equal('');
+    expect(dbx.filesUploadSessionFinish.secondCall.args[0].cursor.offset).to.equal(5);
+    expect(delays).to.deep.equal([500]);
+  });
+
+  it('supports unknown-size one-shot streams', async () => {
+    async function* stream() {
+      yield Buffer.from('abc');
+      yield Buffer.from('def');
+    }
+    const dbx = client();
+    const updates = [];
+
+    await new DropboxFileUploader(dbx, { chunkSize: 4, progress: (value) => updates.push(value) })
+      .upload(readerUpload(stream()), { path: '/stream.bin' });
+
+    expect(bytes(dbx.filesUploadSessionAppendV2.firstCall.args[0].contents)).to.equal('abcd');
+    expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('ef');
+    expect(updates).to.deep.equal([
+      { bytesCommitted: 4, totalBytes: -1 },
+      { bytesCommitted: 6, totalBytes: -1 },
+    ]);
+  });
+
+  it('validates a declared stream size', async () => {
+    async function* stream() { yield Buffer.from('abc'); }
+    try {
+      await new DropboxFileUploader(client()).upload(sizedReaderUpload(stream(), 5), { path: '/stream.bin' });
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error.message).to.contain('expected 5');
+    }
+  });
+
+  it('uses a concurrent session for parallel ranged uploads', async () => {
+    const dbx = client();
+    const data = Buffer.alloc(8 * 1024 * 1024 + 1, 97);
+    await new DropboxFileUploader(dbx, { parallelUploads: 2, chunkSize: 4 * 1024 * 1024 })
+      .upload(bytesUpload(data), { path: '/parallel.bin' });
+
+    expect(dbx.filesUploadSessionStart.firstCall.args[0].session_type).to.deep.equal({ '.tag': 'concurrent' });
+    expect(dbx.filesUploadSessionAppendV2.callCount).to.equal(3);
+    expect(dbx.filesUploadSessionAppendV2.thirdCall.args[0].close).to.equal(true);
+    expect(dbx.filesUploadSessionFinish.firstCall.args[0].cursor.offset).to.equal(data.length);
+    expect(bytes(dbx.filesUploadSessionFinish.firstCall.args[0].contents)).to.equal('');
+  });
+
+  it('treats parallelUploads below two as sequential', async () => {
+    const dbx = client();
+    await new DropboxFileUploader(dbx, { parallelUploads: 0 })
+      .upload(bytesUpload('data'), { path: '/data.bin' });
+    expect(dbx.filesUploadSessionStart.firstCall.args[0].session_type).to.equal(undefined);
+  });
+
+  it('rejects short ranged reads before sending them', async () => {
+    const dbx = client();
+    const source = { size: 3, read: async () => Buffer.from('ab') };
+    try {
+      await new DropboxFileUploader(dbx).upload(source, { path: '/short.bin' });
+      throw new Error('expected upload to fail');
+    } catch (error) {
+      expect(error.message).to.contain('got 2 bytes, expected 3');
+    }
+    expect(dbx.filesUploadSessionFinish.called).to.equal(false);
+  });
+
+  it('opens local file sources independently for each range', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'dropbox-filetransfer-'));
+    const filePath = path.join(directory, 'data.bin');
+    fs.writeFileSync(filePath, 'abcdef');
+    const source = await fileUpload(filePath);
+    expect(await streamBytes(await source.read(0, 3))).to.equal('abc');
+    expect(await streamBytes(await source.read(3, 3))).to.equal('def');
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,6 +92,94 @@ export function downloadFile(
   options?: DropboxFileDownloaderOptions,
 ): Promise<DropboxFileDownloadResult>;
 
+/** Progress reported by the local file upload helper. */
+export interface DropboxFileUploadProgress {
+  /** Cumulative bytes committed to Dropbox. */
+  bytesCommitted: number;
+
+  /** Total bytes in the upload source. */
+  totalBytes: number;
+}
+
+export interface DropboxFileUploaderOptions {
+  /** Maximum number of upload attempts. Defaults to 3. */
+  maxAttempts?: number;
+
+  /** Initial retry delay in milliseconds. Defaults to 500. */
+  retryDelay?: number;
+
+  /** Upload session chunk size in bytes. Defaults to 8 MiB. */
+  chunkSize?: number;
+
+  /** Maximum number of concurrent upload requests. Values below 2 disable concurrency. */
+  parallelUploads?: number;
+
+  /** Receives cumulative upload progress updates. */
+  progress?: (progress: DropboxFileUploadProgress) => void;
+
+  /** An AbortSignal used to cancel Dropbox requests. */
+  signal?: AbortSignal;
+
+  /** Maximum duration for each Dropbox request in milliseconds. Must be a positive integer. */
+  timeout?: number;
+}
+
+export interface DropboxRangedUploadSource {
+  /** Total bytes available from this source. */
+  size: number;
+
+  /** Reads a byte range from this source. */
+  read(offset: number, length: number): Promise<
+    Uint8Array | ArrayBuffer | DropboxFileBlob | AsyncIterable<Uint8Array>
+  >;
+}
+
+export interface DropboxSequentialUploadSource {
+  /** Opens this one-shot source from its beginning. */
+  open(): Promise<AsyncIterable<Uint8Array> | ReadableStream<Uint8Array>>;
+
+  /** Total bytes when known. Omit when the size is unknown. */
+  size?: number;
+}
+
+export type DropboxUploadSource = DropboxRangedUploadSource | DropboxSequentialUploadSource;
+
+export interface DropboxFileUploadResult {
+  /** Metadata returned by the completed upload. */
+  metadata: files.FileMetadata;
+}
+
+export class DropboxFileUploader {
+  constructor(client: Dropbox, options?: DropboxFileUploaderOptions);
+
+  upload(
+    source: DropboxUploadSource,
+    commitInfo: files.CommitInfo,
+  ): Promise<DropboxFileUploadResult>;
+}
+
+export function bytesUpload(
+  contents: string | Uint8Array | ArrayBuffer | DropboxFileBlob,
+): DropboxRangedUploadSource;
+
+export function fileUpload(filePath: string): Promise<DropboxRangedUploadSource>;
+
+export function readerUpload(
+  reader: AsyncIterable<Uint8Array> | ReadableStream<Uint8Array>,
+): DropboxSequentialUploadSource;
+
+export function sizedReaderUpload(
+  reader: AsyncIterable<Uint8Array> | ReadableStream<Uint8Array>,
+  size: number,
+): DropboxSequentialUploadSource;
+
+export function uploadFile(
+  client: Dropbox,
+  source: DropboxUploadSource,
+  commitInfo: files.CommitInfo,
+  options?: DropboxFileUploaderOptions,
+): Promise<DropboxFileUploadResult>;
+
 export interface DropboxAuthOptions {
   // An access token for making authenticated requests.
   accessToken?: string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -58,7 +58,7 @@ export interface DropboxFileDownloaderOptions {
   /** Number of parallel ranged downloads for fresh downloads. Defaults to 1. */
   parallelDownloads?: number;
 
-  /** Initial retry delay in milliseconds. Defaults to 500. */
+  /** Initial retry delay in milliseconds. Defaults to 200. */
   retryDelay?: number;
 
   /** Receives cumulative download progress updates. */
@@ -105,7 +105,7 @@ export interface DropboxFileUploaderOptions {
   /** Maximum number of upload attempts. Defaults to 3. */
   maxAttempts?: number;
 
-  /** Initial retry delay in milliseconds. Defaults to 500. */
+  /** Initial retry delay in milliseconds. Defaults to 200. */
   retryDelay?: number;
 
   /** Upload session chunk size in bytes. Defaults to 8 MiB. */


### PR DESCRIPTION
## Summary

- add resilient file-transfer helpers for sequential, concurrent, and reader-backed uploads
- reconcile upload-session offsets after ambiguous responses and validate source ranges
- honor `Retry-After` for local file-download retries
- add unit, type, and authenticated integration coverage
